### PR TITLE
Add ON_LINK next hop for directly reachable route

### DIFF
--- a/inc/sainexthop.h
+++ b/inc/sainexthop.h
@@ -44,6 +44,9 @@ typedef enum _sai_next_hop_type_t
 {
     SAI_NEXT_HOP_IP,
 
+    /** Lookup the neighbor table for direct reachable subnet */
+    SAI_NEXT_HOP_ON_LINK,
+
     /** 
     Tunneling to be added later
     */
@@ -62,13 +65,18 @@ typedef enum _sai_next_hop_attr_t
     /** Next hop entry type [sai_next_hop_type_t] (MANDATORY_ON_CREATE|CREATE_ONLY) */
     SAI_NEXT_HOP_ATTR_TYPE,
 
+    /** Next hop entry router interface id [sai_object_id_t] (MANDATORY_ON_CREATE|CREATE_ONLY) */
+    SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID,
+
     /** Next hop entry ipv4 address [sai_ip_address_t]
      * (MANDATORY_ON_CREATE when SAI_NEXT_HOP_ATTR_TYPE = SAI_NEXT_HOP_IP)
      * (CREATE_ONLY) */
     SAI_NEXT_HOP_ATTR_IP,
 
-    /** Next hop entry router interface id [sai_object_id_t] (MANDATORY_ON_CREATE|CREATE_ONLY) */
-    SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID,
+    /** Packet action when neighbor table lookup miss
+     * (MANDATORY_ON_CREATE when SAI_NEXT_HOP_ATTR_TYPE = SAI_NEXT_HOP_ON_LINK)
+     * (CREATE_AND_SET) */
+    SAI_NEXT_HOP_NEIGHBOR_MISS_PACKET_ACTION,
 
     /* -- */
 

--- a/inc/sairoute.h
+++ b/inc/sairoute.h
@@ -55,9 +55,8 @@ typedef enum _sai_route_attr_t
     /** Next hop or next hop group id for the packet or a router interface
      * in case of directly reachable route [sai_object_id_t]
      * The next hop id can be a generic next hop object, such as next hop,
-     * next hop group.
-     * Directly reachable routes are the IP subnets that are directly attached to the router.
-     * For such routes, fill the router interface id to which the subnet is attached */
+     * next hop group. (CREATE_AND_SET)
+     * MANDATORY_ON_CREATE when SAI_ROUTE_ATTR_PACKET_ACTION = FORWARD */
     SAI_ROUTE_ATTR_NEXT_HOP_ID,
 
     /** User based Meta Data


### PR DESCRIPTION
Directly reachable route will point to ON_LINK next hop.
Packet Destination IP is looked up in the neighbor table.
Attribute SAI_NEXT_HOP_NEIGHBOR_MISS_PACKET_ACTION for
ON_LINK next hop determines the packet action for neighbor
table lookup miss.