### PR TITLE
Add sai_ip_prefix_t to sai_attribute_value_t for future use

### DIFF
--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -555,6 +555,7 @@ typedef union {
     sai_ip4_t ip4;
     sai_ip6_t ip6;
     sai_ip_address_t ipaddr;
+    sai_ip_prefix_t ipprefix;
     sai_object_id_t oid;
     sai_object_list_t objlist;
     sai_u8_list_t u8list;

--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -221,6 +221,7 @@ sai_mac_t               mac
 sai_ip4_t               ip4
 sai_ip6_t               ip6
 sai_ip_address_t        ipaddr
+sai_ip_prefix_t         ipprefix
 sai_object_id_t         oid
 sai_object_list_t       objlist
 sai_u8_list_t           u8list
@@ -253,6 +254,7 @@ sai_mac_t               MAC
 sai_ip4_t               IPV4
 sai_ip6_t               IPV6
 sai_ip_address_t        IP_ADDRESS
+sai_ip_prefix_t         IP_PREFIX
 sai_object_id_t         OBJECT_ID
 sai_object_list_t       OBJECT_LIST
 sai_u8_list_t           UINT8_LIST

--- a/meta/saimetadatatypes.h
+++ b/meta/saimetadatatypes.h
@@ -135,6 +135,11 @@ typedef enum _sai_attr_value_type_t {
     SAI_ATTR_VALUE_TYPE_IP_ADDRESS,
 
     /**
+     * @brief Attribute value is ip prefix
+     */
+    SAI_ATTR_VALUE_TYPE_IP_PREFIX,
+
+    /**
      * @brief Attribute value is object id.
      */
     SAI_ATTR_VALUE_TYPE_OBJECT_ID,
@@ -323,11 +328,6 @@ typedef enum _sai_attr_value_type_t {
      * @brief Attribute value is acl capability.
      */
     SAI_ATTR_VALUE_TYPE_ACL_CAPABILITY,
-
-    /**
-     * @brief Attribute value is ip prefix
-     */
-    SAI_ATTR_VALUE_TYPE_IP_PREFIX,
 
 } sai_attr_value_type_t;
 

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -506,6 +506,7 @@ void check_attr_object_type_provided(
         case SAI_ATTR_VALUE_TYPE_MAC:
         case SAI_ATTR_VALUE_TYPE_POINTER:
         case SAI_ATTR_VALUE_TYPE_IP_ADDRESS:
+        case SAI_ATTR_VALUE_TYPE_IP_PREFIX:
         case SAI_ATTR_VALUE_TYPE_CHARDATA:
         case SAI_ATTR_VALUE_TYPE_UINT32_RANGE:
         case SAI_ATTR_VALUE_TYPE_UINT32_LIST:
@@ -724,6 +725,7 @@ void check_attr_default_required(
         case SAI_ATTR_VALUE_TYPE_UINT64:
         case SAI_ATTR_VALUE_TYPE_MAC:
         case SAI_ATTR_VALUE_TYPE_IP_ADDRESS:
+        case SAI_ATTR_VALUE_TYPE_IP_PREFIX:
             break;
 
         case SAI_ATTR_VALUE_TYPE_INT8_LIST:


### PR DESCRIPTION
Member of attribute value ipprefix will be used later on
for generic extraction of members from non object id
structs and now is only used inside route_entry