### PR TITLE
Port has ingress and egress buffer profile lists

### DIFF
--- a/inc/saibuffer.h
+++ b/inc/saibuffer.h
@@ -183,7 +183,9 @@ typedef enum _sai_buffer_profile_attr_t
 {
     /** READ-WRITE */
 
-    /** pointer to buffer pool object id [sai_object_id_t] (MANDATORY_ON_CREATE|CREATE_AND_SET)  */
+    /** pointer to buffer pool object id [sai_object_id_t] (MANDATORY_ON_CREATE|CREATE_AND_SET)
+    *  Pool id = SAI_NULL_OBJECT_ID can be used when profile is not associated with specific
+    *  pool, for example for global port buffer */
     SAI_BUFFER_PROFILE_ATTR_POOL_ID,
 
     /** reserved buffer size in bytes [sai_uint32_t] (MANDATORY_ON_CREATE|CREATE_AND_SET) */

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -410,8 +410,13 @@ typedef enum _sai_port_attr_t
      * attributes alone valid. Rest will be ignored */
     SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID,
 
-    /** Buffer profile for port [sai_object_id_t]*/
-    SAI_PORT_ATTR_QOS_BUFFER_PROFILE_ID,
+    /** Ingress buffer profiles for port [sai_object_list_t]
+     *  There can be up to SAI_SWITCH_ATTR_INGRESS_BUFFER_POOL_NUM profiles */
+    SAI_PORT_ATTR_QOS_INGRESS_BUFFER_PROFILE_LIST,
+
+    /** Egress buffer profiles for port [sai_object_list_t]
+     *  There can be up to SAI_SWITCH_ATTR_EGRESS_BUFFER_POOL_NUM profiles */
+    SAI_PORT_ATTR_QOS_EGRESS_BUFFER_PROFILE_LIST,
 
     /** bit vector enable/disable port PFC [sai_uint8_t].
      * Valid from bit 0 to bit 7 */


### PR DESCRIPTION
Port has ingress buffer profile list, can allow profile per ingress pool
For example, suppose we have ingress lossy and lossless pools. Define
one profile of usage from the lossy pool, and one profile of usage from
the lossless pool
Same for egress