### PR TITLE
Remove SAI_TUNNEL_IPINIP_GRE

### DIFF
--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -136,8 +136,6 @@ typedef enum _sai_tunnel_type_t
 {
     SAI_TUNNEL_IPINIP,
 
-    SAI_TUNNEL_IPINIP_GRE,
-
     SAI_TUNNEL_VXLAN,
 
     SAI_TUNNEL_MPLS,


### PR DESCRIPTION
SAI_TUNNEL_IPINIP_GRE has the same functionality of
SAI_TUNNEL_ATTR_ENCAP_GRE_KEY_VALID in sai_tunnel_attribute_t which
indicates whether GRE encapsulation is needed or not.