### PR TITLE
use vlan object id in SAI_ROUTER_INTERFACE_ATTR_VLAN_ID to build

### DIFF
--- a/inc/sairouterintf.h
+++ b/inc/sairouterintf.h
@@ -91,10 +91,10 @@ typedef enum _sai_router_interface_attr_t
     /**
      * @brief Assosiated Vlan
      *
-     * @type sai_uint16_t
+     * @type sai_object_id_t
+     * @objects SAI_OBJECT_TYPE_VLAN
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
      * @condition SAI_ROUTER_INTERFACE_ATTR_TYPE == SAI_ROUTER_INTERFACE_TYPE_VLAN
-     * @isvlan true
      */
     SAI_ROUTER_INTERFACE_ATTR_VLAN_ID,
 


### PR DESCRIPTION
dependency between router interface and vlan object