### PR TITLE
Modified attr name to get max ports supported on switch

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -225,12 +225,12 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_START,
 
     /**
-     * @brief The number of ports on the switch
+     * @brief Maximum number of supported ports on the switch
      *
      * @type sai_uint32_t
      * @flags READ_ONLY
      */
-    SAI_SWITCH_ATTR_PORT_NUMBER = SAI_SWITCH_ATTR_START,
+    SAI_SWITCH_ATTR_MAX_NUMBER_OF_SUPPORTED_PORTS = SAI_SWITCH_ATTR_START,
 
     /**
      * @brief Get the port list

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -225,12 +225,20 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_START,
 
     /**
+     * @brief Number of active ports on the switch
+     *
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_SWITCH_ATTR_NUMBER_OF_ACTIVE_PORTS = SAI_SWITCH_ATTR_START,
+
+    /**
      * @brief Maximum number of supported ports on the switch
      *
      * @type sai_uint32_t
      * @flags READ_ONLY
      */
-    SAI_SWITCH_ATTR_MAX_NUMBER_OF_SUPPORTED_PORTS = SAI_SWITCH_ATTR_START,
+    SAI_SWITCH_ATTR_MAX_NUMBER_OF_SUPPORTED_PORTS,
 
     /**
      * @brief Get the port list


### PR DESCRIPTION
Previous attribute SAI_SWITCH_ATTR_PORT_NUMBER is not clear. 
is this for active ports or max supported ports by NPU ?
Max supported ports are more relevant, since apps can query SAI_SWITCH_ATTR_PORT_LIST to get active list or adapter will create/delete ports as part of switch_init. 
They will have active port count in DB. 