### PR TITLE
Redefine tunnel ttl mode and dscp mode

### DIFF
--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -146,17 +146,33 @@ typedef enum _sai_tunnel_type_t
 
 typedef enum _sai_tunnel_ttl_mode_t
 {
-    SAI_TUNNEL_TTL_COPY_FROM_INNER,
+    /** The uniform model:
+     *  where the TTL field is preserved end-to-end by copying into the
+     *  outer header on encapsulation and copying from the outer header on
+     *  decapsulation. */
+    SAI_TUNNEL_TTL_UNIFORM_MODEL,
 
-    SAI_TUNNEL_TTL_USER_DEFINE
+    /** The pipe model:
+     *  where the outer header is independent of that in the inner header so
+     *  it hides the TTL field of the inner header from any interaction
+     *  with nodes along the tunnel. */
+    SAI_TUNNEL_TTL_PIPE_MODEL
 
 } sai_tunnel_ttl_mode_t;
 
 typedef enum _sai_tunnel_dscp_mode_t
 {
-    SAI_TUNNEL_DSCP_COPY_FROM_INNER,
+    /** The uniform model:
+     *  where the DSCP field is preserved end-to-end by copying into the
+     *  outer header on encapsulation and copying from the outer header on
+     *  decapsulation. */
+    SAI_TUNNEL_DSCP_UNIFORM_MODEL,
 
-    SAI_TUNNEL_DSCP_USER_DEFINE
+    /** The pipe model:
+     *  where the outer header is independent of that in the inner header so
+     *  it hides the DSCP field of the inner header from any interaction
+     *  with nodes along the tunnel. */
+    SAI_TUNNEL_DSCP_PIPE_MODEL
 
 } sai_tunnel_dscp_mode_t;
 
@@ -187,20 +203,22 @@ typedef enum _sai_tunnel_attr_t
     /** tunnel src ip [sai_ip_address_t] (CREATE_ONLY) */
     SAI_TUNNEL_ATTR_ENCAP_SRC_IP,
 
-    /** tunnel TTL mode copy from inner or user define [sai_tunnel_ttl_mode_t]
-     *  (CREATE_ONLY) */
+    /** tunnel TTL mode (pipe or uniform model) [sai_tunnel_ttl_mode_t]
+     *  (CREATE_ONLY) 
+     *  Default would be SAI_TUNNEL_TTL_UNIFORM_MODEL */
     SAI_TUNNEL_ATTR_ENCAP_TTL_MODE,
 
     /** tunnel TTL value [sai_uint8_t]
-     *  (MANDATORY_ON_CREATE when SAI_TUNNEL_ENCAP_TTL_MODE = SAI_TUNNEL_TTL_USER_DEFINE) */
+     *  (MANDATORY_ON_CREATE when SAI_TUNNEL_ENCAP_TTL_MODE = SAI_TUNNEL_TTL_PIPE_MODEL) */
     SAI_TUNNEL_ATTR_ENCAP_TTL_VAL,
 
     /** tunnel dscp mode (pipe or uniform model) [sai_tunnel_dscp_mode_t]
-     *  (CREATE_ONLY) */
+     *  (CREATE_ONLY)
+     *  Default would be SAI_TUNNEL_DSCP_UNIFORM_MODEL */
     SAI_TUNNEL_ATTR_ENCAP_DSCP_MODE,
 
     /** tunnel DSCP value [sai_uint8_t : 6]
-     *  (MANDATORY_ON_CREATE when SAI_TUNNEL_ENCAP_DSCP_MODE = SAI_TUNNEL_DSCP_USER_DEFINE) */
+     *  (MANDATORY_ON_CREATE when SAI_TUNNEL_ENCAP_DSCP_MODE = SAI_TUNNEL_DSCP_PIPE_MODEL) */
     SAI_TUNNEL_ATTR_ENCAP_DSCP_VAL,
 
     /** tunnel GRE key valid [bool] (CREATE_ONLY) */
@@ -224,22 +242,24 @@ typedef enum _sai_tunnel_attr_t
     /**  tunnel decap mappers [sai_object_list_t] */
     SAI_TUNNEL_ATTR_DECAP_MAPPERS,
 
