### PR TITLE
Block BUM traffic ingress on given port to port list provided in the …

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -1019,6 +1019,58 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_EGRESS_BLOCK_PORT_LIST,
 
     /**
+     * @brief Egress broadcast flood traffic block port list
+     *
+     * Broadcast flood Traffic ingressing on this port and egressing out of
+     * the ports in the given port list will be dropped.
+     *
+     * @type sai_object_list_t
+     * @objects SAI_OBJECT_TYPE_PORT
+     * @flags CREATE_AND_SET
+     * @default empty
+     */
+    SAI_PORT_ATTR_EGRESS_FLOOD_BLOCK_BCAST_PORT_LIST,
+
+    /**
+     * @brief Egress Unknown unicast flood traffic block port list
+     *
+     * Unknown unicast Traffic ingressing on this port and egressing out of
+     * the ports in the given port list will be dropped.
+     *
+     * @type sai_object_list_t
+     * @objects SAI_OBJECT_TYPE_PORT
+     * @flags CREATE_AND_SET
+     * @default empty
+     */
+    SAI_PORT_ATTR_EGRESS_FLOOD_BLOCK_UNKNOWN_UCAST_PORT_LIST,
+
+    /**
+     * @brief Egress Unknown multicast flood traffic block port list
+     *
+     * Unknown multicast Traffic ingressing on this port and egressing out of
+     * the ports in the given port list will be dropped.
+     *
+     * @type sai_object_list_t
+     * @objects SAI_OBJECT_TYPE_PORT
+     * @flags CREATE_AND_SET
+     * @default empty
+     */
+    SAI_PORT_ATTR_EGRESS_FLOOD_BLOCK_UNKNOWN_MCAST_PORT_LIST,
+
+    /**
+     * @brief Egress (bcast, Unknown multicast/unicast) flood traffic block port list
+     *
+     * Flood Traffic ingressing on this port and egressing out of
+     * the ports in the given port list will be dropped.
+     *
+     * @type sai_object_list_t
+     * @objects SAI_OBJECT_TYPE_PORT
+     * @flags CREATE_AND_SET
+     * @default empty
+     */
+    SAI_PORT_ATTR_EGRESS_FLOOD_BLOCK_ALL_PORT_LIST,
+
+    /**
      * @brief Port Hardware Configuration Profile ID
      *
      * Port can require different hardware configuration based on the attached


### PR DESCRIPTION
Use Case: Once of our use case is to block Flooding(Broadcast/unknown Unicast/unknown multicast/All three types) from given port to other ports in system.  example, FCoE and FC port can be same vlan. Traffic ingress on FCoE port and it is BUM traffic then block to other FC ports alone and flood it to other Ethernet or FCoE ports and vice versa.  Those port can be many vlan's, instead of vlan control port level control will help us.  