### PR TITLE
Add new sai port attributes

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -197,10 +197,10 @@ typedef enum _sai_port_media_type_t
     /** Media type QSFP28 copper optic */
     SAI_PORT_MEDIA_TYPE_QSFP28_COPPER,
 
-    /** Media type fiber */
+    /** Media type fiber. Remote advertise medium information as fiber */
     SAI_PORT_MEDIA_TYPE_FIBER,
 
-    /** Media type copper */
+    /** Media type copper. Remote advertise medium information as copper */
     SAI_PORT_MEDIA_TYPE_COPPER,
 } sai_port_media_type_t;
 

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -190,6 +190,18 @@ typedef enum _sai_port_media_type_t
 
     /** Media type SFP copper optic */
     SAI_PORT_MEDIA_TYPE_SFP_COPPER,
+
+    /** Media type QSFP28 fiber optic */
+    SAI_PORT_MEDIA_TYPE_QSFP28_FIBER,
+
+    /** Media type QSFP28 copper optic */
+    SAI_PORT_MEDIA_TYPE_QSFP28_COPPER,
+
+    /** Media type fiber */
+    SAI_PORT_MEDIA_TYPE_FIBER,
+
+    /** Media type copper */
+    SAI_PORT_MEDIA_TYPE_COPPER,
 } sai_port_media_type_t;
 
 /**
@@ -227,8 +239,65 @@ typedef enum _sai_port_attr_t
     /** List of Scheduler groups for the port[sai_object_list_t] */
     SAI_PORT_ATTR_QOS_SCHEDULER_GROUP_LIST,
 
-    /** Query list of supported port speed in Mbps [sai_u32_list_t] */
+    /** Query list of supported port speed(full-duplex) in Mbps [sai_u32_list_t] */
     SAI_PORT_ATTR_SUPPORTED_SPEED,
+
+    /** Query list of Supported HALF-Duplex speed in Mbps [sai_u32_list_t] */
+    SAI_PORT_ATTR_SUPPORTED_HALF_DUPLEX_SPEED,
+
+    /** Query auto-negotiation support [bool] */
+    SAI_PORT_ATTR_SUPPORTED_AUTO_NEG_MODE,
+
+    /** Query port supported flow control mode [sai_port_flow_control_mode_t] */
+    SAI_PORT_ATTR_SUPPORTED_FLOW_CONTROL,
+
+    /** Query port supported asymmetric pause mode [bool] */
+    SAI_PORT_ATTR_SUPPORTED_ASYMMETRIC_PAUSE_MODE,
+
+    /** Query port supported MEDIA type [sai_port_media_type_t] */
+    SAI_PORT_ATTR_SUPPORTED_MEDIA_TYPE,
+
+    /** Query list of supported remote port speed (Full-Duplex)
+      * in Mbps [sai_u32_list_t] */
+    SAI_PORT_ATTR_REMOTE_SUPPORTED_SPEED,
+
+    /** Query list of Remote Port’s Supported
+      * HALF-Duplex speed in Mbps [sai_u32_list_t] */
+    SAI_PORT_ATTR_REMOTE_SUPPORTED_HALF_DUPLEX_SPEED,
+
+    /** Query Remote Port’s auto-negotiation support [bool] */
+    SAI_PORT_ATTR_REMOTE_SUPPORTED_AUTO_NEG_MODE,
+
+    /** Query Remote port supported flow control mode
+      * [sai_port_flow_control_mode_t] */
+    SAI_PORT_ATTR_REMOTE_SUPPORTED_FLOW_CONTROL,
+
+    /** Query Remote port supported asymmetric pause mode [bool] */
+    SAI_PORT_ATTR_REMOTE_SUPPORTED_ASYMMETRIC_PAUSE_MODE,
+
+    /** Query Remote port MEDIA type [sai_port_media_type_t] */
+    SAI_PORT_ATTR_REMOTE_SUPPORTED_MEDIA_TYPE,
+
+    /** Query list of Advertised remote port speed (Full-Duplex)
+      * in Mbps [sai_u32_list_t] */
+    SAI_PORT_ATTR_REMOTE_ADVERTISED_SPEED,
+
+    /** Query list of Remote Port’s
+      * Advertised HALF-Duplex speed in Mbps [sai_u32_list_t] */
+    SAI_PORT_ATTR_REMOTE_ADVERTISED_HALF_DUPLEX_SPEED,
+
+    /** Query Remote Port’s auto-negotiation Advertisement [bool] */
+    SAI_PORT_ATTR_REMOTE_ADVERTISED_AUTO_NEG_MODE,
+
+    /** Query Remote port Advertised flow control mode
+      * [sai_port_flow_control_mode_t] */
+    SAI_PORT_ATTR_REMOTE_ADVERTISED_FLOW_CONTROL,
+
+    /** Query Remote port Advertised asymmetric pause mode [bool] */
+    SAI_PORT_ATTR_REMOTE_ADVERTISED_ASYMMETRIC_PAUSE_MODE,
+
+    /** Query Remote port Advertised MEDIA type [sai_port_media_type_t] */
+    SAI_PORT_ATTR_REMOTE_ADVERTISED_MEDIA_TYPE,
 
     /** Number of ingress priority groups [sai_uint32_t] */
     SAI_PORT_ATTR_NUMBER_OF_PRIORITY_GROUPS,
@@ -252,6 +321,27 @@ typedef enum _sai_port_attr_t
     /** Media Type [sai_port_media_type_t],
      * (default to SAI_PORT_MEDIA_TYPE_NOT_PRESENT) */
     SAI_PORT_ATTR_MEDIA_TYPE,
+
+    /** Query/Configure list of Advertised port speed (Full-Duplex)
+      * in Mbps [sai_u32_list_t] */
+    SAI_PORT_ATTR_ADVERTISED_SPEED,
+
+    /** Query/Configure list of Advertised
+     * HALF-Duplex speed in Mbps [sai_u32_list_t] */
+    SAI_PORT_ATTR_ADVERTISED_HALF_DUPLEX_SPEED,
+
+    /** Query/Configure Port’s Advertised auto-negotiation configuration [bool] */
+    SAI_PORT_ATTR_ADVERTISED_AUTO_NEG_MODE,
+
+    /** Query/Configure Port’s Advertised flow control mode
+      * [sai_port_flow_control_mode_t] */
+    SAI_PORT_ATTR_ADVERTISED_FLOW_CONTROL,
+
+    /** Query port's Advertised asymmetric pause mode [bool] */
+    SAI_PORT_ATTR_ADVERTISED_ASYMMETRIC_PAUSE_MODE,
+
+    /** Query/Configure Port’s Advertised media type [sai_port_media_type_t] */
+    SAI_PORT_ATTR_ADVERTISED_MEDIA_TYPE,
 
     /** Port VLAN ID [sai_vlan_id_t]
      * Untagged ingress frames are tagged with Port VLAN ID (PVID)


### PR DESCRIPTION
1) To Query Port's supported capabilities (Speed, Full/Half Duplex capability
for each of the Speeds, Auto-negotiation, Pause RX/TX, Medium information)
2) To Query Remote Port's supported capabilities
3) To Query and Configure Port's advertised capabilities
4) To Query Remote Port's advertised capabilities
5) Add 100G QSFP28 media type

 Changes to be committed:
	modified:   saiport.h