### PR TITLE
saithrift: make: Allow to specify SAI library install path

### DIFF
--- a/test/saithrift/Makefile
+++ b/test/saithrift/Makefile
@@ -1,5 +1,6 @@
 CXX=g++
-SAI_HEADER_DIR = /usr/include/sai
+SAI_PREFIX = /usr
+SAI_HEADER_DIR ?= $(SAI_PREFIX)/include/sai
 SAI_HEADERS = $(SAI_HEADER_DIR)/sai*.h
 CFLAGS = -I$(SAI_HEADER_DIR) -I. -std=c++11
 ifeq ($(platform),MLNX)
@@ -23,7 +24,9 @@ SAIDIR = ./include
 SRC = ./src
 THRIFT = /usr/bin/thrift
 CTYPESGEN = /usr/local/bin/ctypesgen.py
-LIBS = -lthrift -lpthread
+LIBS = -lthrift -lpthread  -lsai
+SAI_LIBRARY_DIR ?= $(SAI_PREFIX)/lib
+LDFLAGS = -L$(SAI_LIBRARY_DIR) -Wl,-rpath=$(SAI_LIBRARY_DIR)
 CPP_SOURCES = \
 				src/gen-cpp/switch_sai_constants.cpp \
 				src/gen-cpp/switch_sai_constants.h \
@@ -75,8 +78,8 @@ $(ODIR)/librpcserver.a: $(ODIR)/switch_sai_rpc.o $(ODIR)/switch_sai_types.o $(OD
 	ar rcs $(ODIR)/librpcserver.a $(ODIR)/switch_sai_rpc.o $(ODIR)/switch_sai_types.o $(ODIR)/switch_sai_constants.o $(ODIR)/switch_sai_rpc_server.o
 
 saiserver: $(ODIR)/saiserver.o $(ODIR)/librpcserver.a
-	$(CXX) $(ODIR)/switch_sai_rpc_server.o $(ODIR)/saiserver.o -o $@ \
-		   $(ODIR)/librpcserver.a $(LIBS) -lsai
+	$(CXX) $(LDFLAGS) $(ODIR)/switch_sai_rpc_server.o $(ODIR)/saiserver.o -o $@ \
+		   $(ODIR)/librpcserver.a $(LIBS)
 
 clean:
 	rm -rf $(ODIR) $(SRC)/gen-cpp $(SRC)/gen-py saiserver dist


### PR DESCRIPTION
Add ability to specify SAI library path from command line like:

    make SAI_LIBRARY_DIR=/path

or via SAI_PREFIX (if SAI headers and library are located in
the same $(SAI_PREFIX) path):

    make SAI_PREFIX=/usr/local

It might be useful for building saiserver with different versions
of SAI library.

Signed-off-by: Vadim Kochan <vadymk@mellanox.com>