### PR TITLE
Remove trap group priority attribute

### DIFF
--- a/inc/saihostintf.h
+++ b/inc/saihostintf.h
@@ -47,10 +47,6 @@ typedef enum _sai_hostif_trap_group_attr_t
     /** Admin Mode [bool] (default to TRUE) */
     SAI_HOSTIF_TRAP_GROUP_ATTR_ADMIN_STATE,
 
-    /** group priority [uint32_t] (MANDATORY_ON_CREATE|CREATE_ONLY).
-    * This is equivalent to ACL table priority SAI_ACL_TABLE_ATTR_PRIORITY */
-    SAI_HOSTIF_TRAP_GROUP_ATTR_PRIO,
-
     /** cpu egress queue [uint32_t] (CREATE_AND_SET)
      * (default to 0) */
     SAI_HOSTIF_TRAP_GROUP_ATTR_QUEUE,


### PR DESCRIPTION
Prioritization in classification for trap is decided by
SAI_HOSTIF_TRAP_ATTR_TRAP_PRIORITY
Qos settings for the trap group are determined by
SAI_HOSTIF_TRAP_GROUP_ATTR_QUEUE and SAI_HOSTIF_TRAP_GROUP_ATTR_POLICER
Therefore, trap group priority is not needed