### PR TITLE
Add ON_LINK next hop for directly reachable route

### DIFF
--- a/inc/sairouterintf.h
+++ b/inc/sairouterintf.h
@@ -89,6 +89,10 @@ typedef enum _sai_router_interface_attr_t
     /** MTU [uint32_t] (CREATE_AND_SET) (default to 1514 bytes) */
     SAI_ROUTER_INTERFACE_ATTR_MTU,
 
+    /** Packet action when neighbor table lookup miss for this router interface [sai_packet_action_t]
+     * (CREATE_AND_SET) (default to SAI_PACKET_ACTION_TRAP) */
+    SAI_ROUTER_INTERFACE_ATTR_NEIGHBOR_MISS_PACKET_ACTION,
+
     /* -- */
 
     /* Custom range base value */


### PR DESCRIPTION
Directly reachable route will point to ON_LINK next hop.
Packet Destination IP is looked up in the neighbor table.
Attribute SAI_NEXT_HOP_NEIGHBOR_MISS_PACKET_ACTION for
ON_LINK next hop determines the packet action for neighbor
table lookup miss.