### PR TITLE
saithrift: Fix indentation in test_profile_get_next_value()

### DIFF
--- a/test/saithrift/src/saiserver.cpp
+++ b/test/saithrift/src/saiserver.cpp
@@ -127,8 +127,8 @@ int test_profile_get_next_value(
     if (gProfileIter == gProfileMap.end())
     {
         printf("iterator reached end");
-    return -1;
-}
+        return -1;
+    }
 
     *variable = gProfileIter->first.c_str();
     *value = gProfileIter->second.c_str();


### PR DESCRIPTION
Align 'if (gProfileIter == gProfileMap.end())' code block
in saiserver.cpp:test_profile_get_next_value() function.

Signed-off-by: Vadim Kochan <vadymk@mellanox.com>