### PR TITLE
Add switch attributes for default objects

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -500,6 +500,12 @@ typedef enum _sai_switch_attr_t
        Default no map */
     SAI_SWITCH_ATTR_QOS_TC_AND_COLOR_TO_DSCP_MAP,
 
+    /** The number of default objects created on the switch [sai_uint32_t] */
+    SAI_SWITCH_ATTR_DEFAULT_OBJ_NUMBER,
+
+    /** Get the list of default objects created on the switch [sai_object_list_t] */
+    SAI_SWITCH_ATTR_DEFAULT_OBJ_LIST,
+
     /** WRITE-ONLY */
 
     /** Port Breakout mode [sai_port_breakout_t] */


### PR DESCRIPTION
Motivation for this attributes is to provide knowledge to end user what objects are created by default after SAI initialization, for example: all port should be on that list, default virtual router, all vlan members objects for vlan 1. All objects with valid object ID should be on that list, this list should be updated every time new object is created or removed.

In my understandind some default objects are created. Extra object without ID is VLAN 1 which is created by default and all ports are added to that vlan createing vlanmember object.
No fdb_entry, route_entry, neighbor_entry should be create by default.