### PR TITLE
saithrift: tests: Fix sail2/3 tests failing

### DIFF
--- a/test/saithrift/tests/sai_base_test.py
+++ b/test/saithrift/tests/sai_base_test.py
@@ -59,7 +59,6 @@ class ThriftInterface(BaseTest):
     def createRpcClient(self):
         # Set up thrift client and contact server
 
-        self.test_params = testutils.test_params_get()
         if self.test_params.has_key("server"):
             server = self.test_params['server']
         else:
@@ -76,6 +75,9 @@ class ThriftInterface(BaseTest):
     def setUp(self):
         global interface_to_front_mapping
         BaseTest.setUp(self)
+
+        self.test_params = testutils.test_params_get()
+
         self.loadPortMap()
         self.createRpcClient()
         return


### PR DESCRIPTION
After 4042cf9 initializing of test_params was moved to
createRpcClient() but they are used earlier in loadPortMap()
and it caused sail2.py & sail3.py fail.

Fixed by move initializing test params earlier in setUp().

Fixes: 4042cf9 ("[copp] Added copp tests (#247)")
Signed-off-by: Vadim Kochan <vadymk@mellanox.com>