### PR TITLE
Port can require different Hardware configuration based on the attach…

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -179,24 +179,6 @@ typedef enum _sai_port_media_type_t
     /** Media type not known */
     SAI_PORT_MEDIA_TYPE_UNKNONWN,
 
-    /** Media type QSFP fiber optic */
-    SAI_PORT_MEDIA_TYPE_QSFP_FIBER,
-
-    /** Media type QSFP copper optic */
-    SAI_PORT_MEDIA_TYPE_QSFP_COPPER,
-
-    /** Media type SFP fiber optic */
-    SAI_PORT_MEDIA_TYPE_SFP_FIBER,
-
-    /** Media type SFP copper optic */
-    SAI_PORT_MEDIA_TYPE_SFP_COPPER,
-
-    /** Media type QSFP28 fiber optic */
-    SAI_PORT_MEDIA_TYPE_QSFP28_FIBER,
-
-    /** Media type QSFP28 copper optic */
-    SAI_PORT_MEDIA_TYPE_QSFP28_COPPER,
-
     /** Media type fiber. Remote advertise medium information as fiber */
     SAI_PORT_MEDIA_TYPE_FIBER,
 

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -431,6 +431,15 @@ typedef enum _sai_port_attr_t
      * given port list will be dropped. */
     SAI_PORT_ATTR_EGRESS_BLOCK_PORT_LIST,
 
+    /** Port Hardware Configuration Profile ID [sai_uint64_t]
+     * Port can require different hardware configuration based on the attached
+     * media type, cable length etc. A Profile ID maps to a Port Hardware
+     * configuration settings that needs to be applied on the Port.
+     * This attribute need not be implemented and can be ignored if the port
+     * doesn't require any specific hardware settings based on media type/cable.
+     */
+    SAI_PORT_ATTR_HW_PROFILE_ID,
+
     /** -- */
 
     /* Custom range base value */

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -515,29 +515,34 @@ typedef enum _sai_switch_attr_t
  * @note This value needs to be incremented whenever a new switch attribute key
  * is added.
  */
-#define SAI_SWITCH_ATTR_MAX_KEY_COUNT         15
+#define SAI_SWITCH_ATTR_MAX_KEY_COUNT         16
 
 /**
  * List of switch attributes keys that can be set using key=value
  */
-#define SAI_KEY_FDB_TABLE_SIZE                "SAI_FDB_TABLE_SIZE"
-#define SAI_KEY_L3_ROUTE_TABLE_SIZE           "SAI_L3_ROUTE_TABLE_SIZE"
-#define SAI_KEY_L3_NEIGHBOR_TABLE_SIZE        "SAI_L3_NEIGHBOR_TABLE_SIZE"
-#define SAI_KEY_NUM_LAG_MEMBERS               "SAI_NUM_LAG_MEMBERS"
-#define SAI_KEY_NUM_LAGS                      "SAI_NUM_LAGS"
-#define SAI_KEY_NUM_ECMP_MEMBERS              "SAI_NUM_ECMP_MEMBERS"
-#define SAI_KEY_NUM_ECMP_GROUPS               "SAI_NUM_ECMP_GROUPS"
-#define SAI_KEY_NUM_UNICAST_QUEUES            "SAI_NUM_UNICAST_QUEUES"
-#define SAI_KEY_NUM_MULTICAST_QUEUES          "SAI_NUM_MULTICAST_QUEUES"
-#define SAI_KEY_NUM_QUEUES                    "SAI_NUM_QUEUES"
-#define SAI_KEY_NUM_CPU_QUEUES                "SAI_NUM_CPU_QUEUES"
-#define SAI_KEY_INIT_CONFIG_FILE              "SAI_INIT_CONFIG_FILE"
+#define SAI_KEY_FDB_TABLE_SIZE                    "SAI_FDB_TABLE_SIZE"
+#define SAI_KEY_L3_ROUTE_TABLE_SIZE               "SAI_L3_ROUTE_TABLE_SIZE"
+#define SAI_KEY_L3_NEIGHBOR_TABLE_SIZE            "SAI_L3_NEIGHBOR_TABLE_SIZE"
+#define SAI_KEY_NUM_LAG_MEMBERS                   "SAI_NUM_LAG_MEMBERS"
+#define SAI_KEY_NUM_LAGS                          "SAI_NUM_LAGS"
+#define SAI_KEY_NUM_ECMP_MEMBERS                  "SAI_NUM_ECMP_MEMBERS"
+#define SAI_KEY_NUM_ECMP_GROUPS                   "SAI_NUM_ECMP_GROUPS"
+#define SAI_KEY_NUM_UNICAST_QUEUES                "SAI_NUM_UNICAST_QUEUES"
+#define SAI_KEY_NUM_MULTICAST_QUEUES              "SAI_NUM_MULTICAST_QUEUES"
+#define SAI_KEY_NUM_QUEUES                        "SAI_NUM_QUEUES"
+#define SAI_KEY_NUM_CPU_QUEUES                    "SAI_NUM_CPU_QUEUES"
+#define SAI_KEY_INIT_CONFIG_FILE                  "SAI_INIT_CONFIG_FILE"
 /** 0: means cold boot, and 1: means warm boot */
-#define SAI_KEY_WARM_BOOT                     "SAI_WARM_BOOT"
+#define SAI_KEY_WARM_BOOT                         "SAI_WARM_BOOT"
 /** The file to recover SAI/NPU state from */
-#define SAI_KEY_WARM_BOOT_READ_FILE           "SAI_WARM_BOOT_READ_FILE"
+#define SAI_KEY_WARM_BOOT_READ_FILE               "SAI_WARM_BOOT_READ_FILE"
 /** The file to write SAI/NPU state to */
-#define SAI_KEY_WARM_BOOT_WRITE_FILE          "SAI_WARM_BOOT_WRITE_FILE"
+#define SAI_KEY_WARM_BOOT_WRITE_FILE              "SAI_WARM_BOOT_WRITE_FILE"
+/** Vendor specific Configuration file for Hardware Port Profile ID parameters.
+ * HW port profile ID can be used to set vendor specific port attributes based on
+ * the tranceiver type plugged in to the port
+ */
+#define SAI_KEY_HW_PORT_PROFILE_ID_CONFIG_FILE    "SAI_HW_PORT_PROFILE_ID_CONFIG_FILE"
 
 
 /**


### PR DESCRIPTION
…ed media type,

attached cable length

Example for an hardware configuration could be (but not limited to) interface type setting,
tuning port pre-emphasis settings, modifying phy registers etc.

Handling SAI_PORT_ATTR_HW_PROFILE_ID configuration is implementation defined.
If the port hardware configuration doesn't vary depending on the attached media type/cable,
then the SAI implementation may chose to ignore this parameter.

 Changes to be committed:
	modified:   saiport.h