### PR TITLE
Cherry-picked fix for vlan membership in sail2.L2LagTest (#277) from master

### DIFF
--- a/test/saithrift/tests/sail2.py
+++ b/test/saithrift/tests/sail2.py
@@ -284,7 +284,7 @@ class L2LagTest(sai_base_test.ThriftInterfaceDataPlane):
         port4 = port_list[3]
         mac1 = '00:11:11:11:11:11'
         mac2 = '00:22:22:22:22:22'
-        mac_action = 1
+        mac_action = SAI_PACKET_ACTION_FORWARD
 
         self.client.sai_thrift_create_vlan(vlan_id)
 
@@ -293,16 +293,12 @@ class L2LagTest(sai_base_test.ThriftInterfaceDataPlane):
         lag_member_id2 = sai_thrift_create_lag_member(self.client, lag_id1, port2)
         lag_member_id3 = sai_thrift_create_lag_member(self.client, lag_id1, port3)
 
-        vlan_member1 = sai_thrift_create_vlan_member(self.client, vlan_id, port1, SAI_VLAN_PORT_UNTAGGED)
-        vlan_member2 = sai_thrift_create_vlan_member(self.client, vlan_id, port2, SAI_VLAN_PORT_UNTAGGED)
-        vlan_member3 = sai_thrift_create_vlan_member(self.client, vlan_id, port3, SAI_VLAN_PORT_UNTAGGED)
-        vlan_member4 = sai_thrift_create_vlan_member(self.client, vlan_id, port4, SAI_VLAN_PORT_UNTAGGED)
+        vlan_member1 = sai_thrift_create_vlan_member(self.client, vlan_id, lag_id1, SAI_VLAN_PORT_UNTAGGED)
+        vlan_member2 = sai_thrift_create_vlan_member(self.client, vlan_id, port4, SAI_VLAN_PORT_UNTAGGED)
 
         attr_value = sai_thrift_attribute_value_t(u16=vlan_id)
         attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
-        self.client.sai_thrift_set_port_attribute(port1, attr)
-        self.client.sai_thrift_set_port_attribute(port2, attr)
-        self.client.sai_thrift_set_port_attribute(port3, attr)
+        self.client.sai_thrift_set_port_attribute(lag_id1, attr)
         self.client.sai_thrift_set_port_attribute(port4, attr)
 
         sai_thrift_create_fdb(self.client, vlan_id, mac1, lag_id1, mac_action)
@@ -364,8 +360,6 @@ class L2LagTest(sai_base_test.ThriftInterfaceDataPlane):
 
             self.client.sai_thrift_remove_vlan_member(vlan_member1)
             self.client.sai_thrift_remove_vlan_member(vlan_member2)
-            self.client.sai_thrift_remove_vlan_member(vlan_member3)
-            self.client.sai_thrift_remove_vlan_member(vlan_member4)
 
             self.client.sai_thrift_remove_lag_member(lag_member_id1)
             self.client.sai_thrift_remove_lag_member(lag_member_id2)
@@ -375,7 +369,5 @@ class L2LagTest(sai_base_test.ThriftInterfaceDataPlane):
 
             attr_value = sai_thrift_attribute_value_t(u16=1)
             attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
-            self.client.sai_thrift_set_port_attribute(port1, attr)
-            self.client.sai_thrift_set_port_attribute(port2, attr)
-            self.client.sai_thrift_set_port_attribute(port3, attr)
+            self.client.sai_thrift_set_port_attribute(lag_id1, attr)
             self.client.sai_thrift_set_port_attribute(port4, attr)


### PR DESCRIPTION
According to discussion of the following pull request:

    https://github.com/opencomputeproject/SAI/pull/86

LAG member is not allowed to be added to the VLAN but only the LAG,
thus changed to add LAG to the vlan=10 instead of LAG members.

Also used packet action enum name instead of '1'.

Signed-off-by: Vadim Kochan <vadymk@mellanox.com>