### PR TITLE
Modify SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE to accept a list

### DIFF
--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -816,7 +816,7 @@ typedef enum _sai_acl_table_attr_t
     /**
      * @brief Range type defined
      *
-     * @type sai_acl_range_type_t
+     * @type sai_s32_list_t sai_acl_range_type_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
      */
     SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE,


### PR DESCRIPTION
The ability to pass only one value for SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE attribute
disallows the creation of SAI Entries with different range types within one ACL Table.

Signed-off-by: Yakiv Huryk <yakivh@mellanox.com>