-    /** tunnel TTL mode copy from inner or user define [sai_tunnel_ttl_mode_t]
-    *  (MANDATORY_ON_CREATE when SAI_TUNNEL_ATTR_TYPE=SAI_TUNNEL_IPINIP,SAI_TUNNEL_IPINIP_GRE)
-    *  (CREATE_ONLY) */
+    /** tunnel TTL mode (pipe or uniform model) [sai_tunnel_ttl_mode_t]
+     *  (MANDATORY_ON_CREATE when SAI_TUNNEL_ATTR_TYPE=SAI_TUNNEL_IPINIP,SAI_TUNNEL_IPINIP_GRE)
+     *  (CREATE_ONLY)
+     *  Default would be SAI_TUNNEL_TTL_UNIFORM_MODEL */
     SAI_TUNNEL_ATTR_DECAP_TTL_MODE,
 
     /** tunnel TTL value [sai_uint8_t]
-    *  (MANDATORY_ON_CREATE when SAI_TUNNEL_DECAP_TTL_MODE = SAI_TUNNEL_TTL_USER_DEFINE) */
+     *  (MANDATORY_ON_CREATE when SAI_TUNNEL_DECAP_TTL_MODE = SAI_TUNNEL_TTL_PIPE_MODEL) */
     SAI_TUNNEL_ATTR_DECAP_TTL_VAL,
 
     /** tunnel dscp mode (pipe or uniform model) [sai_tunnel_dscp_mode_t]
-    *  (MANDATORY_ON_CREATE when SAI_TUNNEL_ATTR_TYPE=SAI_TUNNEL_IPINIP,SAI_TUNNEL_IPINIP_GRE)
-    *  (CREATE_ONLY) */
+     *  (MANDATORY_ON_CREATE when SAI_TUNNEL_ATTR_TYPE=SAI_TUNNEL_IPINIP,SAI_TUNNEL_IPINIP_GRE)
+     *  (CREATE_ONLY)
+     *  Default would be SAI_TUNNEL_DSCP_UNIFORM_MODEL */
     SAI_TUNNEL_ATTR_DECAP_DSCP_MODE,
 
     /** tunnel DSCP value [sai_uint8_t : 6]
-    *  (MANDATORY_ON_CREATE when SAI_TUNNEL_DECAP_DSCP_MODE = SAI_TUNNEL_DSCP_USER_DEFINE) */
+     *  (MANDATORY_ON_CREATE when SAI_TUNNEL_DECAP_DSCP_MODE = SAI_TUNNEL_DSCP_PIPE_MODEL) */
     SAI_TUNNEL_ATTR_DECAP_DSCP_VAL,
 
     /** Custom range base value */

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -209,7 +209,7 @@ typedef enum _sai_tunnel_attr_t
     SAI_TUNNEL_ATTR_ENCAP_TTL_MODE,
 
     /** tunnel TTL value [sai_uint8_t]
-     *  (MANDATORY_ON_CREATE when SAI_TUNNEL_ENCAP_TTL_MODE = SAI_TUNNEL_TTL_PIPE_MODEL) */
+     *  (valid and MANDATORY_ON_CREATE when SAI_TUNNEL_ENCAP_TTL_MODE = SAI_TUNNEL_TTL_PIPE_MODEL) */
     SAI_TUNNEL_ATTR_ENCAP_TTL_VAL,
 
     /** tunnel dscp mode (pipe or uniform model) [sai_tunnel_dscp_mode_t]
@@ -218,7 +218,7 @@ typedef enum _sai_tunnel_attr_t
     SAI_TUNNEL_ATTR_ENCAP_DSCP_MODE,
 
     /** tunnel DSCP value [sai_uint8_t : 6]
-     *  (MANDATORY_ON_CREATE when SAI_TUNNEL_ENCAP_DSCP_MODE = SAI_TUNNEL_DSCP_PIPE_MODEL) */
+     *  (valid and MANDATORY_ON_CREATE when SAI_TUNNEL_ENCAP_DSCP_MODE = SAI_TUNNEL_DSCP_PIPE_MODEL) */
     SAI_TUNNEL_ATTR_ENCAP_DSCP_VAL,
 
     /** tunnel GRE key valid [bool] (CREATE_ONLY) */
@@ -249,7 +249,7 @@ typedef enum _sai_tunnel_attr_t
     SAI_TUNNEL_ATTR_DECAP_TTL_MODE,
 
     /** tunnel TTL value [sai_uint8_t]
-     *  (MANDATORY_ON_CREATE when SAI_TUNNEL_DECAP_TTL_MODE = SAI_TUNNEL_TTL_PIPE_MODEL) */
+     *  (valid and MANDATORY_ON_CREATE when SAI_TUNNEL_DECAP_TTL_MODE = SAI_TUNNEL_TTL_PIPE_MODEL) */
     SAI_TUNNEL_ATTR_DECAP_TTL_VAL,
 
     /** tunnel dscp mode (pipe or uniform model) [sai_tunnel_dscp_mode_t]
@@ -259,7 +259,7 @@ typedef enum _sai_tunnel_attr_t
     SAI_TUNNEL_ATTR_DECAP_DSCP_MODE,
 
     /** tunnel DSCP value [sai_uint8_t : 6]
-     *  (MANDATORY_ON_CREATE when SAI_TUNNEL_DECAP_DSCP_MODE = SAI_TUNNEL_DSCP_PIPE_MODEL) */
+     *  (valid and MANDATORY_ON_CREATE when SAI_TUNNEL_DECAP_DSCP_MODE = SAI_TUNNEL_DSCP_PIPE_MODEL) */
     SAI_TUNNEL_ATTR_DECAP_DSCP_VAL,
 
     /** Custom range base value */


### PR DESCRIPTION
Use uniform model and pipe model (please see RFC 6040 section B.1) to
define the behavior of tunnel encap and decap ttl and dscp mode.