### PR TITLE
Default vlan object id get

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -452,6 +452,16 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_ACL_USER_TRAP_ID_RANGE,
 
     /**
+     * @brief Default SAI VLAN ID
+     *
+     * @type sai_object_id_t
+     * @objects SAI_OBJECT_TYPE_VLAN
+     * @flags READ_ONLY
+     */
+    SAI_SWITCH_ATTR_DEFAULT_VLAN_ID,
+
+
+    /**
      * @brief Default SAI STP instance ID
      *
      * @type sai_object_id_t


### PR DESCRIPTION
Present SAI1.0 modified vlan as sai_object_id_t. 
Added get attribute to retrieve default vlan object id from switch, by using this application can make use of this to get member list and set/get attributed for default vlan object id.