### PR TITLE
saithrift: tests: Fix ports sync up on switch init

### DIFF
--- a/test/saithrift/tests/switch.py
+++ b/test/saithrift/tests/switch.py
@@ -76,14 +76,14 @@ def switch_init(client):
     for num_of_tries in range(200):
         time.sleep(1)
         # wait till the port are up
-        for port in port_list:
+        for port in sai_port_list:
             port_attr_list = client.sai_thrift_get_port_attribute(port)
             attr_list = port_attr_list.attr_list
             for attribute in attr_list:
                 if attribute.id == SAI_PORT_ATTR_OPER_STATUS:
                     if attribute.value.s32 != SAI_PORT_OPER_STATUS_UP:
                         all_ports_are_up = False
-                        print "port %h is down" % port
+                        print "port 0x%x is down" % port
         if all_ports_are_up:
             break
         else:


### PR DESCRIPTION
Fixed to use sai_port_list instead of port_list while waiting
while ports will UP.

Also fixed invalid format specifier '%h' -> '0x%x' when print
port is in down status.

Fixes: a774e18 ("wait for all ports to be up for switch init (#231)")
Signed-off-by: Vadim Kochan <vadymk@mellanox.com>