### PR TITLE
Remove ports from VALN before become LAG member

### DIFF
--- a/test/saithrift/tests/sail2.py
+++ b/test/saithrift/tests/sail2.py
@@ -277,6 +277,7 @@ class L2FloodTest(sai_base_test.ThriftInterfaceDataPlane):
 class L2LagTest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         switch_init(self.client)
+        default_vlan = 1
         vlan_id = 10
         port1 = port_list[0]
         port2 = port_list[1]
@@ -289,6 +290,9 @@ class L2LagTest(sai_base_test.ThriftInterfaceDataPlane):
         self.client.sai_thrift_create_vlan(vlan_id)
 
         lag_id1 = self.client.sai_thrift_create_lag([])
+
+        sai_thrift_vlan_remove_all_ports(self.client, default_vlan)
+
         lag_member_id1 = sai_thrift_create_lag_member(self.client, lag_id1, port1)
         lag_member_id2 = sai_thrift_create_lag_member(self.client, lag_id1, port2)
         lag_member_id3 = sai_thrift_create_lag_member(self.client, lag_id1, port3)
@@ -367,7 +371,89 @@ class L2LagTest(sai_base_test.ThriftInterfaceDataPlane):
             self.client.sai_thrift_remove_lag(lag_id1)
             self.client.sai_thrift_delete_vlan(vlan_id)
 
+            for port in sai_port_list:
+                sai_thrift_create_vlan_member(self.client, default_vlan, port, SAI_VLAN_PORT_UNTAGGED)
+
             attr_value = sai_thrift_attribute_value_t(u16=1)
             attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
-            self.client.sai_thrift_set_port_attribute(lag_id1, attr)
             self.client.sai_thrift_set_port_attribute(port4, attr)
+
+@group('l2')
+@group('sonic')
+class L2VlanBcastUcastTest(sai_base_test.ThriftInterfaceDataPlane):
+    def runTest(self):
+        """
+        For SONiC
+        Vlan broadcast and known unicast test. Verify the broacast packet reaches all ports in the vlan and unicast packet reach specific port. 
+        Steps:
+        1. remove all ports from default vlan
+        2. create vlan 10
+        3. add n-1 ports to vlan 10
+        4. add mac for each port
+        5. send untagged broadcast packet from port 1, verify all n-1 ports receive the packet except the last port
+        6. send untagged unicast packets from port 1 to the rest of the vlan members ports. Verify only one port at a time receives the packet and port n does not.
+        7. clean up.
+        """
+
+        switch_init(self.client)
+        default_vlan = 1
+        vlan_id = 10
+        mac_list = []
+        vlan_member_list = []
+        ingress_port = 0
+
+        for i in range (1, len(port_list)):
+            mac_list.append("00:00:00:00:00:%02x" %(i+1))
+        mac_action = SAI_PACKET_ACTION_FORWARD
+
+        sai_thrift_vlan_remove_all_ports(self.client, default_vlan)
+
+        self.client.sai_thrift_create_vlan(vlan_id)
+        for i in range (0, len(port_list)-1):
+            vlan_member_list.append(sai_thrift_create_vlan_member(self.client, vlan_id, port_list[i], SAI_VLAN_PORT_UNTAGGED))
+
+        attr_value = sai_thrift_attribute_value_t(u16=vlan_id)
+        attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
+        for i in range (0, len(port_list)-1):
+            self.client.sai_thrift_set_port_attribute(port_list[i], attr)	
+            sai_thrift_create_fdb(self.client, vlan_id, mac_list[i], port_list[i], mac_action)
+
+        bcast_pkt = simple_tcp_packet(eth_dst='ff:ff:ff:ff:ff:ff',
+                                eth_src='00:00:00:00:00:01',
+                                ip_dst='10.0.0.1',
+                                ip_id=101,
+                                ip_ttl=64)
+
+        try:
+            expected_ports = []
+            for i in range (1, len(port_list)-1):
+                expected_ports.append(i)
+
+            send_packet(self, ingress_port, str(bcast_pkt))
+            verify_packets(self, bcast_pkt, expected_ports)
+
+            for i in range (1, len(port_list)-1):
+                ucast_pkt = simple_tcp_packet(eth_dst=mac_list[i],
+                                    eth_src='00:00:00:00:00:01',
+                                    ip_dst='10.0.0.1',
+                                    ip_id=101,
+                                    ip_ttl=64)	
+                send_packet(self, ingress_port, str(ucast_pkt))
+                verify_packets(self, ucast_pkt, [i])
+
+        finally:
+            attr_value = sai_thrift_attribute_value_t(u16=default_vlan)
+            attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
+
+            for i in range (0, len(port_list)-1):
+                sai_thrift_delete_fdb(self.client, vlan_id, mac_list[i], port_list[i])
+                self.client.sai_thrift_set_port_attribute(port_list[i], attr)
+
+            for vlan_member in vlan_member_list:
+                self.client.sai_thrift_remove_vlan_member(vlan_member)
+
+            self.client.sai_thrift_delete_vlan(vlan_id)
+
+            for port in sai_port_list:
+                sai_thrift_create_vlan_member(self.client, default_vlan, port, SAI_VLAN_PORT_UNTAGGED)
+

