### PR TITLE
Make all api name functions consistent with object type

### DIFF
--- a/inc/sai.h
+++ b/inc/sai.h
@@ -138,11 +138,11 @@ typedef enum _sai_log_level_t
 
 } sai_log_level_t;
 
-typedef const char* (*profile_get_value_fn)(
+typedef const char* (*sai_profile_get_value_fn)(
         _In_ sai_switch_profile_id_t profile_id,
         _In_ const char *variable);
 
-typedef int (*profile_get_next_value_fn)(
+typedef int (*sai_profile_get_next_value_fn)(
         _In_ sai_switch_profile_id_t profile_id,
         _Out_ const char** variable,
         _Out_ const char** value);
@@ -156,7 +156,7 @@ typedef struct _service_method_table_t
     /**
      * @brief Get variable value given its name
      */
-    profile_get_value_fn        profile_get_value;
+    sai_profile_get_value_fn        profile_get_value;
 
     /**
      * @brief Enumerate all the K/V pairs in a profile.
@@ -164,7 +164,7 @@ typedef struct _service_method_table_t
      * Pointer to NULL passed as variable restarts enumeration. Function
      * returns 0 if next value exists, -1 at the end of the list.
      */
-    profile_get_next_value_fn   profile_get_next_value;
+    sai_profile_get_next_value_fn   profile_get_next_value;
 
 } service_method_table_t;
 

--- a/inc/saibuffer.h
+++ b/inc/saibuffer.h
@@ -133,7 +133,7 @@ typedef sai_status_t(*sai_remove_ingress_priority_group_fn)(
  *
  * @return #SAI_STATUS_SUCCESS on success Failure status code on error
  */
-typedef sai_status_t(*sai_set_ingress_priority_group_attr_fn)(
+typedef sai_status_t(*sai_set_ingress_priority_group_attribute_fn)(
         _In_ sai_object_id_t ingress_pg_id,
         _In_ const sai_attribute_t *attr);
 
@@ -146,7 +146,7 @@ typedef sai_status_t(*sai_set_ingress_priority_group_attr_fn)(
  *
  * @return #SAI_STATUS_SUCCESS on success Failure status code on error
  */
-typedef sai_status_t(*sai_get_ingress_priority_group_attr_fn)(
+typedef sai_status_t(*sai_get_ingress_priority_group_attribute_fn)(
         _In_ sai_object_id_t ingress_pg_id,
         _In_ uint32_t attr_count,
         _Inout_ sai_attribute_t *attr_list);
@@ -322,7 +322,7 @@ typedef sai_status_t(*sai_remove_buffer_pool_fn)(
  *
  * @return #SAI_STATUS_SUCCESS on success Failure status code on error
  */
-typedef sai_status_t(*sai_set_buffer_pool_attr_fn)(
+typedef sai_status_t(*sai_set_buffer_pool_attribute_fn)(
         _In_ sai_object_id_t pool_id,
         _In_ const sai_attribute_t *attr);
 
@@ -335,7 +335,7 @@ typedef sai_status_t(*sai_set_buffer_pool_attr_fn)(
  *
  * @return #SAI_STATUS_SUCCESS on success Failure status code on error
  */
-typedef sai_status_t(*sai_get_buffer_pool_attr_fn)(
+typedef sai_status_t(*sai_get_buffer_pool_attribute_fn)(
         _In_ sai_object_id_t pool_id,
         _In_ uint32_t attr_count,
         _Inout_ sai_attribute_t *attr_list);
@@ -544,7 +544,7 @@ typedef sai_status_t(*sai_remove_buffer_profile_fn)(
  *
  * @return #SAI_STATUS_SUCCESS on success Failure status code on error
  */
-typedef sai_status_t(*sai_set_buffer_profile_attr_fn)(
+typedef sai_status_t(*sai_set_buffer_profile_attribute_fn)(
         _In_ sai_object_id_t buffer_profile_id,
         _In_ const sai_attribute_t *attr);
 
@@ -557,7 +557,7 @@ typedef sai_status_t(*sai_set_buffer_profile_attr_fn)(
  *
  * @return #SAI_STATUS_SUCCESS on success Failure status code on error
  */
-typedef sai_status_t(*sai_get_buffer_profile_attr_fn)(
+typedef sai_status_t(*sai_get_buffer_profile_attribute_fn)(
         _In_ sai_object_id_t buffer_profile_id,
         _In_ uint32_t attr_count,
         _Inout_ sai_attribute_t *attr_list);
@@ -567,22 +567,22 @@ typedef sai_status_t(*sai_get_buffer_profile_attr_fn)(
  */
 typedef struct _sai_buffer_api_t
 {
-    sai_create_buffer_pool_fn                  create_buffer_pool;
-    sai_remove_buffer_pool_fn                  remove_buffer_pool;
-    sai_set_buffer_pool_attr_fn                set_buffer_pool_attribute;
-    sai_get_buffer_pool_attr_fn                get_buffer_pool_attribute;
-    sai_get_buffer_pool_stats_fn               get_buffer_pool_stats;
-    sai_clear_buffer_pool_stats_fn             clear_buffer_pool_stats;
-    sai_create_ingress_priority_group_fn       create_ingress_priority_group;
-    sai_remove_ingress_priority_group_fn       remove_ingress_priority_group;
-    sai_set_ingress_priority_group_attr_fn     set_ingress_priority_group_attribute;
-    sai_get_ingress_priority_group_attr_fn     get_ingress_priority_group_attribute;
-    sai_get_ingress_priority_group_stats_fn    get_ingress_priority_group_stats;
-    sai_clear_ingress_priority_group_stats_fn  clear_ingress_priority_group_stats;
-    sai_create_buffer_profile_fn               create_buffer_profile;
-    sai_remove_buffer_profile_fn               remove_buffer_profile;
-    sai_set_buffer_profile_attr_fn             set_buffer_profile_attribute;
-    sai_get_buffer_profile_attr_fn             get_buffer_profile_attribute;
+    sai_create_buffer_pool_fn                       create_buffer_pool;
+    sai_remove_buffer_pool_fn                       remove_buffer_pool;
+    sai_set_buffer_pool_attribute_fn                set_buffer_pool_attribute;
+    sai_get_buffer_pool_attribute_fn                get_buffer_pool_attribute;
+    sai_get_buffer_pool_stats_fn                    get_buffer_pool_stats;
+    sai_clear_buffer_pool_stats_fn                  clear_buffer_pool_stats;
+    sai_create_ingress_priority_group_fn            create_ingress_priority_group;
+    sai_remove_ingress_priority_group_fn            remove_ingress_priority_group;
+    sai_set_ingress_priority_group_attribute_fn     set_ingress_priority_group_attribute;
+    sai_get_ingress_priority_group_attribute_fn     get_ingress_priority_group_attribute;
+    sai_get_ingress_priority_group_stats_fn         get_ingress_priority_group_stats;
+    sai_clear_ingress_priority_group_stats_fn       clear_ingress_priority_group_stats;
+    sai_create_buffer_profile_fn                    create_buffer_profile;
+    sai_remove_buffer_profile_fn                    remove_buffer_profile;
+    sai_set_buffer_profile_attribute_fn             set_buffer_profile_attribute;
+    sai_get_buffer_profile_attribute_fn             get_buffer_profile_attribute;
 } sai_buffer_api_t;
 
 /**

--- a/inc/saineighbor.h
+++ b/inc/saineighbor.h
@@ -163,7 +163,7 @@ typedef sai_status_t (*sai_remove_neighbor_entry_fn)(
  *
  * @return #SAI_STATUS_SUCCESS on success Failure status code on error
  */
-typedef sai_status_t (*sai_set_neighbor_attribute_fn)(
+typedef sai_status_t (*sai_set_neighbor_entry_attribute_fn)(
         _In_ const sai_neighbor_entry_t *neighbor_entry,
         _In_ const sai_attribute_t *attr);
 
@@ -176,7 +176,7 @@ typedef sai_status_t (*sai_set_neighbor_attribute_fn)(
  *
  * @return #SAI_STATUS_SUCCESS on success Failure status code on error
  */
-typedef sai_status_t (*sai_get_neighbor_attribute_fn)(
+typedef sai_status_t (*sai_get_neighbor_entry_attribute_fn)(
         _In_ const sai_neighbor_entry_t *neighbor_entry,
         _In_ uint32_t attr_count,
         _Inout_ sai_attribute_t *attr_list);
@@ -197,8 +197,8 @@ typedef struct _sai_neighbor_api_t
 {
     sai_create_neighbor_entry_fn        create_neighbor_entry;
     sai_remove_neighbor_entry_fn        remove_neighbor_entry;
-    sai_set_neighbor_attribute_fn       set_neighbor_entry_attribute;
-    sai_get_neighbor_attribute_fn       get_neighbor_entry_attribute;
+    sai_set_neighbor_entry_attribute_fn set_neighbor_entry_attribute;
+    sai_get_neighbor_entry_attribute_fn get_neighbor_entry_attribute;
     sai_remove_all_neighbor_entries_fn  remove_all_neighbor_entries;
 
 } sai_neighbor_api_t;

--- a/inc/sairoute.h
+++ b/inc/sairoute.h
@@ -148,7 +148,7 @@ typedef struct _sai_route_entry_t
  *
  * @return #SAI_STATUS_SUCCESS on success Failure status code on error
  */
-typedef sai_status_t (*sai_create_route_fn)(
+typedef sai_status_t (*sai_create_route_entry_fn)(
         _In_ const sai_route_entry_t *route_entry,
         _In_ uint32_t attr_count,
         _In_ const sai_attribute_t *attr_list);
@@ -162,7 +162,7 @@ typedef sai_status_t (*sai_create_route_fn)(
  *
  * @return #SAI_STATUS_SUCCESS on success Failure status code on error
  */
-typedef sai_status_t (*sai_remove_route_fn)(
+typedef sai_status_t (*sai_remove_route_entry_fn)(
         _In_ const sai_route_entry_t *route_entry);
 
 /**
@@ -173,7 +173,7 @@ typedef sai_status_t (*sai_remove_route_fn)(
  *
  * @return #SAI_STATUS_SUCCESS on success Failure status code on error
  */
-typedef sai_status_t (*sai_set_route_attribute_fn)(
+typedef sai_status_t (*sai_set_route_entry_attribute_fn)(
         _In_ const sai_route_entry_t *route_entry,
         _In_ const sai_attribute_t *attr);
 
@@ -186,7 +186,7 @@ typedef sai_status_t (*sai_set_route_attribute_fn)(
  *
  * @return #SAI_STATUS_SUCCESS on success Failure status code on error
  */
-typedef sai_status_t (*sai_get_route_attribute_fn)(
+typedef sai_status_t (*sai_get_route_entry_attribute_fn)(
         _In_ const sai_route_entry_t *route_entry,
         _In_ uint32_t attr_count,
         _Inout_ sai_attribute_t *attr_list);
@@ -196,10 +196,10 @@ typedef sai_status_t (*sai_get_route_attribute_fn)(
  */
 typedef struct _sai_route_api_t
 {
-    sai_create_route_fn         create_route_entry;
-    sai_remove_route_fn         remove_route_entry;
-    sai_set_route_attribute_fn  set_route_entry_attribute;
-    sai_get_route_attribute_fn  get_route_entry_attribute;
+    sai_create_route_entry_fn         create_route_entry;
+    sai_remove_route_entry_fn         remove_route_entry;
+    sai_set_route_entry_attribute_fn  set_route_entry_attribute;
+    sai_get_route_entry_attribute_fn  get_route_entry_attribute;
 
 } sai_route_api_t;
 

--- a/inc/saisamplepacket.h
+++ b/inc/saisamplepacket.h
@@ -127,8 +127,8 @@ typedef enum _sai_samplepacket_attr_t
  * @return #SAI_STATUS_SUCCESS if operation is successful otherwise a different
  * error code is returned.
  */
-typedef sai_status_t (*sai_create_samplepacket_session_fn)(
-        _Out_ sai_object_id_t *session_id,
+typedef sai_status_t (*sai_create_samplepacket_fn)(
+        _Out_ sai_object_id_t *samplepacket_id,
         _In_ sai_object_id_t switch_id,
         _In_ uint32_t attr_count,
         _In_ const sai_attribute_t *attr_list);
@@ -141,8 +141,8 @@ typedef sai_status_t (*sai_create_samplepacket_session_fn)(
  * @return #SAI_STATUS_SUCCESS if operation is successful otherwise a different
  * error code is returned.
  */
-typedef sai_status_t (*sai_remove_samplepacket_session_fn)(
-        _In_ sai_object_id_t session_id);
+typedef sai_status_t (*sai_remove_samplepacket_fn)(
+        _In_ sai_object_id_t samplepacket_id);
 
 /**
  * @brief Set samplepacket session attributes.
@@ -154,7 +154,7 @@ typedef sai_status_t (*sai_remove_samplepacket_session_fn)(
  * error code is returned.
  */
 typedef sai_status_t (*sai_set_samplepacket_attribute_fn)(
-        _In_ sai_object_id_t session_id,
+        _In_ sai_object_id_t samplepacket_id,
         _In_ const sai_attribute_t *attr);
 
 /**
@@ -168,7 +168,7 @@ typedef sai_status_t (*sai_set_samplepacket_attribute_fn)(
  * error code is returned.
  */
 typedef sai_status_t (*sai_get_samplepacket_attribute_fn)(
-        _In_ sai_object_id_t session_id,
+        _In_ sai_object_id_t sample_packet_id,
         _In_ uint32_t attr_count,
         _Inout_ sai_attribute_t *attr_list);
 
@@ -177,8 +177,8 @@ typedef sai_status_t (*sai_get_samplepacket_attribute_fn)(
  */
 typedef struct _sai_samplepacket_api_t
 {
-    sai_create_samplepacket_session_fn  create_samplepacket;
-    sai_remove_samplepacket_session_fn  remove_samplepacket;
+    sai_create_samplepacket_fn          create_samplepacket;
+    sai_remove_samplepacket_fn          remove_samplepacket;
     sai_set_samplepacket_attribute_fn   set_samplepacket_attribute;
     sai_get_samplepacket_attribute_fn   get_samplepacket_attribute;
 

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -61,6 +61,137 @@ typedef enum _sai_tunnel_map_type_t
 
 } sai_tunnel_map_type_t;
 
+typedef enum _sai_tunnel_map_item_attr_t
+{
+    /**
+     * @brief Start of attributes
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_START = 0x00000000,
+
+    /**
+     * @brief Tunnel Map type
+     *
+     * @type sai_tunnel_map_type_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE = SAI_TUNNEL_MAP_ITEM_ATTR_START,
+
+    /**
+     * @brief Tunnel map ex
+     *
+     * @type sai_object_id_t
+     * @objects SAI_OBJECT_TYPE_TUNNEL_MAP
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP = 0x00000001,
+
+    /**
+     * @brief Inner ECN key
+     *
+     * @type sai_uint8_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_OECN_TO_UECN or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_UECN_OECN_TO_OECN
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_OECN_KEY = 0x00000002,
+
+    /**
+     * @brief Inner ECN value
+     *
+     * @type sai_uint8_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_OECN_TO_UECN or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_UECN_OECN_TO_OECN
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_OECN_VALUE = 0x00000003,
+
+    /**
+     * @brief Outer ECN key
+     *
+     * @type sai_uint8_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_OECN_TO_UECN or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_UECN_OECN_TO_OECN
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_UECN_KEY = 0x00000004,
+
+    /**
+     * @brief Outer ECN value
+     *
+     * @type sai_uint8_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_OECN_TO_UECN or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_UECN_OECN_TO_OECN
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_UECN_VALUE = 0x00000005,
+
+    /**
+     * @brief Vlan ID key
+     *
+     * @type sai_uint16_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @isvlan true
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VNI_TO_VLAN_ID or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VLAN_ID_TO_VNI
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_VLAN_ID_KEY = 0x00000006,
+
+    /**
+     * @brief Vlan ID value
+     *
+     * @type sai_uint16_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @isvlan true
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VNI_TO_VLAN_ID or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VLAN_ID_TO_VNI
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_VLAN_ID_VALUE = 0x00000007,
+
+    /**
+     * @brief VNI ID key
+     *
+     * @type sai_uint32_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VNI_TO_VLAN_ID or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VLAN_ID_TO_VNI or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VNI_TO_BRIDGE_IF or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_BRIDGE_IF_TO_VNI
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_VNI_ID_KEY = 0x00000008,
+
+    /**
+     * @brief VNI ID value
+     *
+     * @type sai_uint32_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VNI_TO_VLAN_ID or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VLAN_ID_TO_VNI or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VNI_TO_BRIDGE_IF or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_BRIDGE_IF_TO_VNI
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_VNI_ID_VALUE = 0x00000009,
+
+    /**
+     * @brief Bridge ID key
+     *
+     * @type sai_object_id_t
+     * @objects SAI_OBJECT_TYPE_BRIDGE
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VNI_TO_BRIDGE_IF or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_BRIDGE_IF_TO_VNI
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_BRIDGE_ID_KEY = 0x0000000a,
+
+    /**
+     * @brief Bridge ID value
+     *
+     * @type sai_object_id_t
+     * @objects SAI_OBJECT_TYPE_BRIDGE
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_VNI_TO_BRIDGE_IF or SAI_TUNNEL_MAP_ITEM_ATTR_TUNNEL_MAP_TYPE == SAI_TUNNEL_MAP_TYPE_BRIDGE_IF_TO_VNI
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_BRIDGE_ID_VALUE = 0x0000000b,
+
+    /**
+     * @brief End of attributes
+     */
+    SAI_TUNNEL_MAP_ITEM_ATTR_END,
+
+    /** Custom range base value */
+    SAI_TUNNEL_MAP_ITEM_ATTR_CUSTOM_RANGE_START = 0x10000000,
+
+    /** End of custom range base */
+    SAI_TUNNEL_MAP_ITEM_ATTR_CUSTOM_RANGE_END
+
+} sai_tunnel_map_item_attr_t;
+
 /**
  * @brief Defines tunnel map attributes
  */
@@ -81,6 +212,9 @@ typedef enum _sai_tunnel_map_attr_t
 
     /**
      * @brief Tunnel mapper
+     *
+     * If list is empty, TUNNEL_MAP can be used to assign
+     * TUNNEL_MAP_ITEM objects.
      *
      * @type sai_tunnel_map_list_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
@@ -644,6 +778,58 @@ typedef sai_status_t (*sai_get_tunnel_term_table_entry_attribute_fn)(
         _Inout_ sai_attribute_t *attr_list);
 
 /**
+ * @brief Create tunnel map item
+ *
+ * @param[out] tunnel_map_item_id Tunnel map item id
+ * @param[in] switch_id Switch Id
+ * @param[in] attr_count Number of attributes
+ * @param[in] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success Failure status code on error
+ */
+typedef sai_status_t (*sai_create_tunnel_map_item_fn)(
+        _Out_ sai_object_id_t *tunnel_map_item_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list);
+
+/**
+ * @brief Remove tunnel map item
+ *
+ * @param[in] tunnel_map_item_id Tunnel map item id
+ *
+ * @return #SAI_STATUS_SUCCESS on success Failure status code on error
+ */
+typedef sai_status_t (*sai_remove_tunnel_map_item_fn)(
+        _In_ sai_object_id_t tunnel_map_item_id);
+
+/**
+ * @brief Set tunnel map item attribute
+ *
+ * @param[in] tunnel_map_item_id Tunnel map item id
+ * @param[in] attr Attribute
+ *
+ * @return #SAI_STATUS_SUCCESS on success Failure status code on error
+ */
+typedef sai_status_t (*sai_set_tunnel_map_item_attribute_fn)(
+        _In_ sai_object_id_t tunnel_map_item_id,
+        _In_ const sai_attribute_t *attr);
+
+/**
+ * @brief Get tunnel map item attributes
+ *
+ * @param[in] tunnel_map_item_id Tunnel map item id
+ * @param[in] attr_count Number of attributes
+ * @param[inout] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success Failure status code on error
+ */
+typedef sai_status_t (*sai_get_tunnel_map_item_attribute_fn)(
+        _In_ sai_object_id_t tunnel_map_item_id,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list);
+
+/**
  * @brief tunnel methods table retrieved with sai_api_query()
  */
 typedef struct _sai_tunnel_api_t
@@ -660,6 +846,10 @@ typedef struct _sai_tunnel_api_t
     sai_remove_tunnel_term_table_entry_fn        remove_tunnel_term_table_entry;
     sai_set_tunnel_term_table_entry_attribute_fn set_tunnel_term_table_entry_attribute;
     sai_get_tunnel_term_table_entry_attribute_fn get_tunnel_term_table_entry_attribute;
+    sai_create_tunnel_map_item_fn                create_tunnel_map_item;
+    sai_remove_tunnel_map_item_fn                remove_tunnel_map_item;
+    sai_set_tunnel_map_item_attribute_fn         set_tunnel_map_item_attribute;
+    sai_get_tunnel_map_item_attribute_fn         get_tunnel_map_item_attribute;
 
 } sai_tunnel_api_t;
 

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -216,7 +216,8 @@ typedef enum _sai_object_type_t {
     SAI_OBJECT_TYPE_HOSTIF_USER_DEFINED_TRAP = 56,
     SAI_OBJECT_TYPE_BRIDGE                   = 57,
     SAI_OBJECT_TYPE_BRIDGE_PORT              = 58,
-    SAI_OBJECT_TYPE_MAX                      = 59
+    SAI_OBJECT_TYPE_TUNNEL_MAP_ITEM          = 59,
+    SAI_OBJECT_TYPE_MAX                      = 60,
 } sai_object_type_t;
 
 typedef struct _sai_u8_list_t {
@@ -475,9 +476,6 @@ typedef struct _sai_tunnel_map_params_t
 
     /** VNI id */
     sai_uint32_t vni_id;
-
-    /** Bridge IF */
-    sai_object_id_t bridge_if;
 
 } sai_tunnel_map_params_t;
 

--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -1591,6 +1591,24 @@ sub ProcessStructObjectLen
     return $count;
 }
 
+sub ProcessStructEnumData
+{
+    my $type = shift;
+
+    return "&metadata_enum_$type" if $type =~ /^sai_\w+_type_t$/; # enum
+
+    return "NULL";
+}
+
+sub ProcessStructIsEnum
+{
+    my $type = shift;
+
+    return "true" if $type =~ /^sai_\w+_type_t$/; # enum
+
+    return "false";
+}
+
 sub ProcessStructMembers
 {
     my ($struct, $ot, $rawname) = @_;
@@ -1605,6 +1623,8 @@ sub ProcessStructMembers
         my $isvlan      = ProcessStructIsVlan($struct->{$key}{type});
         my $objects     = ProcessStructObjects($rawname, $key, $struct->{$key});
         my $objectlen   = ProcessStructObjectLen($rawname, $key, $struct->{$key});
+        my $isenum      = ProcessStructIsEnum($struct->{$key}{type});
+        my $enumdata    = ProcessStructEnumData($struct->{$key}{type});
 
         WriteSource "const sai_struct_member_info_t struct_member_sai_${rawname}_t_$key = {";
 
@@ -1613,8 +1633,9 @@ sub ProcessStructMembers
         WriteSource "    .isvlan                    = $isvlan,";
         WriteSource "    .allowedobjecttypes        = $objects,";
         WriteSource "    .allowedobjecttypeslength  = $objectlen,";
+        WriteSource "    .isenum                    = $isenum,";
+        WriteSource "    .enummetadata              = $enumdata,";
 
-        # TODO add enum type is value is enum
         # TODO allow null
 
         WriteSource "};";

--- a/meta/saimetadatatypes.h
+++ b/meta/saimetadatatypes.h
@@ -826,6 +826,21 @@ typedef struct _sai_struct_member_info_t
      */
     size_t                              allowedobjecttypeslength;
 
+    /**
+     * @brief Indicates wheter member is enum value.
+     *
+     * Type must be set as INT32.
+     *
+     * @note Could be deduced from enum type string or
+     * enum vector values and attr value type.
+     */
+    bool                                isenum;
+
+    /**
+     * @brief Provides enum metadata if member is enum
+     */
+    const sai_enum_metadata_t* const    enummetadata;
+
 } sai_struct_member_info_t;
 
 /**

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -1814,6 +1814,18 @@ void check_non_object_id_object_types()
                     META_FAIL("struct member %s have invalid value type %d", m->membername, m->membervaluetype);
             }
 
+            if (m->isenum)
+            {
+                META_ASSERT_NOT_NULL(m->enummetadata);
+
+                META_ASSERT_TRUE(m->membervaluetype == SAI_ATTR_VALUE_TYPE_INT32,
+                        "when enum is defined in struct member non objectid its type must be INT32");
+            }
+            else
+            {
+                META_ASSERT_NULL(m->enummetadata);
+            }
+
             if (m->isvlan)
             {
                 META_ASSERT_TRUE(m->membervaluetype == SAI_ATTR_VALUE_TYPE_UINT16, "member marked as vlan, but wrong type specified");
@@ -2239,7 +2251,7 @@ void check_read_only_attributes()
 
 void check_mixed_object_list_types()
 {
-    META_LOG_ENTER(); 
+    META_LOG_ENTER();
 
     /*
      * Purpose of this check is to find out if any of object id lists supports

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -2368,10 +2368,18 @@ void check_api_names()
         generic_remove_fn remove = apiname ## _api.remove_ ## short_object_type;\
         generic_set_fn set = apiname ## _api.set_ ## short_object_type ## _attribute;\
         generic_get_fn get =  apiname ## _api.get_ ## short_object_type ## _attribute;\
+        sai_create_ ## short_object_type ## _fn cr = NULL;\
+        sai_remove_ ## short_object_type ## _fn re = NULL;\
+        sai_set_ ## short_object_type ## _attribute_fn se = NULL;\
+        sai_get_ ## short_object_type ## _attribute_fn ge = NULL;\
         dummy = &create;\
         dummy = &remove;\
         dummy = &set;\
         dummy = &get;\
+        dummy = &cr;\
+        dummy = &re;\
+        dummy = &se;\
+        dummy = &ge;\
     }
 
     /*
@@ -2444,6 +2452,7 @@ void check_api_names()
     CHECK_API(hostif, hostif_user_defined_trap, SAI_OBJECT_TYPE_HOSTIF_USER_DEFINED_TRAP);
     CHECK_API(bridge, bridge, SAI_OBJECT_TYPE_BRIDGE);
     CHECK_API(bridge, bridge_port, SAI_OBJECT_TYPE_BRIDGE_PORT);
+    CHECK_API(tunnel, tunnel_map_item, SAI_OBJECT_TYPE_TUNNEL_MAP_ITEM);
 
 #define CHECK_ENTRY_API(apiname, entry_name, object_type)\
     {\
@@ -2468,10 +2477,18 @@ void check_api_names()
         entry_name ## _remove_fn remove = apiname ## _api.remove_ ## entry_name;\
         entry_name ## _set_fn set = apiname ## _api.set_ ## entry_name ## _attribute;\
         entry_name ## _get_fn get =  apiname ## _api.get_ ## entry_name ## _attribute;\
+        sai_create_ ## entry_name ## _fn cr = NULL;\
+        sai_remove_ ## entry_name ## _fn re = NULL;\
+        sai_set_ ## entry_name ## _attribute_fn se = NULL;\
+        sai_get_ ## entry_name ## _attribute_fn ge = NULL;\
         dummy = &create;\
         dummy = &remove;\
         dummy = &set;\
         dummy = &get;\
+        dummy = &cr;\
+        dummy = &re;\
+        dummy = &se;\
+        dummy = &ge;\
     }
 
     /*
@@ -2500,10 +2517,18 @@ void check_api_names()
         generic_remove_fn remove = switch_api.remove_switch;
         generic_set_fn set = switch_api.set_switch_attribute;
         generic_get_fn get = switch_api.get_switch_attribute;
+        sai_create_switch_fn cr = NULL;
+        sai_remove_switch_fn re = NULL;
+        sai_set_switch_attribute_fn se = NULL;
+        sai_get_switch_attribute_fn ge = NULL;
         dummy = &create;
         dummy = &remove;
         dummy = &set;
         dummy = &get;
+        dummy = &cr;
+        dummy = &re;
+        dummy = &se;
+        dummy = &ge;
     }
 
     if (debug)


### PR DESCRIPTION
This also fixes current build because of adding new object type TUNNEL_MAP_ITEM which when not added to api check will cause fail to build other PR