### PR TITLE
saiswitch: Remove default 1Q bridge port

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -544,19 +544,6 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_DEFAULT_1Q_BRIDGE_ID,
 
     /**
-     * @brief Default .1Q bridge router port ID
-     *
-     * This bridge router port is associated with the default .1Q Bridge
-     * #SAI_SWITCH_ATTR_DEFAULT_1Q_BRIDGE_ID
-     *
-     * @type sai_object_id_t
-     * @flags READ_ONLY
-     * @objects SAI_OBJECT_TYPE_BRIDGE_PORT
-     * @default internal
-     */
-    SAI_SWITCH_ATTR_DEFAULT_1Q_BRIDGE_PORT_ID,
-
-    /**
      * @brief Switch/Global bind point for ingress ACL object
      *
      * Bind (or unbind) an ingress acl table or acl group globally. Enable/Update


### PR DESCRIPTION
Remove SAI_SWITCH_ATTR_DEFAULT_1Q_BRIDGE_PORT_ID attribute as the
default 1Q router bridge port can be fetched via SAI_BRIDGE_ATTR_PORT_LIST
from the default 1Q bridge object.

The purpose is to simplify SAI Switch API.

Signed-off-by: Vadim Kochan <vadymk@mellanox.com>