--- a/test/saithrift/tests/sail3.py
+++ b/test/saithrift/tests/sail3.py
@@ -692,6 +692,7 @@ class L3IPv4LagTest(sai_base_test.ThriftInterfaceDataPlane):
         port1 = port_list[0]
         port2 = port_list[1]
         port3 = port_list[2]
+        default_vlan = 1
         v4_enabled = 1
         v6_enabled = 1
         mac = ''
@@ -701,6 +702,8 @@ class L3IPv4LagTest(sai_base_test.ThriftInterfaceDataPlane):
         ip_addr1_subnet = '10.10.10.0'
         ip_mask1 = '255.255.255.0'
         dmac1 = '00:11:22:33:44:55'
+
+        sai_thrift_vlan_remove_all_ports(self.client, default_vlan)
 
         vr_id = sai_thrift_create_virtual_router(self.client, v4_enabled, v6_enabled)
 
@@ -754,9 +757,12 @@ class L3IPv6LagTest(sai_base_test.ThriftInterfaceDataPlane):
         port1 = port_list[0]
         port2 = port_list[1]
         port3 = port_list[2]
+        default_vlan = 1
         v4_enabled = 1
         v6_enabled = 1
         mac = ''
+
+        sai_thrift_vlan_remove_all_ports(self.client, default_vlan)
 
         vr_id = sai_thrift_create_virtual_router(self.client, v4_enabled, v6_enabled)
 
@@ -818,6 +824,7 @@ class L3EcmpLagTest(sai_base_test.ThriftInterfaceDataPlane):
         port5 = port_list[4]
         port6 = port_list[5]
         port7 = port_list[6]
+        default_vlan = 1
         v4_enabled = 1
         v6_enabled = 1
         mac = ''
@@ -831,6 +838,8 @@ class L3EcmpLagTest(sai_base_test.ThriftInterfaceDataPlane):
         dmac1 = '00:11:22:33:44:55'
         dmac2 = '00:11:22:33:44:56'
         dmac3 = '00:11:22:33:44:57'
+
+        sai_thrift_vlan_remove_all_ports(self.client, default_vlan)
 
         vr_id = sai_thrift_create_virtual_router(self.client, v4_enabled, v6_enabled)
 

--- a/test/saithrift/tests/switch.py
+++ b/test/saithrift/tests/switch.py
@@ -669,6 +669,19 @@ def sai_thrift_create_vlan_member(client, vlan_id, port_id, tagging_mode):
     vlan_member_id = client.sai_thrift_create_vlan_member(vlan_member_attr_list)
     return vlan_member_id
 
+def sai_thrift_vlan_remove_all_ports(client, vid):
+        vlan_members_list = []
+
+        vlan_attr_list = client.sai_thrift_get_vlan_attribute(vid)
+        attr_list = vlan_attr_list.attr_list
+        for attribute in attr_list:
+            if attribute.id == SAI_VLAN_ATTR_MEMBER_LIST:
+                for vlan_member in attribute.value.objlist.object_id_list:
+                    vlan_members_list.append(vlan_member)
+
+        for vlan_member in vlan_members_list:
+            client.sai_thrift_remove_vlan_member(vlan_member)
+
 def sai_thrift_set_port_shaper(client, port_id, max_rate):
     sched_prof_id=sai_thrift_create_scheduler_profile(client, max_rate)
     attr_value = sai_thrift_attribute_value_t(oid=sched_prof_id)


### PR DESCRIPTION
Based on [ff87fbebe2270829c643896919c1b9d629ce6978 ](https://github.com/opencomputeproject/SAI/commit/ff87fbebe2270829c643896919c1b9d629ce6978)commit.

Port must be cleaned from .1q bridge attributes (VLANs) before
adding to the LAG, the same rule is for creation a LAG member.

Propagate to L3 LAG  TCs