### PR TITLE
Made SAI_BUFFER_POOL_ATTR_TH_MODE as create only

### DIFF
--- a/inc/saibuffer.h
+++ b/inc/saibuffer.h
@@ -120,7 +120,7 @@ typedef enum _sai_buffer_pool_attr_t
     /** buffer pool size in bytes [sai_uint32_t] (MANDATORY_ON_CREATE|CREATE_AND_SET) */
     SAI_BUFFER_POOL_ATTR_SIZE,
 
-    /** shared threshold mode for the buffer pool [sai_buffer_threadhold_mode_t] (CREATE_AND_SET)
+    /** shared threshold mode for the buffer pool [sai_buffer_threadhold_mode_t] (CREATE_ONLY)
      * (default to SAI_BUFFER_POOL_DYNAMIC_TH) */
     SAI_BUFFER_POOL_ATTR_TH_MODE,
 


### PR DESCRIPTION
We have the below attributes in buffer profile

    /** dynamic threshold for the shared usage [sai_int8_t]
     * The threshold is set to the 2^n of available buffer of the pool.
     * Mandatory when SAI_BUFFER_POOL_TH_MODE = SAI_BUFFER_THRESHOLD_MODE_DYNAMIC
     * (CREATE_AND_SET). */
    SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH,

    /** static threshold for the shared usage in bytes [sai_uint32_t]
     * Mandatory when SAI_BUFFER_POOL_TH_MODE = SAI_BUFFER_THRESHOLD_MODE_STATIC
     * (CREATE_AND_SET) */
    SAI_BUFFER_PROFILE_ATTR_SHARED_STATIC_TH,

In buffer pool attribute
    /** shared threshold mode for the buffer pool sai_buffer_threadhold_mode_t (CREATE_AND_SET)
     * (default to SAI_BUFFER_POOL_DYNAMIC_TH) */
    SAI_BUFFER_POOL_ATTR_TH_MODE,


If we had created some buffer profiles and associated them to a pool changing the pool th_mode should be restricted since we already would have set the profile thresholds values based on initial pool threshold modifying them would cause problems. Also there are no use case to modify threshold mode dynamically and hence having it as create only.
