### PR TITLE
Fix types for virtual functions.

### DIFF
--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -1691,10 +1691,10 @@ class switch_sai_rpcHandler : virtual public switch_sai_rpcIf {
   }
 
   void sai_thrift_get_port_stats(
-          std::vector<uint64_t> & thrift_counters,
+          std::vector<int64_t> & thrift_counters,
           const sai_thrift_object_id_t port_id,
           const std::vector<sai_thrift_port_stat_counter_t> & thrift_counter_ids,
-          const uint32_t number_of_counters) {
+          const int32_t number_of_counters) {
       printf("sai_thrift_get_port_stats\n");
       sai_status_t status = SAI_STATUS_SUCCESS;
       sai_port_api_t *port_api;
@@ -1796,10 +1796,10 @@ class switch_sai_rpcHandler : virtual public switch_sai_rpcIf {
   }
 
   void sai_thrift_get_queue_stats(
-          std::vector<uint64_t> & thrift_counters,
+          std::vector<int64_t> & thrift_counters,
           const sai_thrift_object_id_t queue_id,
           const std::vector<sai_thrift_queue_stat_counter_t> & thrift_counter_ids,
-          const uint32_t number_of_counters) {
+          const int32_t number_of_counters) {
       printf("sai_thrift_get_queue_stats\n");
       sai_status_t status = SAI_STATUS_SUCCESS;
       sai_queue_api_t *queue_api;
@@ -1846,7 +1846,7 @@ class switch_sai_rpcHandler : virtual public switch_sai_rpcIf {
   sai_thrift_status_t sai_thrift_clear_queue_stats(
           const sai_thrift_object_id_t queue_id,
           const std::vector<sai_thrift_queue_stat_counter_t> & thrift_counter_ids,
-          const uint32_t number_of_counters) {
+          const int32_t number_of_counters) {
       printf("sai_thrift_clear_queue_stats\n");
       sai_status_t status = SAI_STATUS_SUCCESS;
       sai_queue_api_t *queue_api;
@@ -1970,10 +1970,10 @@ class switch_sai_rpcHandler : virtual public switch_sai_rpcIf {
   }
 
   void sai_thrift_get_pg_stats(
-          std::vector<uint64_t> & thrift_counters,
+          std::vector<int64_t> & thrift_counters,
           const sai_thrift_object_id_t pg_id,
           const std::vector<sai_thrift_pg_stat_counter_t> & thrift_counter_ids,
-          const uint32_t number_of_counters) {
+          const int32_t number_of_counters) {
       printf("sai_thrift_get_pg_stats\n");
       sai_status_t status = SAI_STATUS_SUCCESS;
       sai_buffer_api_t *buffer_api;


### PR DESCRIPTION
Otherwise they don't match to the generated from thrift abstract class. thrift doesn't have unsigned integer types.