### PR TITLE
hash enum list is s32list (not u32list) + default fields definition

### DIFF
--- a/inc/saihash.h
+++ b/inc/saihash.h
@@ -93,7 +93,7 @@ typedef enum _sai_hash_attr_t
 
     /** READ-WRITE */
 
-    /** Hash native fields [sai_u32_list_t(sai_native_hash_field)] (CREATE_AND_SET) (default to an empty list) */
+    /** Hash native fields [sai_s32_list_t(sai_native_hash_field)] (CREATE_AND_SET) (default to an empty list) */
     SAI_HASH_NATIVE_FIELD_LIST,
 
     /** Hash UDF group [sai_object_list_t(sai_udf_group_t)] (CREATE_AND_SET) (default to an empty list) */

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -279,11 +279,13 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_DEFAULT_TRAP_GROUP,
 
     /** The hash object for packets going through ECMP [sai_object_id_t]
-     * The object id is read only, while the object attributes can be modified */
-    SAI_SWITCH_ATTR_ECMP_HASH,
+     * The object id is read only, while the object attributes can be modified 
+     * (default all fields in sai_native_hash_field_t are enabled) */
+     SAI_SWITCH_ATTR_ECMP_HASH,
 
     /** The hash object for packets going through LAG [sai_object_id_t]
-     * The object id is read only, while the object attributes can be modified */
+     * The object id is read only, while the object attributes can be modified
+     * (default all fields in sai_native_hash_field_t are enabled) */
     SAI_SWITCH_ATTR_LAG_HASH,
 
 


### PR DESCRIPTION
hash enum list is s32list (not u32list)
default initial fields definition for switch lag and ecmp hash objects