### PR TITLE
Flags for SAI_SWITCH_ATTR_*_HASH* should be CREATE_AND_SET

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -558,11 +558,10 @@ typedef enum _sai_switch_attr_t
      * #SAI_NATIVE_HASH_FIELD_ETHERTYPE\]
      * #SAI_HASH_ATTR_UDF_GROUP_LIST empty list
      *
-     * The object id is read only, while the object attributes can be modified
      *
      * @type sai_object_id_t
      * @objects SAI_OBJECT_TYPE_HASH
-     * @flags READ_ONLY
+     * @flags CREATE_AND_SET
      */
     SAI_SWITCH_ATTR_ECMP_HASH,
 
@@ -576,11 +575,10 @@ typedef enum _sai_switch_attr_t
      * #SAI_NATIVE_HASH_FIELD_ETHERTYPE\]
      * #SAI_HASH_ATTR_UDF_GROUP_LIST empty list)
      *
-     * The object id is read only, while the object attributes can be modified
      *
      * @type sai_object_id_t
      * @objects SAI_OBJECT_TYPE_HASH
-     * @flags READ_ONLY
+     * @flags CREATE_AND_SET
      */
     SAI_SWITCH_ATTR_LAG_HASH,
 
@@ -768,7 +766,7 @@ typedef enum _sai_switch_attr_t
      *
      * @type sai_object_id_t
      * @objects SAI_OBJECT_TYPE_HASH
-     * @flags READ_ONLY
+     * @flags CREATE_AND_SET
      */
     SAI_SWITCH_ATTR_ECMP_HASH_IPV4,
 
@@ -777,7 +775,7 @@ typedef enum _sai_switch_attr_t
      *
      * @type sai_object_id_t
      * @objects SAI_OBJECT_TYPE_HASH
-     * @flags READ_ONLY
+     * @flags CREATE_AND_SET
      */
     SAI_SWITCH_ATTR_ECMP_HASH_IPV4_IN_IPV4,
 
@@ -786,7 +784,7 @@ typedef enum _sai_switch_attr_t
      *
      * @type sai_object_id_t
      * @objects SAI_OBJECT_TYPE_HASH
-     * @flags READ_ONLY
+     * @flags CREATE_AND_SET
      */
     SAI_SWITCH_ATTR_ECMP_HASH_IPV6,
 
@@ -826,7 +824,7 @@ typedef enum _sai_switch_attr_t
      *
      * @type sai_object_id_t
      * @objects SAI_OBJECT_TYPE_HASH
-     * @flags READ_ONLY
+     * @flags CREATE_AND_SET
      */
     SAI_SWITCH_ATTR_LAG_HASH_IPV4,
 
@@ -834,7 +832,7 @@ typedef enum _sai_switch_attr_t
      *
      * @type sai_object_id_t
      * @objects SAI_OBJECT_TYPE_HASH
-     * @flags READ_ONLY
+     * @flags CREATE_AND_SET
      */
     SAI_SWITCH_ATTR_LAG_HASH_IPV4_IN_IPV4,
 
@@ -843,7 +841,7 @@ typedef enum _sai_switch_attr_t
      *
      * @type sai_object_id_t
      * @objects SAI_OBJECT_TYPE_HASH
-     * @flags READ_ONLY
+     * @flags CREATE_AND_SET
      */
     SAI_SWITCH_ATTR_LAG_HASH_IPV6,
 


### PR DESCRIPTION
User should have the possibility to set created hash objects as an attribute for switch object, not only to read it.