### PR TITLE
Add sai_switch_id_query api to query switch id from sai objects

### DIFF
--- a/inc/sai.h
+++ b/inc/sai.h
@@ -226,6 +226,19 @@ sai_object_type_t sai_object_type_query(
         _In_ sai_object_id_t sai_object_id);
 
 /**
+ * @brief Query sai switch id.
+ *
+ * @param[in] sai_object_id Object id
+ *
+ * @return Return #SAI_NULL_OBJECT_ID when sai_object_id is not valid.
+ * Otherwise, return a valid SAI_OBJECT_TYPE_SWITCH object on which
+ * provided object id belongs. If valid switch id object is provided
+ * as input parameter it should returin itself.
+ */
+sai_object_id_t sai_switch_id_query(
+        _In_ sai_object_id_t sai_object_id);
+
+/**
  * @brief Generate dump file. The dump file may include SAI state information and vendor SDK information.
  *
  * @param[in] dump_file_name Full path for dump file

--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -2308,7 +2308,7 @@ sub CheckHeadersStyle
             next if $line =~ /^$/;                  # empty line
             next if $line =~ /^typedef /;           # type definition
             next if $line =~ /^sai_status/;         # return codes
-            next if $line =~ /^sai_object_type/;    # return codes
+            next if $line =~ /^sai_object/;         # return codes
             next if $line =~ /^[{}#\/]/;            # start end of struct, define, start of comment
             next if $line =~ /^ {8}(_In|_Out)/;     # function arguments
             next if $line =~ /^ {4}(sai_)/i;        # sai struct entry or SAI enum


### PR DESCRIPTION
When multiple asic will be present in sai, multiple switch objects can be created each one for each asic.
Purpose of this api is to get actual switch id to which created object id belongs like LAG or VLAN and all objects, since be definition you can use object created on one switch on a object created created on second switch.