### PR TITLE
Recreated!! Extended SAI callbacks mechanism & extended host intf attribute type with ability to retrieve VLAN pkt belongs to.

### DIFF
--- a/inc/saifdb.h
+++ b/inc/saifdb.h
@@ -253,13 +253,16 @@ typedef sai_status_t (*sai_flush_fdb_entries_fn)(
  * Arguments:
  *    @param[in] count - number of notifications
  *    @param[in] data  - pointer to fdb event notification data array
+ *    @param[in] cb_data - Pointer to pplication data passed to
+ *           callback
  *
  * Return Values:
  *    None
  */
 typedef void (*sai_fdb_event_notification_fn)(
     _In_ uint32_t count,
-    _In_ sai_fdb_event_notification_data_t *data
+    _In_ sai_fdb_event_notification_data_t *data,
+    void *cb_data
     );
 
 /**

--- a/inc/saifdb.h
+++ b/inc/saifdb.h
@@ -253,7 +253,7 @@ typedef sai_status_t (*sai_flush_fdb_entries_fn)(
  * Arguments:
  *    @param[in] count - number of notifications
  *    @param[in] data  - pointer to fdb event notification data array
- *    @param[in] cb_data - Pointer to pplication data passed to
+ *    @param[in] cb_data - Pointer to aplication data passed to
  *           callback
  *
  * Return Values:

--- a/inc/saihostintf.h
+++ b/inc/saihostintf.h
@@ -627,6 +627,8 @@ typedef sai_status_t(*sai_send_hostif_packet_fn)(
  *    @param[in] buffer_size - actual packet size in bytes
  *    @param[in] attr_count - number of attributes
  *    @param[in] attr_list - array of attributes
+ *    @param[in] cb_data - Pointer to application data passed to
+ *          callback
  *
  * Return Values:
  *		None
@@ -635,7 +637,8 @@ typedef void(*sai_packet_event_notification_fn)(
     _In_ const void *buffer,
     _In_ sai_size_t buffer_size,
     _In_ uint32_t attr_count,
-    _In_ const sai_attribute_t *attr_list
+    _In_ const sai_attribute_t *attr_list,
+    void *cb_data
     );
 
 /**

--- a/inc/saihostintf.h
+++ b/inc/saihostintf.h
@@ -556,6 +556,9 @@ typedef enum _sai_hostif_packet_attr
     /** Ingress LAG [sai_object_id_t] (for receive-only) */
     SAI_HOSTIF_PACKET_INGRESS_LAG,
 
+    /** Ingress VLAN [sai_vlan_id_t] (for receive-only) */
+    SAI_HOSTIF_PACKET_INGRESS_VLAN,
+
     /** packet transmit type [sai_hostif_tx_type_t]. (MANDATORY_ON_SEND) */
     SAI_HOSTIF_PACKET_TX_TYPE,
 

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -670,13 +670,16 @@ typedef sai_status_t (*sai_clear_port_all_stats_fn)(
  * Arguments:
  *   @param[in] count - number of notifications
  *   @param[in] data  - array of port operational status
+ *   @param[in] cb_data - Pointer to application data passed to
+ *         callback
  *
  * Return Values:
  *    None
  */
 typedef void (*sai_port_state_change_notification_fn)(
     _In_ uint32_t count,
-    _In_ sai_port_oper_status_notification_t *data
+    _In_ sai_port_oper_status_notification_t *data,
+    void *cb_data
     );
 
 /**
@@ -686,13 +689,16 @@ typedef void (*sai_port_state_change_notification_fn)(
  * Arguments:
  *    @param[in] count - number of notifications
  *    @param[in] data  - array of port events
-
+ *    @param[in] cb_data - Pointer to application data passed to
+ *          callback
+ * 
  * Return Values:
  *    None
  */
 typedef void (*sai_port_event_notification_fn)(
     _In_ uint32_t count,
-    _In_ sai_port_event_notification_t *data
+    _In_ sai_port_event_notification_t *data,
+    void *cb_data
     );
 /**
  * @brief Port methods table retrieved with sai_api_query()

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -495,12 +495,16 @@ typedef void (*sai_switch_shutdown_request_fn)(
  *
  * Arguments:
  *  @param[in] switch_oper_status - new switch oper state
+ *  @param[in] *cb_data - Pointer to application data passed to
+ *        callback
+ * 
  *
  * Return Values:
  *    None
  */
 typedef void (*sai_switch_state_change_notification_fn)(
-    _In_ sai_switch_oper_status_t switch_oper_status
+    _In_ sai_switch_oper_status_t switch_oper_status,
+    void *cb_data
     );
 
 
@@ -510,11 +514,16 @@ typedef void (*sai_switch_state_change_notification_fn)(
 typedef struct _sai_switch_notification_t
 {
     sai_switch_state_change_notification_fn on_switch_state_change;
+    void *on_switch_state_change_cb_data;   
     sai_fdb_event_notification_fn           on_fdb_event;
+    void *on_fdb_event_cb_data;  
     sai_port_state_change_notification_fn   on_port_state_change;
+    void *on_port_state_change_cb_data;  
     sai_port_event_notification_fn          on_port_event;
+    void *on_port_event_cb_data;  
     sai_switch_shutdown_request_fn          on_switch_shutdown_request;
     sai_packet_event_notification_fn        on_packet_event;
+    void *on_packet_event_cb_data;  
 } sai_switch_notification_t;
 
 /**


### PR DESCRIPTION
1) Extended SAI callbacks to allow the callback creator to provide callback with some data callback creator is needed.
2) Extended host intf attribute type with ability to retrieve VLAN pkt belongs to.
