### PR TITLE
remove DSCP_TO_TC_AND_COLOR_MAP and DOT1P_TO_TC_AND_COLOR_MAP

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -358,12 +358,6 @@ typedef enum _sai_port_attr_t
     * Default no map */
     SAI_PORT_ATTR_QOS_DOT1P_TO_COLOR_MAP,
 
-    /** Enable DOT1P -> TC AND COLOR MAP [sai_object_id_t] on port
-    * MAP id = SAI_NULL_OBJECT_ID to disable map on port.
-    * To enable/disable trust Dot1p, Map ID should be add/remove on port.
-    * Default no map */
-    SAI_PORT_ATTR_QOS_DOT1P_TO_TC_AND_COLOR_MAP,
-
    /** Enable DSCP -> TC MAP [sai_object_id_t] on port
     * MAP id = SAI_NULL_OBJECT_ID to disable map on port.
     * To enable/disable trust DSCP, Map ID should be add/remove on port.
@@ -376,31 +370,16 @@ typedef enum _sai_port_attr_t
     * Default no map */
     SAI_PORT_ATTR_QOS_DSCP_TO_COLOR_MAP,
 
-    /** Enable DSCP -> TC AND COLOR MAP [sai_object_id_t] on port
-    * MAP id = SAI_NULL_OBJECT_ID to disable map on port.
-    * To enable/disable trust DSCP, Map ID should be add/remove on port.
-    * Default no map */
-    SAI_PORT_ATTR_QOS_DSCP_TO_TC_AND_COLOR_MAP,
 
    /** Enable TC -> Queue MAP [sai_object_id_t]  on port
     * Map id = SAI_NULL_OBJECT_ID to disable map on port.
     * Default no map i.e All packets to queue 0 */
     SAI_PORT_ATTR_QOS_TC_TO_QUEUE_MAP,
 
-   /** Enable TC -> DOT1P MAP [sai_object_id_t]
-    * Map id = SAI_NULL_OBJECT_ID to disable map on port.
-    * Default no map */
-    SAI_PORT_ATTR_QOS_TC_TO_DOT1P_MAP,
-
     /** Enable TC AND COLOR -> DOT1P MAP [sai_object_id_t]
     * Map id = SAI_NULL_OBJECT_ID to disable map on port.
     * Default no map */
     SAI_PORT_ATTR_QOS_TC_AND_COLOR_TO_DOT1P_MAP,
-
-   /** Enable TC -> DSCP MAP [sai_object_id_t]
-    * Map id = SAI_NULL_OBJECT_ID to disable map on port.
-    * Default no map */
-    SAI_PORT_ATTR_QOS_TC_TO_DSCP_MAP,
 
    /** Enable TC AND COLOR -> DSCP MAP [sai_object_id_t]
     * Map id = SAI_NULL_OBJECT_ID to disable map on port.

--- a/inc/saiqosmaps.h
+++ b/inc/saiqosmaps.h
@@ -39,41 +39,29 @@ typedef enum _sai_qos_map_type_t
     /** Qos Map to set DOT1P to color*/
     SAI_QOS_MAP_DOT1P_TO_COLOR = 0x00000001,
 
-    /** Qos Map to set DOT1P to traffic class and color*/
-    SAI_QOS_MAP_DOT1P_TO_TC_AND_COLOR = 0x00000002,
-
     /** Qos Map to set DSCP to Traffic class*/
-    SAI_QOS_MAP_DSCP_TO_TC = 0x00000003,
+    SAI_QOS_MAP_DSCP_TO_TC = 0x00000002,
 
     /** Qos Map to set DSCP to color*/
-    SAI_QOS_MAP_DSCP_TO_COLOR = 0x00000004,
-
-    /** Qos Map to set DSCP to traffic class and color*/
-    SAI_QOS_MAP_DSCP_TO_TC_AND_COLOR = 0x00000005,
+    SAI_QOS_MAP_DSCP_TO_COLOR = 0x00000003,
 
     /** Qos Map to set traffic class to queue */
-    SAI_QOS_MAP_TC_TO_QUEUE = 0x00000006,
-
-    /** Qos Map to set traffic class to DSCP */
-    SAI_QOS_MAP_TC_TO_DSCP = 0x00000007,
+    SAI_QOS_MAP_TC_TO_QUEUE = 0x00000004,
 
     /** Qos Map to set traffic class and color to DSCP */
-    SAI_QOS_MAP_TC_AND_COLOR_TO_DSCP = 0x00000008,
-
-    /** Qos Map to set traffic class to DOT1P */
-    SAI_QOS_MAP_TC_TO_DOT1P = 0x00000009,
+    SAI_QOS_MAP_TC_AND_COLOR_TO_DSCP = 0x00000005,
 
     /** Qos Map to set traffic class and color to DSCP */
-    SAI_QOS_MAP_TC_AND_COLOR_TO_DOT1P = 0x0000000a,
+    SAI_QOS_MAP_TC_AND_COLOR_TO_DOT1P = 0x00000006,
 
     /** Qos Map to set traffic class to priority group */
-    SAI_QOS_MAP_TC_TO_PRIORITY_GROUP = 0x0000000b,
+    SAI_QOS_MAP_TC_TO_PRIORITY_GROUP = 0x00000007,
 
     /** Qos Map to set priority group to PFC priority */
-    SAI_QOS_MAP_PRIORITY_GROUP_TO_PFC_PRIORITY = 0x0000000c,
+    SAI_QOS_MAP_PRIORITY_GROUP_TO_PFC_PRIORITY = 0x00000008,
 
     /** Qos Map to set PFC priority to queue */
-    SAI_QOS_MAP_PFC_PRIORITY_TO_QUEUE = 0x0000000d,
+    SAI_QOS_MAP_PFC_PRIORITY_TO_QUEUE = 0x00000009,
 
     /* -- */
     /* Custom range base value */


### PR DESCRIPTION
remove TC_TO_DSCP_MAP and DOT1P_TO_DSCP_MAP

DSCP_TO_TC_AND_COLOR_MAP is covered by DSCP_TO_TC and DSCP_TO_COLOR MAP.
So, it is redundent. Same thing applies to DOT1P_TO_TC_AND_COLOR_MAP.

TC_TO_DSCP_MAP is covered by TC_AND_COLOR_TO_DSCP_MAP, so it is redundent.
Same thing applies to DOT1P_TO_DSCP_MAP.