### PR TITLE
Add defaults to PG and Queue buffer profile

### DIFF
--- a/inc/saibuffer.h
+++ b/inc/saibuffer.h
@@ -45,10 +45,12 @@ typedef enum _sai_ingress_priority_group_attr_t
 
     /**
      * @brief Buffer profile pointer
+     * Default no profile
      *
      * @type sai_object_id_t
      * @objects SAI_OBJECT_TYPE_BUFFER_PROFILE
      * @flags CREATE_AND_SET
+     * @allownull true
      */
     SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE = SAI_INGRESS_PRIORITY_GROUP_ATTR_START,
 

--- a/inc/saiqueue.h
+++ b/inc/saiqueue.h
@@ -96,6 +96,7 @@ typedef enum _sai_queue_attr_t
 
     /**
      * @brief Attach buffer profile to Queue
+     * Default no profile
      *
      * @type sai_object_id_t
      * @objects SAI_OBJECT_TYPE_BUFFER_PROFILE


### PR DESCRIPTION
After switch init, the default is no profile
PG and queue buffer settings are according to SAI/SDK defaults
No explicit buffer profile object is created/bounded as PG/Queue buffer
profile