### PR TITLE
Tunnel map items as objects proposal

### DIFF
--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -778,6 +778,58 @@ typedef sai_status_t (*sai_get_tunnel_term_table_entry_attribute_fn)(
         _Inout_ sai_attribute_t *attr_list);
 
 /**
+ * @brief Create tunnel map item
+ *
+ * @param[out] tunnel_map_item_id Tunnel map item id
+ * @param[in] switch_id Switch Id
+ * @param[in] attr_count Number of attributes
+ * @param[in] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success Failure status code on error
+ */
+typedef sai_status_t (*sai_create_tunnel_map_item_fn)(
+        _Out_ sai_object_id_t *tunnel_map_item_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list);
+
+/**
+ * @brief Remove tunnel map item
+ *
+ * @param[in] tunnel_map_item_id Tunnel map item id
+ *
+ * @return #SAI_STATUS_SUCCESS on success Failure status code on error
+ */
+typedef sai_status_t (*sai_remove_tunnel_map_item_fn)(
+        _In_ sai_object_id_t tunnel_map_item_id);
+
+/**
+ * @brief Set tunnel map item attribute
+ *
+ * @param[in] tunnel_map_item_id Tunnel map item id
+ * @param[in] attr Attribute
+ *
+ * @return #SAI_STATUS_SUCCESS on success Failure status code on error
+ */
+typedef sai_status_t (*sai_set_tunnel_map_item_attribute_fn)(
+        _In_ sai_object_id_t tunnel_map_item_id,
+        _In_ const sai_attribute_t *attr);
+
+/**
+ * @brief Get tunnel map item attributes
+ *
+ * @param[in] tunnel_map_item_id Tunnel map item id
+ * @param[in] attr_count Number of attributes
+ * @param[inout] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success Failure status code on error
+ */
+typedef sai_status_t (*sai_get_tunnel_map_item_attribute_fn)(
+        _In_ sai_object_id_t tunnel_map_item_id,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list);
+
+/**
  * @brief tunnel methods table retrieved with sai_api_query()
  */
 typedef struct _sai_tunnel_api_t
@@ -794,6 +846,10 @@ typedef struct _sai_tunnel_api_t
     sai_remove_tunnel_term_table_entry_fn        remove_tunnel_term_table_entry;
     sai_set_tunnel_term_table_entry_attribute_fn set_tunnel_term_table_entry_attribute;
     sai_get_tunnel_term_table_entry_attribute_fn get_tunnel_term_table_entry_attribute;
+    sai_create_tunnel_map_item_fn                create_tunnel_map_item;
+    sai_remove_tunnel_map_item_fn                remove_tunnel_map_item;
+    sai_set_tunnel_map_item_attribute_fn         set_tunnel_map_item_attribute;
+    sai_get_tunnel_map_item_attribute_fn         get_tunnel_map_item_attribute;
 
 } sai_tunnel_api_t;
 

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -61,6 +61,137 @@ typedef enum _sai_tunnel_map_type_t
 
 } sai_tunnel_map_type_t;
 
