### PR TITLE
corrected a comment in sai.h

### DIFF
--- a/inc/sai.h
+++ b/inc/sai.h
@@ -89,7 +89,7 @@ typedef enum _sai_api_t
     SAI_API_ROUTER_INTERFACE =  9, /**< sai_router_interface_api_t */
     SAI_API_NEIGHBOR         = 10, /**< sai_neighbor_api_t */
     SAI_API_ACL              = 11, /**< sai_acl_api_t */
-    SAI_API_HOST_INTERFACE   = 12, /**< sai_host_interface_api_t */
+    SAI_API_HOST_INTERFACE   = 12, /**< sai_hostif_api_t */
     SAI_API_MIRROR           = 13, /**< sai_mirror_api_t */
     SAI_API_SAMPLEPACKET     = 14, /**< sai_samplepacket_api_t */
     SAI_API_STP              = 15, /**< sai_stp_api_t */


### PR DESCRIPTION
Changed the api structure name from sai_host_interface_api_t to sai_hostif_api_t in a comment.
In the saihostintf.h file the api structure name is sai_hostif_api_t but in sai.h file in the enum sai_api_t the comment provided for SAI_API_HOST_INTERFACE is /**< sai_host_interface_api_t */ while it is supposed to be /**< sai_hostif_api_t */ . So corrected this.