### PR TITLE
Added new port learn mode

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -136,8 +136,8 @@ typedef enum _sai_port_fdb_learning_mode_t
     /** Trap packets with unknown source MAC to CPU. Do not learn. Forward based on destination MAC */
     SAI_PORT_FDB_LEARNING_MODE_CPU_LOG,
 
-    /** Send MAC notification via FDB callback. Do not learn. Do not forward */
-    SAI_PORT_FDB_LEARNING_MODE_SW_TRAP,
+    /** Notify unknown source MAC using FDB callback. Do not learn. Do not forward */
+    SAI_PORT_FDB_LEARNING_MODE_FDB_NOTIFICATION,
 
 } sai_port_fdb_learning_mode_t;
 

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -136,7 +136,11 @@ typedef enum _sai_port_fdb_learning_mode_t
     /** Trap packets with unknown source MAC to CPU. Do not learn. Forward based on destination MAC */
     SAI_PORT_FDB_LEARNING_MODE_CPU_LOG,
 
-    /** Notify unknown source MAC using FDB callback. Do not learn. Do not forward */
+    /** Notify unknown source MAC using FDB callback. Do not learn in hardware. Do not forward.
+      * When a packet from unknown source MAC comes this mode will trigger a new learn notification
+      * via FDB callback for the MAC address. This mode will generate only one notification
+      * per unknown source MAC to FDB callback.
+      */
     SAI_PORT_FDB_LEARNING_MODE_FDB_NOTIFICATION,
 
 } sai_port_fdb_learning_mode_t;

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -136,6 +136,9 @@ typedef enum _sai_port_fdb_learning_mode_t
     /** Trap packets with unknown source MAC to CPU. Do not learn. Forward based on destination MAC */
     SAI_PORT_FDB_LEARNING_MODE_CPU_LOG,
 
+    /** Send MAC notification via FDB callback. Do not learn. Do not forward */
+    SAI_PORT_FDB_LEARNING_MODE_SW_TRAP,
+
 } sai_port_fdb_learning_mode_t;
 
 /**


### PR DESCRIPTION
SAI_PORT_FDB_LEARNING_MODE_FDB_NOTIFICATION mode is proposed so that when a packet from unknown source MAC comes, it is sent as a notification via FDB callback as new MAC learn. This mode will not forward traffic(until application re-installs the FDB entry. This mode will generate only one notification per unknown source MAC to FDB callback.
