### PR TITLE
saithrift: make: Add option to compile in debug mode

### DIFF
--- a/test/saithrift/Makefile
+++ b/test/saithrift/Makefile
@@ -3,6 +3,10 @@ SAI_PREFIX = /usr
 SAI_HEADER_DIR ?= $(SAI_PREFIX)/include/sai
 SAI_HEADERS = $(SAI_HEADER_DIR)/sai*.h
 CFLAGS = -I$(SAI_HEADER_DIR) -I. -std=c++11
+ifeq ($(DEBUG),1)
+CFLAGS += -O0 -ggdb
+endif
+
 ifeq ($(platform),MLNX)
 CDEFS = -DMLNXSAI
 else


### PR DESCRIPTION
Add 'DEBUG' option which allows to compile with debug flags '-O0 -ggdb':

    make DEBUG=1 clean all

Signed-off-by: Vadim Kochan <vadymk@mellanox.com>