### PR TITLE
Add PG port and index attributes

### DIFF
--- a/inc/saibuffer.h
+++ b/inc/saibuffer.h
@@ -57,6 +57,23 @@ typedef enum _sai_ingress_priority_group_attr_t
     SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE = SAI_INGRESS_PRIORITY_GROUP_ATTR_START,
 
     /**
+     * @brief Pord id
+     *
+     * @type sai_object_id_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY | KEY
+     * @objects SAI_OBJECT_TYPE_PORT
+     */
+    SAI_INGRESS_PRIORITY_GROUP_ATTR_PORT,
+
+    /**
+     * @brief PG index
+     *
+     * @type sai_uint8_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY | KEY
+     */
+    SAI_INGRESS_PRIORITY_GROUP_ATTR_INDEX,
+
+    /**
      * @brief End of attributes
      */
     SAI_INGRESS_PRIORITY_GROUP_ATTR_END

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -1502,7 +1502,7 @@ void check_attr_key(
 
             case SAI_ATTR_VALUE_TYPE_OBJECT_ID:
 
-                if (md->objecttype == SAI_OBJECT_TYPE_QUEUE && md->attrid == SAI_QUEUE_ATTR_PORT)
+                if ((md->objecttype == SAI_OBJECT_TYPE_QUEUE || md->objecttype == SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP) && md->attrid == SAI_QUEUE_ATTR_PORT)
                 {
                     /*
                      * This is also special case, OBJECT_ID at should not be a


### PR DESCRIPTION
For PG creation, it is needed to specify what is the Port and PG index
(similar to Queue API)