### PR TITLE
saithrift: Add RPC implementation for SAI QoS MAP

### DIFF
--- a/test/saithrift/src/saiserver.cpp
+++ b/test/saithrift/src/saiserver.cpp
@@ -358,6 +358,7 @@ main(int argc, char* argv[])
     sai_log_set(SAI_API_BUFFERS, SAI_LOG_NOTICE);
     sai_log_set(SAI_API_POLICER, SAI_LOG_NOTICE);
     sai_log_set(SAI_API_WRED, SAI_LOG_NOTICE);
+    sai_log_set(SAI_API_QOS_MAPS, SAI_LOG_NOTICE);
 
     while (1) pause();
 

--- a/test/saithrift/src/switch_sai.thrift
+++ b/test/saithrift/src/switch_sai.thrift
@@ -126,6 +126,26 @@ struct sai_thrift_u32_list_t {
     2: list<i32> u32list;
 }
 
+struct sai_thrift_qos_map_params_t {
+    1: byte tc;
+    2: byte dscp;
+    3: byte dot1p;
+    4: byte prio;
+    5: byte pg;
+    6: byte queue_index;
+    7: byte color;
+}
+
+struct sai_thrift_qos_map_t {
+    1: sai_thrift_qos_map_params_t key;
+    2: sai_thrift_qos_map_params_t value;
+}
+
+struct sai_thrift_qos_map_list_t {
+    1: i32 count;
+    2: list<sai_thrift_qos_map_t> map_list;
+}
+
 union sai_thrift_attribute_value_t {
     1:  bool booldata;
     2:  string chardata;
@@ -147,6 +167,7 @@ union sai_thrift_attribute_value_t {
     18: sai_thrift_acl_field_data_t aclfield;
     19: sai_thrift_acl_action_data_t aclaction;
     20: sai_thrift_u32_list_t u32list;
+    21: sai_thrift_qos_map_list_t qosmap;
 }
 
 struct sai_thrift_attribute_t {
@@ -305,4 +326,8 @@ service switch_sai_rpc {
     // WRED API
     sai_thrift_object_id_t sai_thrift_create_wred_profile(1: list<sai_thrift_attribute_t> thrift_attr_list);
     sai_thrift_status_t sai_thrift_remove_wred_profile(1: sai_thrift_object_id_t wred_id);
+
+    // QoS Map API
+    sai_thrift_object_id_t sai_thrift_create_qos_map(1: list<sai_thrift_attribute_t> thrift_attr_list);
+    sai_thrift_status_t sai_thrift_remove_qos_map(1: sai_thrift_object_id_t qos_map_id);
 }


### PR DESCRIPTION
1) Add thrift declaration for SAI QoS MAP types & API.
2) Implement saithrift RPC for SAI QoS MAP API
3) Handle SAI_PORT_ATTR_QOS_XXX_MAP attributes for bind QoS map to port.

Signed-off-by: Vadim Kochan <vadymk@mellanox.com>