### PR TITLE
 Added ability to push egress physical port ID to neighbour and nexthop functionalites.

### DIFF
--- a/inc/saineighbor.h
+++ b/inc/saineighbor.h
@@ -74,6 +74,7 @@ typedef enum _sai_neighbor_attr_t
 typedef struct _sai_neighbor_entry_t
 {
     sai_object_id_t rif_id;
+    sai_object_id_t egress_port_id; /*Must be set to SAI_NULL_OBJECT_ID in case rif_id points to router port(not a VLAN).*/
     sai_ip_address_t ip_address;
 
 } sai_neighbor_entry_t;

--- a/inc/sainexthop.h
+++ b/inc/sainexthop.h
@@ -70,6 +70,13 @@ typedef enum _sai_next_hop_attr_t
     /** Next hop entry router interface id [sai_object_id_t] (MANDATORY_ON_CREATE|CREATE_ONLY) */
     SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID,
 
+    /** Next hop entry egress port id [sai_object_id_t]
+     *  (MANDATORY_ON_CREATE|CREATE_ONLY).
+     *  Must be set to SAI_NULL_OBJECT_ID in case
+     *  SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID points to router
+     *  port(not a VLAN). */
+    SAI_NEXT_HOP_ATTR_EGRESS_PORT_ID,
+
     /* -- */
 
     /** Custom range base value */


### PR DESCRIPTION
```
  In case of VLAN routing there are no possibility to resolve physical egress port pkt should pass over.
  It must be resolved by control plane and pushed to SDK during neighbour or nexthop configuration.
```

Signed-off-by: Rostyslav Ivasiv Rostyslav.Ivasiv@caviumnetworks.com
