### PR TITLE
Remove decap ttl val and decap dscp val

### DIFF
--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -229,18 +229,10 @@ typedef enum _sai_tunnel_attr_t
     *  (CREATE_ONLY) */
     SAI_TUNNEL_ATTR_DECAP_TTL_MODE,
 
-    /** tunnel TTL value [sai_uint8_t]
-    *  (MANDATORY_ON_CREATE when SAI_TUNNEL_DECAP_TTL_MODE = SAI_TUNNEL_TTL_USER_DEFINE) */
-    SAI_TUNNEL_ATTR_DECAP_TTL_VAL,
-
     /** tunnel dscp mode (pipe or uniform model) [sai_tunnel_dscp_mode_t]
     *  (MANDATORY_ON_CREATE when SAI_TUNNEL_ATTR_TYPE=SAI_TUNNEL_IPINIP,SAI_TUNNEL_IPINIP_GRE)
     *  (CREATE_ONLY) */
     SAI_TUNNEL_ATTR_DECAP_DSCP_MODE,
-
-    /** tunnel DSCP value [sai_uint8_t : 6]
-    *  (MANDATORY_ON_CREATE when SAI_TUNNEL_DECAP_DSCP_MODE = SAI_TUNNEL_DSCP_USER_DEFINE) */
-    SAI_TUNNEL_ATTR_DECAP_DSCP_VAL,
 
     /** Custom range base value */
     SAI_TUNNEL_ATTR_CUSTOM_RANGE_BASE = 0x10000000


### PR DESCRIPTION
For uniform mode, ttl val and dscp val are copied from outer header in
decap.
For pipe mode, ttl val and dscp val are copied from innner header in
decap.
Thus ttl val and dscp val are not used for either mode.