### PR TITLE
allow SAI_ROUTE_ATTR_NEXT_HOP_ID point to SAI_NULL_OBJECT_ID by default

### DIFF
--- a/inc/sairoute.h
+++ b/inc/sairoute.h
@@ -81,8 +81,8 @@ typedef enum _sai_route_entry_attr_t
      *
      * @type sai_object_id_t
      * @objects SAI_OBJECT_TYPE_NEXT_HOP, SAI_OBJECT_TYPE_NEXT_HOP_GROUP, SAI_OBJECT_TYPE_ROUTER_INTERFACE, SAI_OBJECT_TYPE_PORT
-     * @flags CREATE_AND_SET
      * @default SAI_NULL_OBJECT_ID
+     * @flags CREATE_AND_SET
      * @allownull true
      */
     SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID,

--- a/inc/sairoute.h
+++ b/inc/sairoute.h
@@ -67,6 +67,9 @@ typedef enum _sai_route_entry_attr_t
      * @brief Next hop or next hop group id for the packet, or a router interface
      * in case of directly reachable route, or the CPU port in case of IP2ME route
      *
+     * The next hop id is only effective when the packet action is one of the following:
+     *  FORWARD, COPY, LOG, TRANSIT
+     *
      * The next hop id can be a generic next hop object, such as next hop, next
      * hop group. Directly reachable routes are the IP subnets that are
      * directly attached to the router. For such routes, fill the router
@@ -74,9 +77,13 @@ typedef enum _sai_route_entry_attr_t
      * router IP address. For such routes, fill the CPU port
      * (#SAI_SWITCH_ATTR_CPU_PORT).
      *
+     * When it is SAI_NULL_OBJECT_ID, then packet will be dropped.
+     *
      * @type sai_object_id_t
      * @objects SAI_OBJECT_TYPE_NEXT_HOP, SAI_OBJECT_TYPE_NEXT_HOP_GROUP, SAI_OBJECT_TYPE_ROUTER_INTERFACE, SAI_OBJECT_TYPE_PORT
-     * @flags MANDATORY_ON_CREATE | CREATE_AND_SET
+     * @flags CREATE_AND_SET
+     * @default SAI_NULL_OBJECT_ID
+     * @allownull true
      */
     SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID,
 

--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -873,6 +873,8 @@ sub ProcessDefaultValueType
 
     return "SAI_DEFAULT_VALUE_TYPE_NONE" if not defined $default;
 
+    return "SAI_DEFAULT_VALUE_TYPE_CONST" if $default =~ /^SAI_NULL_OBJECT_ID$/;
+
     return "SAI_DEFAULT_VALUE_TYPE_CONST" if $default =~ /^(true|false|const|\d+|SAI_\w+)$/ and not $default =~ /_ATTR_|SAI_OBJECT_TYPE_/;
 
     return "SAI_DEFAULT_VALUE_TYPE_INHERIT" if $default =~ /^inherit SAI_\w+$/ and $default =~ /_ATTR_/;
@@ -901,6 +903,10 @@ sub ProcessDefaultValue
     if ($default =~ /^(true|false)$/ and $type eq "bool")
     {
         WriteSource "$val = { .booldata = $default };";
+    }
+    elsif ($default =~ /^SAI_NULL_OBJECT_ID$/ and $type =~ /^sai_object_id_t$/)
+    {
+        WriteSource "$val = { .oid = $default };";
     }
     elsif ($default =~ /^SAI_\w+$/ and $type =~ /^sai_\w+_t$/ and not defined $VALUE_TYPES{$type})
     {


### PR DESCRIPTION
When SAI_ROUTE_ATTR_NEXT_HOP_ID = SAI_NULL_OBJECT_ID, packet is dropped.
This allows user to change packet action from DROP to FORWARD using set API.
Otherwise, the behavior transition from DROP to FORWARD is undefined.