+typedef enum _sai_tunnel_map_item_attr_t
+{
+    /**
+     * @brief Start of attributes
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_START = 0x00000000,
+
+    /**
+     * @brief Tunnel Map type
+     *
+     * @type sai_tunnel_map_type_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE = SAI_TUNNEL_MAP_ITEM_ATTR_START,
+
+    /**
+     * @brief Tunnel map ex
+     *
+     * @type sai_object_id_t
+     * @objects SAI_OBJECT_TYPE_TUNNEL_MAP
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP = 0x00000001,
+
+    /**
+     * @brief Inner ECN key
+     *
+     * @type sai_uint8_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_OECN_TO_UECN or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_UECN_OECN_TO_OECN
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_OECN_KEY = 0x00000002,
+
+    /**
+     * @brief Inner ECN value
+     *
+     * @type sai_uint8_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_OECN_TO_UECN or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_UECN_OECN_TO_OECN
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_OECN_VALUE = 0x00000003,
+
+    /**
+     * @brief Outer ECN key
+     *
+     * @type sai_uint8_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_OECN_TO_UECN or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_UECN_OECN_TO_OECN
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_UECN_KEY = 0x00000004,
+
+    /**
+     * @brief Outer ECN value
+     *
+     * @type sai_uint8_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_OECN_TO_UECN or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_UECN_OECN_TO_OECN
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_UECN_VALUE = 0x00000005,
+
+    /**
+     * @brief Vlan ID key
+     *
+     * @type sai_uint16_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @isvlan true
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VNI_TO_VLAN_ID or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VLAN_ID_TO_VNI
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_VLAN_ID_KEY = 0x00000006,
+
+    /**
+     * @brief Vlan ID value
+     *
+     * @type sai_uint16_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @isvlan true
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VNI_TO_VLAN_ID or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VLAN_ID_TO_VNI
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_VLAN_ID_VALUE = 0x00000007,
+
+    /**
+     * @brief VNI ID key
+     *
+     * @type sai_uint32_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VNI_TO_VLAN_ID or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VLAN_ID_TO_VNI or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VNI_TO_BRIDGE_IF or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_BRIDGE_IF_TO_VNI
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_VNI_ID_KEY = 0x00000008,
+
+    /**
+     * @brief VNI ID value
+     *
+     * @type sai_uint32_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VNI_TO_VLAN_ID or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VLAN_ID_TO_VNI or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VNI_TO_BRIDGE_IF or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_BRIDGE_IF_TO_VNI
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_VNI_ID_VALUE = 0x00000009,
+
+    /**
+     * @brief Bridge ID key
+     *
+     * @type sai_object_id_t
+     * @objects SAI_OBJECT_TYPE_BRIDGE
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VNI_TO_BRIDGE_IF or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_BRIDGE_IF_TO_VNI
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_BRIDGE_ID_KEY = 0x0000000a,
+
+    /**
+     * @brief Bridge ID value
+     *
+     * @type sai_object_id_t
+     * @objects SAI_OBJECT_TYPE_BRIDGE
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VNI_TO_BRIDGE_IF or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_BRIDGE_IF_TO_VNI
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_BRIDGE_ID_VALUE = 0x0000000b,
+
+    /**
+     * @brief End of attributes
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_END,
+
+    /** Custom range base value */
+    SAI_TUNNEL_MAP_ITEM_ATTR_CUSTOM_RANGE_START = 0x10000000,
+
+    /** End of custom range base */
+    SAI_TUNNEL_MAP_ITEM_ATTR_CUSTOM_RANGE_END
+
+} sai_tunnel_map_item_attr_t;
+
 /**
  * @brief Defines tunnel map attributes
  */
@@ -81,6 +212,9 @@ typedef enum _sai_tunnel_map_attr_t
 
     /**
      * @brief Tunnel mapper
+     *
+     * If list is empty, TUNNEL_MAP can be used to assign
+     * TUNNEL_MAP_ITEM objects.
      *
      * @type sai_tunnel_map_list_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -216,7 +216,8 @@ typedef enum _sai_object_type_t {
     SAI_OBJECT_TYPE_HOSTIF_USER_DEFINED_TRAP = 56,
     SAI_OBJECT_TYPE_BRIDGE                   = 57,
     SAI_OBJECT_TYPE_BRIDGE_PORT              = 58,
-    SAI_OBJECT_TYPE_MAX                      = 59
+    SAI_OBJECT_TYPE_TUNNEL_MAP_ITEM          = 59,
+    SAI_OBJECT_TYPE_MAX                      = 60,
 } sai_object_type_t;
 
 typedef struct _sai_u8_list_t {
@@ -475,9 +476,6 @@ typedef struct _sai_tunnel_map_params_t
 
     /** VNI id */
     sai_uint32_t vni_id;
-
-    /** Bridge IF */
-    sai_object_id_t bridge_if;
 
 } sai_tunnel_map_params_t;
 


### PR DESCRIPTION
Purpose for this change is to remove bridge id from sai_tunnel_map_params_t and replace it with new object type to keep same feature. Current solution will require very special logic to handle bridge_if id in sai_tunnel_map_params_t in metadata in evey place where it will be used, and its not uniform with all other objects in SAI

This change could be much simpler if there would be requirement that when bridge id is used, then same bridge must be used for all tunnel map, then this bridge_if id could be moved tunnel itself instead of tunnel map