### PR TITLE
Add test for checking enum size

### DIFF
--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -2277,6 +2277,28 @@ sub CreateNonObjectIdTest
     WriteTest "}";
 }
 
+sub CreateEnumSizeCheckTest
+{
+    DefineTestName "enum_size_check_test";
+
+    WriteTest "{";
+
+    # purpose of this test is to check if all enums size is int32_t in this compiler
+    # since serialize/deserialize enums make assumption that enum base is int32_t
+
+    for my $key (sort keys %SAI_ENUMS)
+    {
+        next if not $key =~ /^(sai_\w+_t)$/;
+        next if $key =~ /^(sai_null_attr_t)$/;
+
+        WriteTest "    if (sizeof($1) != sizeof(int32_t)) exit(1);";
+    }
+
+    WriteTest "    if (sizeof(sai_status_t) != sizeof(int32_t)) exit(1);";
+
+    WriteTest "}";
+}
+
 sub ExtractStructInfo
 {
     my $struct = shift;
@@ -3019,6 +3041,8 @@ WriteTestHeader();
 CreateNonObjectIdTest();
 
 CreatePointersTest();
+
+CreateEnumSizeCheckTest();
 
 WriteTestMain();
 


### PR DESCRIPTION
Purpose of this test is to check if all enums size is int32_t in this compiler since serialize/deserialize enums make assumption that enum base is int32_t