### PR TITLE
Changed const_iterator to iterator. This fixes compilation issue on some compilers. m_FdbVector.erase(it); can not use const_iterator.

### DIFF
--- a/test/basic_router/fdb_mgr.cpp
+++ b/test/basic_router/fdb_mgr.cpp
@@ -131,7 +131,7 @@ bool FdbMgr::Del(MacAddress macAddr,
     sai_fdb_entry_t saifdbent;
 
 
-    std::vector<FdbEntry>::const_iterator it;
+    std::vector<FdbEntry>::iterator it;
 
     for (it = m_FdbVector.begin(); it != m_FdbVector.end(); ++it)
     {


### PR DESCRIPTION
Changed const_iterator to iterator. This fixes compilation issue on some compilers. m_FdbVector.erase(it); can not use const_iterator.

Signed-off-by: Rostyslav Ivasiv <Rostyslav.Ivasiv@caviumnetworks.com>