### PR TITLE
saithrift: sail2: Fix default vlan oid/id usage

### DIFF
--- a/test/saithrift/src/switch_sai.thrift
+++ b/test/saithrift/src/switch_sai.thrift
@@ -34,8 +34,9 @@ typedef i32 sai_thrift_port_stat_counter_t
 typedef i32 sai_thrift_queue_stat_counter_t
 typedef i32 sai_thrift_pg_stat_counter_t
 
-struct sai_thrift_result_data_t {
+union sai_thrift_result_data_t {
     1: sai_thrift_object_id_t oid;
+    2: i16 u16;
 }
 
 struct sai_thrift_result_t {
@@ -224,6 +225,7 @@ service switch_sai_rpc {
     sai_thrift_object_id_t sai_thrift_create_vlan_member(1: list<sai_thrift_attribute_t> thrift_attr_list);
     sai_thrift_status_t sai_thrift_remove_vlan_member(1: sai_thrift_object_id_t vlan_member_id);
     sai_thrift_attribute_list_t sai_thrift_get_vlan_attribute(1: sai_thrift_object_id_t vlan_id);
+    sai_thrift_result_t sai_thrift_get_vlan_id(1: sai_thrift_object_id_t vlan_id);
 
     //virtual router API
     sai_thrift_object_id_t sai_thrift_create_virtual_router(1: list<sai_thrift_attribute_t> thrift_attr_list);
@@ -269,6 +271,7 @@ service switch_sai_rpc {
     sai_thrift_object_id_t sai_thrift_get_cpu_port_id();
     sai_thrift_object_id_t sai_thrift_get_default_trap_group();
     sai_thrift_object_id_t sai_thrift_get_default_router_id();
+    sai_thrift_result_t sai_thrift_get_default_vlan_id();
     sai_thrift_object_id_t sai_thrift_get_port_id_by_front_port(1: string port_name);
     sai_thrift_status_t sai_thrift_set_switch_attribute(1: sai_thrift_attribute_t attribute);
 

--- a/test/saithrift/tests/sail2.py
+++ b/test/saithrift/tests/sail2.py
@@ -278,7 +278,6 @@ class L2FloodTest(sai_base_test.ThriftInterfaceDataPlane):
 class L2LagTest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         switch_init(self.client)
-        default_vlan = 1
         vlan_id = 10
         port1 = port_list[0]
         port2 = port_list[1]
@@ -292,7 +291,7 @@ class L2LagTest(sai_base_test.ThriftInterfaceDataPlane):
 
         lag_id1 = self.client.sai_thrift_create_lag([])
 
-        sai_thrift_vlan_remove_all_ports(self.client, default_vlan)
+        sai_thrift_vlan_remove_all_ports(self.client, default_vlan.oid)
 
         lag_member_id1 = sai_thrift_create_lag_member(self.client, lag_id1, port1)
         lag_member_id2 = sai_thrift_create_lag_member(self.client, lag_id1, port2)
@@ -373,7 +372,7 @@ class L2LagTest(sai_base_test.ThriftInterfaceDataPlane):
             self.client.sai_thrift_remove_vlan(vlan_oid)
 
             for port in sai_port_list:
-                sai_thrift_create_vlan_member(self.client, default_vlan, port, SAI_VLAN_TAGGING_MODE_UNTAGGED)
+                sai_thrift_create_vlan_member(self.client, default_vlan.oid, port, SAI_VLAN_TAGGING_MODE_UNTAGGED)
 
             attr_value = sai_thrift_attribute_value_t(u16=1)
             attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
@@ -397,7 +396,6 @@ class L2VlanBcastUcastTest(sai_base_test.ThriftInterfaceDataPlane):
         """
 
         switch_init(self.client)
-        default_vlan = 1
         vlan_id = 10
         mac_list = []
         vlan_member_list = []
@@ -407,7 +405,7 @@ class L2VlanBcastUcastTest(sai_base_test.ThriftInterfaceDataPlane):
             mac_list.append("00:00:00:00:00:%02x" %(i+1))
         mac_action = SAI_PACKET_ACTION_FORWARD
 
-        sai_thrift_vlan_remove_all_ports(self.client, default_vlan)
+        sai_thrift_vlan_remove_all_ports(self.client, default_vlan.oid)
 
         vlan_oid = sai_thrift_create_vlan(self.client, vlan_id)
         for i in range (0, len(port_list)-1):
@@ -443,7 +441,7 @@ class L2VlanBcastUcastTest(sai_base_test.ThriftInterfaceDataPlane):
                 verify_packets(self, ucast_pkt, [i])
 
         finally:
-            attr_value = sai_thrift_attribute_value_t(u16=default_vlan)
+            attr_value = sai_thrift_attribute_value_t(u16=default_vlan.vid)
             attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
 
             for i in range (0, len(port_list)-1):
@@ -453,8 +451,8 @@ class L2VlanBcastUcastTest(sai_base_test.ThriftInterfaceDataPlane):
             for vlan_member in vlan_member_list:
                 self.client.sai_thrift_remove_vlan_member(vlan_member)
 
-            self.client.sai_thrift_remove_vlan(vlan_id)
+            self.client.sai_thrift_remove_vlan(vlan_oid)
 
             for port in sai_port_list:
-                sai_thrift_create_vlan_member(self.client, default_vlan, port, SAI_VLAN_TAGGING_MODE_UNTAGGED)
+                sai_thrift_create_vlan_member(self.client, default_vlan.oid, port, SAI_VLAN_TAGGING_MODE_UNTAGGED)
 


### PR DESCRIPTION
In some places like removing all ports from vlan the vlan id is
used instead of oid, so added additional RPC functions to get default
vlan id.

Some short summary of changes:

    1) Add sai_thrift_get_default_vlan_id() RPC function to obtain
       SAI_SWITCH_ATTR_DEFAULT_VLAN_ID attribute.

    2) Add sai_thrift_get_vlan_id() RPC function to obtain vlan id by oid

    3) Add VlanObj class to easy export default vlan vid & oid on switch init

Signed-off-by: Vadim Kochan <vadymk@mellanox.com>