### PR TITLE
fixed issue with incorrect socket number during saithrift server init

### DIFF
--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -2321,9 +2321,11 @@ extern "C" {
 
 int start_sai_thrift_rpc_server(int port)
 {
+    static int param = port;
+
     std::cerr << "Starting SAI RPC server on port " << port << std::endl;
 
-    int rc = pthread_create(&switch_sai_thrift_rpc_thread, NULL, switch_sai_thrift_rpc_server_thread, &port);
+    int rc = pthread_create(&switch_sai_thrift_rpc_thread, NULL, switch_sai_thrift_rpc_server_thread, &param);
     std::cerr << "create pthread switch_sai_thrift_rpc_server_thread result " << rc << std::endl;
 
     rc = pthread_detach(switch_sai_thrift_rpc_thread);


### PR DESCRIPTION
Fixed issue which is observed during saithrift server initialization
_TTransportException: Could not connect to localhost:XXXX

The root cause is in start_sai_thrift_rpc_server() which passes local variable pointer to pthread_create(). This location is sometimes overwritten and socket is being bind to incorrect port.