### PR TITLE
Add data structure for tunnel ecn decap map

### DIFF
--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -42,11 +42,11 @@
  */
 typedef enum _sai_tunnel_map_type_t
 {
-    /** TUNNEL Map overlay ECN to underlay ECN   */
+    /** TUNNEL Map overlay ECN to underlay ECN (only valid for encap)  */
     SAI_TUNNEL_MAP_OECN_TO_UECN = 0x00000001,
 
-    /** TUNNEL Map underlay ECN to overlay ECN   */
-    SAI_TUNNEL_MAP_UECN_TO_OECN = 0x00000002,
+    /** TUNNEL Map underlay ECN and overlay ECN to overlay ECN (only valid for decap)  */
+    SAI_TUNNEL_MAP_UECN_OECN_TO_OECN = 0x00000002,
 
     /** TUNNEL Map VNI to VLAN ID  */
     SAI_TUNNEL_MAP_VNI_TO_VLAN_ID = 0x00000003,

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -490,7 +490,7 @@ typedef struct _sai_tunnel_map_params_t
 
 } sai_tunnel_map_params_t;
 
-typedef struct _sai_tunnel_general_map_t
+typedef struct _sai_tunnel_map_t
 {
     /** Input parameters to match */
     sai_tunnel_map_params_t key;

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -497,7 +497,7 @@ typedef struct _sai_tunnel_map_t
 
     /** Output map parameters */
     sai_tunnel_map_params_t value;
-    
+
 } sai_tunnel_map_t;
 
 typedef struct _sai_tunnel_map_list_t

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -487,7 +487,7 @@ typedef struct _sai_tunnel_map_params_t
 
 } sai_tunnel_map_params_t;
 
-typedef struct _sai_tunnel_map_t
+typedef struct _sai_tunnel_general_map_t
 {
     /** Input parameters to match */
     sai_tunnel_map_params_t key;
@@ -495,6 +495,33 @@ typedef struct _sai_tunnel_map_t
     /** Output map parameters */
     sai_tunnel_map_params_t value;
 
+} sai_tunnel_general_map_t;
+
+typedef struct _sai_tunnel_ecn_decap_map_t
+{
+    /** Input inner parameters to match */
+    sai_tunnel_map_params_t key_inner;
+
+    /** Input outer parameters to match */
+    sai_tunnel_map_params_t key_outer;
+    
+    /** Output map parameters */
+    sai_tunnel_map_params_t value;
+
+} sai_tunnel_ecn_decap_map_t;
+
+typedef struct _sai_tunnel_map_t
+{
+    /** Tunnel map */
+    union {
+        /** Tunnel general map */
+        sai_tunnel_general_map_t general_map;
+        
+        /** Tunnel ecn decap map */
+        sai_tunnel_ecn_decap_map_t ecn_decap_map;
+        
+    } tunnel_map;
+    
 } sai_tunnel_map_t;
 
 typedef struct _sai_tunnel_map_list_t

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -476,8 +476,11 @@ typedef struct _sai_qos_map_list_t
 
 typedef struct _sai_tunnel_map_params_t
 {
-    /** ECN */
-    sai_uint8_t ecn;
+    /** inner ECN */
+    sai_uint8_t oecn;
+    
+    /** outer ECN */
+    sai_uint8_t uecn;
 
     /** vlan id  */
     sai_vlan_id_t vlan_id;
@@ -494,33 +497,6 @@ typedef struct _sai_tunnel_general_map_t
 
     /** Output map parameters */
     sai_tunnel_map_params_t value;
-
-} sai_tunnel_general_map_t;
-
-typedef struct _sai_tunnel_ecn_decap_map_t
-{
-    /** Input inner parameters to match */
-    sai_tunnel_map_params_t key_inner;
-
-    /** Input outer parameters to match */
-    sai_tunnel_map_params_t key_outer;
-    
-    /** Output map parameters */
-    sai_tunnel_map_params_t value;
-
-} sai_tunnel_ecn_decap_map_t;
-
-typedef struct _sai_tunnel_map_t
-{
-    /** Tunnel map */
-    union {
-        /** Tunnel general map */
-        sai_tunnel_general_map_t general_map;
-        
-        /** Tunnel ecn decap map */
-        sai_tunnel_ecn_decap_map_t ecn_decap_map;
-        
-    } tunnel_map;
     
 } sai_tunnel_map_t;
 


### PR DESCRIPTION
Add data structure <key_inner, key_outer, value> for tunnel ecn decap
map according to RFC 6040 section 4.2.