### PR TITLE
Added an ALIASE for "isvlan" flag in DoxyFile.

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -245,6 +245,7 @@ ALIASES                += "allownull    =@par Allows NULL object ID\n   @xmlonly
 ALIASES                += "condition    =@par Condition:\n              @xmlonly @@condition     @endxmlonly"
 ALIASES                += "default      =@par Default value:\n          @xmlonly @@default       @endxmlonly"
 ALIASES                += "ignore       =@par Ignored:\n                @xmlonly @@ignore        @endxmlonly"
+ALIASES                += "isvlan       =@par IsVlan:\n                 @xmlonly @@isvlan        @endxmlonly"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"


### PR DESCRIPTION
An ALIASE for "isvaln" flag is missing in DoxyFile. This flag is used in saimirror.h attribute properties.