### PR TITLE
saithrift: Fix compilation issues with new SAI API

### DIFF
--- a/test/saithrift/src/saiserver.cpp
+++ b/test/saithrift/src/saiserver.cpp
@@ -146,7 +146,7 @@ void sai_diag_shell()
         sai_attribute_t attr;
         attr.id = SAI_SWITCH_ATTR_SWITCH_SHELL_ENABLE;
         attr.value.booldata = true;
-        status = sai_switch_api->set_switch_attribute(&attr);
+        status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
         if (status != SAI_STATUS_SUCCESS)
         {
             return;

--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -458,7 +458,7 @@ public:
               case SAI_HOSTIF_ATTR_TYPE:
                   attr_list[i].value.s32 = attribute.value.s32;
                   break;
-              case SAI_HOSTIF_ATTR_RIF_OR_PORT_ID:
+              case SAI_HOSTIF_ATTR_OBJ_ID:
                   attr_list[i].value.oid = attribute.value.oid;
                   break;
               case SAI_HOSTIF_ATTR_NAME:
@@ -953,7 +953,7 @@ public:
       sai_thrift_parse_next_hop_group_member_attributes(thrift_attr_list, attr_list);
 
       sai_object_id_t nextHopGroupMbrObjId = 0;
-      status = nhop_group_api->create_next_hop_group_member(&nextHopGroupMbrObjId, attr_size, attr_list);
+      status = nhop_group_api->create_next_hop_group_member(&nextHopGroupMbrObjId, gSwitchId, attr_size, attr_list);
 
       if (status == SAI_STATUS_SUCCESS)
       {

--- a/test/saithrift/tests/switch.py
+++ b/test/saithrift/tests/switch.py
@@ -395,7 +395,7 @@ def sai_thrift_create_hostif(client, rif_or_port_id, intf_name):
     attribute1 = sai_thrift_attribute_t(id=SAI_HOSTIF_ATTR_TYPE,
                                         value=attribute1_value)
     attribute2_value = sai_thrift_attribute_value_t(oid=rif_or_port_id)
-    attribute2 = sai_thrift_attribute_t(id=SAI_HOSTIF_ATTR_RIF_OR_PORT_ID,
+    attribute2 = sai_thrift_attribute_t(id=SAI_HOSTIF_ATTR_OBJ_ID,
                                         value=attribute2_value)
     attribute3_value = sai_thrift_attribute_value_t(chardata=intf_name)
     attribute3 = sai_thrift_attribute_t(id=SAI_HOSTIF_ATTR_NAME,


### PR DESCRIPTION
Thereare few fixes to make possible compile saithrift tests
with the newer SAI API headers:

    1) Missing switch id in create & set_switch_attribute calls
    2) Replace SAI_HOSTIF_ATTR_RIF_OR_PORT_ID by XXX_OBJ_ID

Signed-off-by: Vadim Kochan <vadymk@mellanox.com>