### PR TITLE
add SAI_HOSTIF_OPER_STATUS as a host interface attribute.

### DIFF
--- a/inc/saihostintf.h
+++ b/inc/saihostintf.h
@@ -467,6 +467,9 @@ typedef enum _sai_hostif_attr_t
     *   (MANDATORY_ON_CREATE when SAI_HOSTIF_ATTR_TYPE == SAI_HOSTIF_TYPE_NETDEV) */
     SAI_HOSTIF_ATTR_NAME,
 
+    /** Set the operational status for this host interface [bool] (default to false) */
+    SAI_HOSTIF_OPER_STATUS,
+
     /* Custom range base value */
     SAI_HOSTIF_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 


### PR DESCRIPTION
This is to set the operational status for a host interface in the host OS.