### PR TITLE
Add pedantic rules on keywords in comments

### DIFF
--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -79,7 +79,7 @@ typedef enum _sai_acl_ip_type_t
     /** IPv4 and IPv6 packets */
     SAI_ACL_IP_TYPE_IP,
 
-    /** Non-Ip packet */
+    /** Non-IP packet */
     SAI_ACL_IP_TYPE_NON_IP,
 
     /** Any IPv4 packet */
@@ -268,7 +268,7 @@ typedef enum _sai_acl_table_group_attr_t
      * groups to let the user specify his intention to allow further error
      * checks and optimizations based on a specific ASIC's SAI implementation.
      * ACL members being added to this group SHOULD be a subset of the bind
-     * point list that acl group was created with.
+     * point list that ACL group was created with.
      *
      * @type sai_s32_list_t sai_acl_bind_point_type_t
      * @flags CREATE_ONLY
@@ -282,8 +282,8 @@ typedef enum _sai_acl_table_group_attr_t
      * ACL table group type represents the way various ACL tables within this
      * ACL table group perform their lookups. There are two optional values :
      * Sequential - All the ACL tables are looked up in a sequential order ,
-     * which is based on the ACL table priorities and only one acl entry is matched
-     * with its corresponding acl entry action applied. In case two ACL tables
+     * which is based on the ACL table priorities and only one ACL entry is matched
+     * with its corresponding ACL entry action applied. In case two ACL tables
      * have the same priority they are looked up on a first come basis.
      * Parallel - All the ACL tables within the ACL table groups are looked up
      * in parallel and non-conflicting actions are resolved and applied from
@@ -326,7 +326,7 @@ typedef enum _sai_acl_table_group_member_attr_t
      * @brief ACL table group id
      *
      * This attribute is required to associate or attach a member object (acl_table_id)
-     * to a acl table group id allocated by the create acl group api.
+     * to a ACL table group id allocated by the create ACL group api.
      *
      * User should always use the group id returned by SAI create_acl_group api,
      * to group the tables else Invalid attribute value error code will be returned.
@@ -703,7 +703,7 @@ typedef enum _sai_acl_table_attr_t
     SAI_ACL_TABLE_ATTR_FIELD_IP_IDENTIFICATION,
 
     /**
-     * @brief Ip Dscp
+     * @brief IP DSCP
      *
      * @type bool
      * @flags CREATE_ONLY
@@ -712,7 +712,7 @@ typedef enum _sai_acl_table_attr_t
     SAI_ACL_TABLE_ATTR_FIELD_DSCP,
 
     /**
-     * @brief Ip Ecn
+     * @brief IP ECN
      *
      * @type bool
      * @flags CREATE_ONLY
@@ -721,7 +721,7 @@ typedef enum _sai_acl_table_attr_t
     SAI_ACL_TABLE_ATTR_FIELD_ECN,
 
     /**
-     * @brief Ip Ttl
+     * @brief IP TTL
      *
      * @type bool
      * @flags CREATE_ONLY
@@ -730,7 +730,7 @@ typedef enum _sai_acl_table_attr_t
     SAI_ACL_TABLE_ATTR_FIELD_TTL,
 
     /**
-     * @brief Ip Tos
+     * @brief IP TOS
      *
      * @type bool
      * @flags CREATE_ONLY
@@ -739,7 +739,7 @@ typedef enum _sai_acl_table_attr_t
     SAI_ACL_TABLE_ATTR_FIELD_TOS,
 
     /**
-     * @brief Ip Flags
+     * @brief IP Flags
      *
      * @type bool
      * @flags CREATE_ONLY
@@ -748,7 +748,7 @@ typedef enum _sai_acl_table_attr_t
     SAI_ACL_TABLE_ATTR_FIELD_IP_FLAGS,
 
     /**
-     * @brief Tcp Flags
+     * @brief TCP Flags
      *
      * @type bool
      * @flags CREATE_ONLY
@@ -757,7 +757,7 @@ typedef enum _sai_acl_table_attr_t
     SAI_ACL_TABLE_ATTR_FIELD_TCP_FLAGS,
 
     /**
-     * @brief Ip Type
+     * @brief IP Type
      *
      * @type bool
      * @flags CREATE_ONLY
@@ -766,7 +766,7 @@ typedef enum _sai_acl_table_attr_t
     SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE,
 
     /**
-     * @brief Ip Frag
+     * @brief IP Frag
      *
      * @type bool
      * @flags CREATE_ONLY
@@ -1130,7 +1130,7 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_FIELD_OUT_PORT,
 
     /**
-     * @brief Source port which could be a physical or lag port
+     * @brief Source port which could be a physical or LAG port
      * (mask is not needed)
      *
      * @type sai_acl_field_data_t sai_object_id_t
@@ -1234,7 +1234,7 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_FIELD_IP_IDENTIFICATION,
 
     /**
-     * @brief Ip Dscp (6 bits)
+     * @brief IP DSCP (6 bits)
      *
      * @type sai_acl_field_data_t sai_uint8_t
      * @flags CREATE_AND_SET
@@ -1242,7 +1242,7 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_FIELD_DSCP,
 
     /**
-     * @brief Ip Ecn (2 bits)
+     * @brief IP ECN (2 bits)
      *
      * @type sai_acl_field_data_t sai_uint8_t
      * @flags CREATE_AND_SET
@@ -1250,7 +1250,7 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_FIELD_ECN,
 
     /**
-     * @brief Ip Ttl
+     * @brief IP TTL
      *
      * @type sai_acl_field_data_t sai_uint8_t
      * @flags CREATE_AND_SET
@@ -1258,7 +1258,7 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_FIELD_TTL,
 
     /**
-     * @brief Ip Tos
+     * @brief IP TOS
      *
      * @type sai_acl_field_data_t sai_uint8_t
      * @flags CREATE_AND_SET
@@ -1266,7 +1266,7 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_FIELD_TOS,
 
     /**
-     * @brief Ip Flags (3 bits)
+     * @brief IP Flags (3 bits)
      *
      * @type sai_acl_field_data_t sai_uint8_t
      * @flags CREATE_AND_SET
@@ -1274,7 +1274,7 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_FIELD_IP_FLAGS,
 
     /**
-     * @brief Tcp Flags (6 bits)
+     * @brief TCP Flags (6 bits)
      *
      * @type sai_acl_field_data_t sai_uint8_t
      * @flags CREATE_AND_SET
@@ -1282,7 +1282,7 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_FIELD_TCP_FLAGS,
 
     /**
-     * @brief Ip Type (field mask is not needed)
+     * @brief IP Type (field mask is not needed)
      *
      * @type sai_acl_field_data_t sai_acl_ip_type_t
      * @flags CREATE_AND_SET
@@ -1290,7 +1290,7 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_FIELD_ACL_IP_TYPE,
 
     /**
-     * @brief Ip Frag (field mask is not needed)
+     * @brief IP Frag (field mask is not needed)
      *
      * @type sai_acl_field_data_t sai_acl_ip_frag_t
      * @flags CREATE_AND_SET
@@ -1485,7 +1485,7 @@ typedef enum _sai_acl_entry_attr_t
 
     /**
      * @brief Redirect Packet to a destination which can be a port,
-     * lag, nexthop, nexthopgroup
+     * LAG, nexthop, nexthopgroup
      *
      * @type sai_acl_action_data_t sai_object_id_t
      * @flags CREATE_AND_SET

--- a/inc/saibridge.h
+++ b/inc/saibridge.h
@@ -70,10 +70,10 @@ typedef enum _sai_bridge_port_fdb_learning_mode_t
  */
 typedef enum _sai_bridge_port_type_t
 {
-    /** Port or Lag */
+    /** Port or LAG */
     SAI_BRIDGE_PORT_TYPE_PORT,
 
-    /** {Port or Lag.vlan} */
+    /** {Port or LAG.vlan} */
     SAI_BRIDGE_PORT_TYPE_SUB_PORT,
 
     /** bridge router port */
@@ -106,7 +106,7 @@ typedef enum _sai_bridge_port_attr_t
     SAI_BRIDGE_PORT_ATTR_TYPE = SAI_BRIDGE_PORT_ATTR_START,
 
     /**
-     * @brief Associated Port or Lag object id
+     * @brief Associated Port or LAG object id
      *
      * @type sai_object_id_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
@@ -177,7 +177,7 @@ typedef enum _sai_bridge_port_attr_t
     SAI_BRIDGE_PORT_ATTR_MAX_LEARNED_ADDRESSES,
 
     /**
-     * @brief Action for packets with unknown source mac address
+     * @brief Action for packets with unknown source MAC address
      * when FDB learning limit is reached.
      *
      * @type sai_packet_action_t

--- a/inc/saifdb.h
+++ b/inc/saifdb.h
@@ -58,7 +58,7 @@ typedef struct _sai_fdb_entry_t
      */
     sai_object_id_t switch_id;
 
-    /** Mac address */
+    /** MAC address */
     sai_mac_t mac_address;
 
     /** Bridge type */
@@ -96,7 +96,7 @@ typedef enum _sai_fdb_event_t
 } sai_fdb_event_t;
 
 /**
- * @brief Attribute Id for fdb entry
+ * @brief Attribute Id for FDB entry
  */
 typedef enum _sai_fdb_entry_attr_t
 {
@@ -192,7 +192,7 @@ typedef enum _sai_fdb_flush_entry_type_t
  * then there is no need to specify the #SAI_FDB_FLUSH_ATTR_ENTRY_TYPE attribute.
  * The API uses AND operation when multiple attributes are specified. For
  * exmaple,
- * 1) Flush all entries in fdb table - Do not specify any attribute
+ * 1) Flush all entries in FDB table - Do not specify any attribute
  * 2) Flush all entries by bridge port - Set #SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID
  * 3) Flush all entries by VLAN - Set #SAI_FDB_FLUSH_ATTR_VLAN_ID
  * 4) Flush all entries by bridge port and VLAN - Set #SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID
@@ -294,7 +294,7 @@ typedef sai_status_t (*sai_remove_fdb_entry_fn)(
         _In_ const sai_fdb_entry_t *fdb_entry);
 
 /**
- * @brief Set fdb entry attribute value
+ * @brief Set FDB entry attribute value
  *
  * @param[in] fdb_entry FDB entry
  * @param[in] attr Attribute
@@ -306,7 +306,7 @@ typedef sai_status_t (*sai_set_fdb_entry_attribute_fn)(
         _In_ const sai_attribute_t *attr);
 
 /**
- * @brief Get fdb entry attribute value
+ * @brief Get FDB entry attribute value
  *
  * @param[in] fdb_entry FDB entry
  * @param[in] attr_count Number of attributes
@@ -337,7 +337,7 @@ typedef sai_status_t (*sai_flush_fdb_entries_fn)(
  * @brief FDB notifications
  *
  * @param[in] count Number of notifications
- * @param[in] data Pointer to fdb event notification data array
+ * @param[in] data Pointer to FDB event notification data array
  */
 typedef void (*sai_fdb_event_notification_fn)(
         _In_ uint32_t count,

--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -66,7 +66,7 @@ typedef enum _sai_hostif_trap_group_attr_t
     SAI_HOSTIF_TRAP_GROUP_ATTR_ADMIN_STATE = SAI_HOSTIF_TRAP_GROUP_ATTR_START,
 
     /**
-     * @brief Cpu egress queue
+     * @brief CPU egress queue
      *
      * @type sai_uint32_t
      * @flags CREATE_AND_SET
@@ -75,7 +75,7 @@ typedef enum _sai_hostif_trap_group_attr_t
     SAI_HOSTIF_TRAP_GROUP_ATTR_QUEUE,
 
     /**
-     * @brief Sai policer object id
+     * @brief SAI policer object id
      *
      * @type sai_object_id_t
      * @flags CREATE_AND_SET
@@ -263,25 +263,25 @@ typedef enum _sai_hostif_trap_type_t
     SAI_HOSTIF_TRAP_TYPE_IP2ME = 0x00004000,
 
     /**
-     * @brief SSH traffic (tcp dst port == 22) to local router IP address
+     * @brief SSH traffic (TCP dst port == 22) to local router IP address
      * (default packet action is drop)
      */
     SAI_HOSTIF_TRAP_TYPE_SSH = 0x00004001,
 
     /**
-     * @brief SNMP traffic (udp dst port == 161) to local router IP address
+     * @brief SNMP traffic (UDP dst port == 161) to local router IP address
      * (default packet action is drop)
      */
     SAI_HOSTIF_TRAP_TYPE_SNMP = 0x00004002,
 
     /**
-     * @brief BGP traffic (tcp src port == 179 or tcp dst port == 179) to local
+     * @brief BGP traffic (TCP src port == 179 or TCP dst port == 179) to local
      * router IP address (default packet action is drop)
      */
     SAI_HOSTIF_TRAP_TYPE_BGP = 0x00004003,
 
     /**
-     * @brief BGPv6 traffic (tcp src port == 179 or tcp dst port == 179) to
+     * @brief BGPv6 traffic (TCP src port == 179 or TCP dst port == 179) to
      * local router IP address (default packet action is drop)
      */
     SAI_HOSTIF_TRAP_TYPE_BGPV6 = 0x00004004,
@@ -456,7 +456,7 @@ typedef enum _sai_hostif_user_defined_trap_type_t
     /** ACL traps (default packet action is drop) */
     SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_ACL,
 
-    /** fdb traps (default packet action is drop) */
+    /** FDB traps (default packet action is drop) */
     SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_FDB,
 
     /** Custom range base */
@@ -785,7 +785,7 @@ typedef enum _sai_hostif_table_entry_attr_t
      * Valid only when #SAI_HOSTIF_TABLE_ENTRY_ATTR_TYPE == #SAI_HOSTIF_TABLE_ENTRY_TYPE_PORT
      * || #SAI_HOSTIF_TABLE_ENTRY_TYPE_LAG || #SAI_HOSTIF_TABLE_ENTRY_TYPE_VLAN
      * should be port object when type is SAI_HOSTIF_TABLE_ENTRY_TYPE_PORT
-     * should be lag object when type is SAI_HOSTIF_TABLE_ENTRY_TYPE_LAG
+     * should be LAG object when type is SAI_HOSTIF_TABLE_ENTRY_TYPE_LAG
      * should be VLAN ID object when type is SAI_HOSTIF_TABLE_ENTRY_TYPE_VLAN
      *
      * @type sai_object_id_t

--- a/inc/sail2mc.h
+++ b/inc/sail2mc.h
@@ -82,7 +82,7 @@ typedef struct _sai_l2mc_entry_t
 } sai_l2mc_entry_t;
 
 /**
- * @brief Attribute Id for l2mc entry
+ * @brief Attribute Id for L2MC entry
  */
 typedef enum _sai_l2mc_entry_attr_t
 {
@@ -152,7 +152,7 @@ typedef sai_status_t (*sai_remove_l2mc_entry_fn)(
         _In_ const sai_l2mc_entry_t *l2mc_entry);
 
 /**
- * @brief Set l2mc entry attribute value
+ * @brief Set L2MC entry attribute value
  *
  * @param[in] l2mc_entry L2MC entry
  * @param[in] attr Attribute
@@ -164,7 +164,7 @@ typedef sai_status_t (*sai_set_l2mc_entry_attribute_fn)(
         _In_ const sai_attribute_t *attr);
 
 /**
- * @brief Get l2mc entry attribute value
+ * @brief Get L2MC entry attribute value
  *
  * @param[in] l2mc_entry L2MC entry
  * @param[in] attr_count Number of attributes

--- a/inc/sailag.h
+++ b/inc/sailag.h
@@ -34,7 +34,7 @@
  */
 
 /**
- * @brief Lag attribute: List of attributes for LAG object
+ * @brief LAG attribute: List of attributes for LAG object
  */
 typedef enum _sai_lag_attr_t
 {
@@ -57,7 +57,7 @@ typedef enum _sai_lag_attr_t
     /**
      * @brief LAG bind point for ingress ACL object
      *
-     * Bind (or unbind) an ingress acl table or acl group on a LAG. Enable/Update
+     * Bind (or unbind) an ingress ACL table or ACL group on a LAG. Enable/Update
      * ingress ACL table or ACL group filtering by assigning the list of valid
      * object id. Disable ingress filtering by assigning SAI_NULL_OBJECT_ID
      * in the attribute value.
@@ -73,7 +73,7 @@ typedef enum _sai_lag_attr_t
     /**
      * @brief LAG bind point for egress ACL object
      *
-     * Bind (or unbind) an egress acl tables or acl groups on a LAG. Enable/Update
+     * Bind (or unbind) an egress ACL tables or ACL groups on a LAG. Enable/Update
      * egress ACL table or ACL group filtering by assigning the list of valid
      * object id. Disable egress filtering by assigning SAI_NULL_OBJECT_ID
      * in the attribute value.

--- a/inc/saimcastfdb.h
+++ b/inc/saimcastfdb.h
@@ -45,7 +45,7 @@ typedef struct _sai_mcast_fdb_entry_t
      */
     sai_object_id_t switch_id;
 
-    /** Mac address */
+    /** MAC address */
     sai_mac_t mac_address;
 
     /** Vlan ID */
@@ -54,7 +54,7 @@ typedef struct _sai_mcast_fdb_entry_t
 } sai_mcast_fdb_entry_t;
 
 /**
- * @brief Attribute Id for multicast fdb entry
+ * @brief Attribute Id for multicast FDB entry
  */
 typedef enum _sai_mcast_fdb_entry_attr_t
 {
@@ -132,7 +132,7 @@ typedef sai_status_t (*sai_remove_mcast_fdb_entry_fn)(
         _In_ const sai_mcast_fdb_entry_t *fdb_entry);
 
 /**
- * @brief Set multicast fdb entry attribute value
+ * @brief Set multicast FDB entry attribute value
  *
  * @param[in] fdb_entry FDB entry
  * @param[in] attr Attribute
@@ -144,7 +144,7 @@ typedef sai_status_t (*sai_set_mcast_fdb_entry_attribute_fn)(
         _In_ const sai_attribute_t *attr);
 
 /**
- * @brief Get fdb entry attribute value
+ * @brief Get FDB entry attribute value
  *
  * @param[in] fdb_entry FDB entry
  * @param[in] attr_count Number of attributes

--- a/inc/saimirror.h
+++ b/inc/saimirror.h
@@ -38,13 +38,13 @@
  */
 typedef enum _sai_mirror_session_type_t
 {
-    /** Local span */
+    /** Local SPAN */
     SAI_MIRROR_SESSION_TYPE_LOCAL = 0,
 
-    /** Remote span */
+    /** Remote SPAN */
     SAI_MIRROR_SESSION_TYPE_REMOTE,
 
-    /** Enhanced Remote span */
+    /** Enhanced Remote SPAN */
     SAI_MIRROR_SESSION_TYPE_ENHANCED_REMOTE,
 
 } sai_mirror_session_type_t;

--- a/inc/saineighbor.h
+++ b/inc/saineighbor.h
@@ -50,7 +50,7 @@ typedef enum _sai_neighbor_entry_attr_t
     SAI_NEIGHBOR_ENTRY_ATTR_START,
 
     /**
-     * @brief Destination mac address for the neighbor
+     * @brief Destination MAC address for the neighbor
      *
      * @type sai_mac_t
      * @flags MANDATORY_ON_CREATE | CREATE_AND_SET

--- a/inc/saipolicer.h
+++ b/inc/saipolicer.h
@@ -28,7 +28,7 @@
 #include <saitypes.h>
 
 /**
- * @defgroup SAIPOLICER SAI - Qos Policer specific API definitions
+ * @defgroup SAIPOLICER SAI - QOS Policer specific API definitions
  *
  * @{
  */

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -124,7 +124,7 @@ typedef enum _sai_port_internal_loopback_mode_t
     /** port internal loopback at phy module */
     SAI_PORT_INTERNAL_LOOPBACK_MODE_PHY,
 
-    /** port internal loopback at mac module */
+    /** port internal loopback at MAC module */
     SAI_PORT_INTERNAL_LOOPBACK_MODE_MAC
 
 } sai_port_internal_loopback_mode_t;
@@ -639,7 +639,7 @@ typedef enum _sai_port_attr_t
     /**
      * @brief Port bind point for ingress ACL object
      *
-     * Bind (or unbind) an ingress acl table or acl group on a port. Enable/Update
+     * Bind (or unbind) an ingress ACL table or ACL group on a port. Enable/Update
      * ingress ACL table or ACL group filtering by assigning the list of valid
      * object id. Disable ingress filtering by assigning SAI_NULL_OBJECT_ID
      * in the attribute value.
@@ -655,7 +655,7 @@ typedef enum _sai_port_attr_t
     /**
      * @brief Port bind point for egress ACL object
      *
-     * Bind (or unbind) an egress acl tables or acl group on a port. Enable/Update
+     * Bind (or unbind) an egress ACL tables or ACL group on a port. Enable/Update
      * egress ACL table or ACL group filtering by assigning the list of valid
      * object id. Disable egress filtering by assigning SAI_NULL_OBJECT_ID
      * in the attribute value.
@@ -1172,7 +1172,7 @@ typedef enum _sai_port_stat_t
     /** SAI port stat ether stats collisions */
     SAI_PORT_STAT_ETHER_STATS_COLLISIONS,
 
-    /** SAI port stat ether stats crc align errors */
+    /** SAI port stat ether stats CRC align errors */
     SAI_PORT_STAT_ETHER_STATS_CRC_ALIGN_ERRORS,
 
     /** SAI port stat ether stats tx no errors */
@@ -1181,31 +1181,31 @@ typedef enum _sai_port_stat_t
     /** SAI port stat ether stats rx no errors */
     SAI_PORT_STAT_ETHER_STATS_RX_NO_ERRORS,
 
-    /** SAI port stat ip in receives */
+    /** SAI port stat IP in receives */
     SAI_PORT_STAT_IP_IN_RECEIVES,
 
-    /** SAI port stat ip in octets */
+    /** SAI port stat IP in octets */
     SAI_PORT_STAT_IP_IN_OCTETS,
 
-    /** SAI port stat ip in ucast pkts */
+    /** SAI port stat IP in ucast pkts */
     SAI_PORT_STAT_IP_IN_UCAST_PKTS,
 
-    /** SAI port stat ip in non ucast pkts */
+    /** SAI port stat IP in non ucast pkts */
     SAI_PORT_STAT_IP_IN_NON_UCAST_PKTS,
 
-    /** SAI port stat ip in discards */
+    /** SAI port stat IP in discards */
     SAI_PORT_STAT_IP_IN_DISCARDS,
 
-    /** SAI port stat ip out octets */
+    /** SAI port stat IP out octets */
     SAI_PORT_STAT_IP_OUT_OCTETS,
 
-    /** SAI port stat ip out ucast pkts */
+    /** SAI port stat IP out ucast pkts */
     SAI_PORT_STAT_IP_OUT_UCAST_PKTS,
 
-    /** SAI port stat ip out non ucast pkts */
+    /** SAI port stat IP out non ucast pkts */
     SAI_PORT_STAT_IP_OUT_NON_UCAST_PKTS,
 
-    /** SAI port stat ip out discards */
+    /** SAI port stat IP out discards */
     SAI_PORT_STAT_IP_OUT_DISCARDS,
 
     /** SAI port stat ipv6 in receives */
@@ -1367,73 +1367,73 @@ typedef enum _sai_port_stat_t
     /** PFC Packet Counters for RX and TX per PFC priority [uint64_t] */
     SAI_PORT_STAT_PFC_0_RX_PKTS,
 
-    /** SAI port stat pfc 0 tx pkts */
+    /** SAI port stat PFC 0 tx pkts */
     SAI_PORT_STAT_PFC_0_TX_PKTS,
 
-    /** SAI port stat pfc 1 rx pkts */
+    /** SAI port stat PFC 1 rx pkts */
     SAI_PORT_STAT_PFC_1_RX_PKTS,
 
-    /** SAI port stat pfc 1 tx pkts */
+    /** SAI port stat PFC 1 tx pkts */
     SAI_PORT_STAT_PFC_1_TX_PKTS,
 
-    /** SAI port stat pfc 2 rx pkts */
+    /** SAI port stat PFC 2 rx pkts */
     SAI_PORT_STAT_PFC_2_RX_PKTS,
 
-    /** SAI port stat pfc 2 tx pkts */
+    /** SAI port stat PFC 2 tx pkts */
     SAI_PORT_STAT_PFC_2_TX_PKTS,
 
-    /** SAI port stat pfc 3 rx pkts */
+    /** SAI port stat PFC 3 rx pkts */
     SAI_PORT_STAT_PFC_3_RX_PKTS,
 
-    /** SAI port stat pfc 3 tx pkts */
+    /** SAI port stat PFC 3 tx pkts */
     SAI_PORT_STAT_PFC_3_TX_PKTS,
 
-    /** SAI port stat pfc 4 rx pkts */
+    /** SAI port stat PFC 4 rx pkts */
     SAI_PORT_STAT_PFC_4_RX_PKTS,
 
-    /** SAI port stat pfc 4 tx pkts */
+    /** SAI port stat PFC 4 tx pkts */
     SAI_PORT_STAT_PFC_4_TX_PKTS,
 
-    /** SAI port stat pfc 5 rx pkts */
+    /** SAI port stat PFC 5 rx pkts */
     SAI_PORT_STAT_PFC_5_RX_PKTS,
 
-    /** SAI port stat pfc 5 tx pkts */
+    /** SAI port stat PFC 5 tx pkts */
     SAI_PORT_STAT_PFC_5_TX_PKTS,
 
-    /** SAI port stat pfc 6 rx pkts */
+    /** SAI port stat PFC 6 rx pkts */
     SAI_PORT_STAT_PFC_6_RX_PKTS,
 
-    /** SAI port stat pfc 6 tx pkts */
+    /** SAI port stat PFC 6 tx pkts */
     SAI_PORT_STAT_PFC_6_TX_PKTS,
 
-    /** SAI port stat pfc 7 rx pkts */
+    /** SAI port stat PFC 7 rx pkts */
     SAI_PORT_STAT_PFC_7_RX_PKTS,
 
-    /** SAI port stat pfc 7 tx pkts */
+    /** SAI port stat PFC 7 tx pkts */
     SAI_PORT_STAT_PFC_7_TX_PKTS,
 
     /** PFC based ON to OFF pause transitions counter per PFC priority [uint64_t] */
     SAI_PORT_STAT_PFC_0_ON2OFF_RX_PKTS,
 
-    /** SAI port stat pfc 1 on to off rx pkts */
+    /** SAI port stat PFC 1 on to off rx pkts */
     SAI_PORT_STAT_PFC_1_ON2OFF_RX_PKTS,
 
-    /** SAI port stat pfc 2 on to off rx pkts */
+    /** SAI port stat PFC 2 on to off rx pkts */
     SAI_PORT_STAT_PFC_2_ON2OFF_RX_PKTS,
 
-    /** SAI port stat pfc 3 on to off rx pkts */
+    /** SAI port stat PFC 3 on to off rx pkts */
     SAI_PORT_STAT_PFC_3_ON2OFF_RX_PKTS,
 
-    /** SAI port stat pfc 4 on to off rx pkts */
+    /** SAI port stat PFC 4 on to off rx pkts */
     SAI_PORT_STAT_PFC_4_ON2OFF_RX_PKTS,
 
-    /** SAI port stat pfc 5 on to off rx pkts */
+    /** SAI port stat PFC 5 on to off rx pkts */
     SAI_PORT_STAT_PFC_5_ON2OFF_RX_PKTS,
 
-    /** SAI port stat pfc 6 on to off rx pkts */
+    /** SAI port stat PFC 6 on to off rx pkts */
     SAI_PORT_STAT_PFC_6_ON2OFF_RX_PKTS,
 
-    /** SAI port stat pfc 7 on to off rx pkts */
+    /** SAI port stat PFC 7 on to off rx pkts */
     SAI_PORT_STAT_PFC_7_ON2OFF_RX_PKTS,
 
     /**

--- a/inc/saiqosmap.h
+++ b/inc/saiqosmap.h
@@ -28,44 +28,44 @@
 #include <saitypes.h>
 
 /**
- * @defgroup SAIQOSMAPS SAI - Qos Maps specific API definitions.
+ * @defgroup SAIQOSMAPS SAI - QOS Maps specific API definitions.
  *
  * @{
  */
 
 /**
- * @brief Enum defining qos map types.
+ * @brief Enum defining QOS map types.
  */
 typedef enum _sai_qos_map_type_t
 {
-    /** Qos Map to set DOT1P to Traffic class */
+    /** QOS Map to set DOT1P to Traffic class */
     SAI_QOS_MAP_TYPE_DOT1P_TO_TC = 0x00000000,
 
-    /** Qos Map to set DOT1P to color */
+    /** QOS Map to set DOT1P to color */
     SAI_QOS_MAP_TYPE_DOT1P_TO_COLOR = 0x00000001,
 
-    /** Qos Map to set DSCP to Traffic class */
+    /** QOS Map to set DSCP to Traffic class */
     SAI_QOS_MAP_TYPE_DSCP_TO_TC = 0x00000002,
 
-    /** Qos Map to set DSCP to color */
+    /** QOS Map to set DSCP to color */
     SAI_QOS_MAP_TYPE_DSCP_TO_COLOR = 0x00000003,
 
-    /** Qos Map to set traffic class to queue */
+    /** QOS Map to set traffic class to queue */
     SAI_QOS_MAP_TYPE_TC_TO_QUEUE = 0x00000004,
 
-    /** Qos Map to set traffic class and color to DSCP */
+    /** QOS Map to set traffic class and color to DSCP */
     SAI_QOS_MAP_TYPE_TC_AND_COLOR_TO_DSCP = 0x00000005,
 
-    /** Qos Map to set traffic class and color to DSCP */
+    /** QOS Map to set traffic class and color to DSCP */
     SAI_QOS_MAP_TYPE_TC_AND_COLOR_TO_DOT1P = 0x00000006,
 
-    /** Qos Map to set traffic class to priority group */
+    /** QOS Map to set traffic class to priority group */
     SAI_QOS_MAP_TYPE_TC_TO_PRIORITY_GROUP = 0x00000007,
 
-    /** Qos Map to set PFC priority to priority group */
+    /** QOS Map to set PFC priority to priority group */
     SAI_QOS_MAP_TYPE_PFC_PRIORITY_TO_PRIORITY_GROUP = 0x00000008,
 
-    /** Qos Map to set PFC priority to queue */
+    /** QOS Map to set PFC priority to queue */
     SAI_QOS_MAP_TYPE_PFC_PRIORITY_TO_QUEUE = 0x00000009,
 
     /** Custom range base value */
@@ -74,7 +74,7 @@ typedef enum _sai_qos_map_type_t
 } sai_qos_map_type_t;
 
 /**
- * @brief Enum defining attributes for Qos Maps.
+ * @brief Enum defining attributes for QOS Maps.
  */
 typedef enum _sai_qos_map_attr_t
 {
@@ -84,7 +84,7 @@ typedef enum _sai_qos_map_attr_t
     SAI_QOS_MAP_ATTR_START,
 
     /**
-     * @brief Qos Map type
+     * @brief QOS Map type
      *
      * @type sai_qos_map_type_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
@@ -118,9 +118,9 @@ typedef enum _sai_qos_map_attr_t
 } sai_qos_map_attr_t ;
 
 /**
- * @brief Create Qos Map
+ * @brief Create QOS Map
  *
- * @param[out] qos_map_id Qos Map Id
+ * @param[out] qos_map_id QOS Map Id
  * @param[in] switch_id Switch id
  * @param[in] attr_count Number of attributes
  * @param[in] attr_list Array of attributes
@@ -134,9 +134,9 @@ typedef sai_status_t (*sai_create_qos_map_fn)(
         _In_ const sai_attribute_t *attr_list);
 
 /**
- * @brief Remove Qos Map
+ * @brief Remove QOS Map
  *
- * @param[in] qos_map_id Qos Map id to be removed.
+ * @param[in] qos_map_id QOS Map id to be removed.
  *
  * @return #SAI_STATUS_SUCCESS on success Failure status code on error
  */
@@ -144,9 +144,9 @@ typedef sai_status_t (*sai_remove_qos_map_fn) (
         _In_ sai_object_id_t qos_map_id);
 
 /**
- * @brief Set attributes for qos map
+ * @brief Set attributes for QOS map
  *
- * @param[in] qos_map_id Qos Map Id
+ * @param[in] qos_map_id QOS Map Id
  * @param[in] attr Attribute to set
  *
  * @return #SAI_STATUS_SUCCESS on success Failure status code on error
@@ -156,7 +156,7 @@ typedef sai_status_t (*sai_set_qos_map_attribute_fn)(
         _In_ const sai_attribute_t *attr);
 
 /**
- * @brief Get attrbutes of qos map
+ * @brief Get attrbutes of QOS map
  *
  * @param[in] qos_map_id Map id
  * @param[in] attr_count Number of attributes
@@ -170,7 +170,7 @@ typedef sai_status_t (*sai_get_qos_map_attribute_fn)(
         _Inout_ sai_attribute_t *attr_list);
 
 /**
- * @brief Qos Map methods table retrieved with sai_api_query()
+ * @brief QOS Map methods table retrieved with sai_api_query()
  */
 typedef struct _sai_qos_map_api_t
 {

--- a/inc/saiqueue.h
+++ b/inc/saiqueue.h
@@ -28,7 +28,7 @@
 #include <saitypes.h>
 
 /**
- * @defgroup SAIQUEUE SAI - Qos Queue specific API definitions.
+ * @defgroup SAIQUEUE SAI - QOS Queue specific API definitions.
  *
  * @{
  */
@@ -92,8 +92,8 @@ typedef enum _sai_queue_attr_t
     /**
      * @brief Parent scheduler node
      *
-     * In case of Hierarchical Qos not supported, the parent node is the port.
-     * Condition on whether Hierarchial Qos is supported or not, need to remove
+     * In case of Hierarchical QOS not supported, the parent node is the port.
+     * Condition on whether Hierarchial QOS is supported or not, need to remove
      * the MANDATORY_ON_CREATE FLAG when HQoS is introduced
      *
      * @type sai_object_id_t
@@ -340,7 +340,7 @@ typedef sai_status_t (*sai_clear_queue_stats_fn)(
         _In_ const sai_queue_stat_t *counter_ids);
 
 /**
- * @brief Qos methods table retrieved with sai_api_query()
+ * @brief QOS methods table retrieved with sai_api_query()
  */
 typedef struct _sai_queue_api_t
 {

--- a/inc/sairouterinterface.h
+++ b/inc/sairouterinterface.h
@@ -38,7 +38,7 @@
  */
 typedef enum _sai_router_interface_type_t
 {
-    /** Port or Lag Router Interface Type */
+    /** Port or LAG Router Interface Type */
     SAI_ROUTER_INTERFACE_TYPE_PORT,
 
     /** VLAN Router Interface Type */
@@ -85,7 +85,7 @@ typedef enum _sai_router_interface_attr_t
     SAI_ROUTER_INTERFACE_ATTR_TYPE,
 
     /**
-     * @brief Assosiated Port or Lag object id
+     * @brief Assosiated Port or LAG object id
      *
      * @type sai_object_id_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
@@ -148,7 +148,7 @@ typedef enum _sai_router_interface_attr_t
     /**
      * @brief RIF bind point for ingress ACL object
      *
-     * Bind (or unbind) an ingress acl table or acl group on a RIF. Enable/Update
+     * Bind (or unbind) an ingress ACL table or ACL group on a RIF. Enable/Update
      * ingress ACL table or ACL group filtering by assigning a valid object id.
      * Disable ingress filtering by assigning SAI_NULL_OBJECT_ID in the
      * attribute value.
@@ -164,7 +164,7 @@ typedef enum _sai_router_interface_attr_t
     /**
      * @brief RIF bind point for egress ACL object
      *
-     * Bind (or unbind) an egress acl table or acl group on a RIF. Enable/Update
+     * Bind (or unbind) an egress ACL table or ACL group on a RIF. Enable/Update
      * egress ACL table or ACL group filtering by assigning a valid object id.
      * Disable egress filtering by assigning SAI_NULL_OBJECT_ID
      * in the attribute value.

--- a/inc/saischeduler.h
+++ b/inc/saischeduler.h
@@ -28,7 +28,7 @@
 #include <saitypes.h>
 
 /**
- * @defgroup SAISCHEDULER SAI - Qos scheduler specific API definitions
+ * @defgroup SAISCHEDULER SAI - QOS scheduler specific API definitions
  *
  * @{
  */

--- a/inc/saischedulergroup.h
+++ b/inc/saischedulergroup.h
@@ -28,7 +28,7 @@
 #include <saitypes.h>
 
 /**
- * @defgroup SAISCHEDULERGROUP SAI - Qos scheduler group specific API definitions
+ * @defgroup SAISCHEDULERGROUP SAI - QOS scheduler group specific API definitions
  *
  * @{
  */

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -546,7 +546,7 @@ typedef enum _sai_switch_attr_t
     /**
      * @brief Switch/Global bind point for ingress ACL object
      *
-     * Bind (or unbind) an ingress acl table or acl group globally. Enable/Update
+     * Bind (or unbind) an ingress ACL table or ACL group globally. Enable/Update
      * ingress ACL table or ACL group filtering by assigning the list of valid
      * object id . Disable ingress filtering by assigning SAI_NULL_OBJECT_ID
      * in the attribute value.
@@ -562,7 +562,7 @@ typedef enum _sai_switch_attr_t
     /**
      * @brief Switch/Global bind point for egress ACL object
      *
-     * Bind (or unbind) an egress acl tables or acl group globally. Enable/Update
+     * Bind (or unbind) an egress ACL tables or ACL group globally. Enable/Update
      * egress ACL table or ACL group filtering by assigning the list of valid
      * object id. Disable egress filtering by assigning SAI_NULL_OBJECT_ID
      * in the attribute value.
@@ -860,7 +860,7 @@ typedef enum _sai_switch_attr_t
      * @brief SAI ECMP default symmetric hash
      *
      * When set, the hash calculation will result in the same value as when the
-     * source and destination addresses (L2 src/dst mac,L3 src/dst ip,L4
+     * source and destination addresses (L2 src/dst MAC,L3 src/dst IP,L4
      * src/dst port) were swapped, ensuring the same conversation will result
      * in the same hash value.
      *
@@ -922,7 +922,7 @@ typedef enum _sai_switch_attr_t
      * @brief SAI LAG default symmetric hash
      *
      * When set, the hash calculation will result in the same value as when the source and
-     * destination addresses (L2 src/dst mac,L3 src/dst ip,L4 src/dst port) were swapped,
+     * destination addresses (L2 src/dst MAC,L3 src/dst IP,L4 src/dst port) were swapped,
      * ensuring the same conversation will result in the same hash value.
      *
      * @type bool
@@ -1241,7 +1241,7 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_MIRROR_TC,
 
     /**
-     * @brief Ingress acl stage.
+     * @brief Ingress ACL stage.
      *
      * @type sai_acl_capability_t
      * @flags READ_ONLY
@@ -1249,7 +1249,7 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_ACL_STAGE_INGRESS,
 
     /**
-     * @brief Egress acl stage.
+     * @brief Egress ACL stage.
      *
      * @type sai_acl_capability_t
      * @flags READ_ONLY

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -302,7 +302,7 @@ typedef enum _sai_tunnel_type_t
 } sai_tunnel_type_t;
 
 /**
- * @brief Defines tunnel ttl mode
+ * @brief Defines tunnel TTL mode
  */
 typedef enum _sai_tunnel_ttl_mode_t
 {
@@ -330,7 +330,7 @@ typedef enum _sai_tunnel_ttl_mode_t
 } sai_tunnel_ttl_mode_t;
 
 /**
- * @brief Defines tunnel dscp mode
+ * @brief Defines tunnel DSCP mode
  */
 typedef enum _sai_tunnel_dscp_mode_t
 {
@@ -358,7 +358,7 @@ typedef enum _sai_tunnel_dscp_mode_t
 } sai_tunnel_dscp_mode_t;
 
 /**
- * @brief Defines tunnel encap ecn mode
+ * @brief Defines tunnel encap ECN mode
  */
 typedef enum _sai_tunnel_encap_ecn_mode_t
 {
@@ -378,7 +378,7 @@ typedef enum _sai_tunnel_encap_ecn_mode_t
 } sai_tunnel_encap_ecn_mode_t;
 
 /**
- * @brief Defines tunnel decap ecn mode
+ * @brief Defines tunnel decap ECN mode
  */
 typedef enum _sai_tunnel_decap_ecn_mode_t
 {
@@ -446,7 +446,7 @@ typedef enum _sai_tunnel_attr_t
     /* Tunnel encap attributes */
 
     /**
-     * @brief Tunnel src ip
+     * @brief Tunnel src IP
      *
      * @type sai_ip_address_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
@@ -474,7 +474,7 @@ typedef enum _sai_tunnel_attr_t
     SAI_TUNNEL_ATTR_ENCAP_TTL_VAL,
 
     /**
-     * @brief Tunnel dscp mode (pipe or uniform model)
+     * @brief Tunnel DSCP mode (pipe or uniform model)
      *
      * @type sai_tunnel_dscp_mode_t
      * @flags CREATE_ONLY
@@ -562,7 +562,7 @@ typedef enum _sai_tunnel_attr_t
     SAI_TUNNEL_ATTR_DECAP_TTL_MODE,
 
     /**
-     * @brief Tunnel dscp mode (pipe or uniform model)
+     * @brief Tunnel DSCP mode (pipe or uniform model)
      *
      * Default SAI_TUNNEL_DSCP_MODE_UNIFORM_MODEL
      *
@@ -642,10 +642,10 @@ typedef sai_status_t (*sai_get_tunnel_attribute_fn)(
  */
 typedef enum _sai_tunnel_term_table_entry_type_t
 {
-    /** tunnel termination table point to point entry match on dst & src ip & tunnel type */
+    /** tunnel termination table point to point entry match on dst & src IP & tunnel type */
     SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2P,
 
-    /** tunnel termination table point to multi point entry match on dst ip & tunnel type */
+    /** tunnel termination table point to multi point entry match on dst IP & tunnel type */
     SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2MP,
 
 } sai_tunnel_term_table_entry_type_t;
@@ -678,7 +678,7 @@ typedef enum _sai_tunnel_term_table_entry_attr_t
     SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE,
 
     /**
-     * @brief Tunnel termination ip address [
+     * @brief Tunnel termination IP address
      *
      * @type sai_ip_address_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
@@ -686,7 +686,7 @@ typedef enum _sai_tunnel_term_table_entry_attr_t
     SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_DST_IP,
 
     /**
-     * @brief Tunnel source ip address
+     * @brief Tunnel source IP address
      *
      * @type sai_ip_address_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -115,9 +115,10 @@ typedef int8_t sai_int8_t;
 typedef size_t sai_size_t;
 typedef uint64_t sai_object_id_t;
 typedef void *sai_pointer_t;
+
 /**
  * @def SAI_NULL_OBJECT_ID
- * Sai NULL object ID
+ * SAI NULL object ID
  */
 #define SAI_NULL_OBJECT_ID 0L
 
@@ -143,7 +144,7 @@ typedef struct _sai_object_list_t {
 } sai_object_list_t;
 
 /**
- * @brief Sai common api type
+ * @brief SAI common api type
  */
 typedef enum _sai_common_api_t {
     SAI_COMMON_API_CREATE = 0,
@@ -154,7 +155,7 @@ typedef enum _sai_common_api_t {
 } sai_common_api_t;
 
 /**
- * @brief Sai object type
+ * @brief SAI object type
  */
 typedef enum _sai_object_type_t {
     SAI_OBJECT_TYPE_NULL                     =  0, /**< invalid object type */
@@ -407,16 +408,16 @@ typedef enum _sai_packet_color_t
 } sai_packet_color_t;
 
 /**
- * @brief Defines qos map types.
+ * @brief Defines QOS map types.
  *
  * @par Examples:
  *
- * dot1p/dscp --> TC
- * dot1p/dscp --> Color
- * dot1p/dscp --> TC + Color
- * Tc --> dot1p/Dscp.
- * Tc + color --> dot1p/Dscp.
- * Tc --> Egress Queue.
+ * dot1p/DSCP --> TC
+ * dot1p/DSCP --> Color
+ * dot1p/DSCP --> TC + Color
+ * TC --> dot1p/DSCP.
+ * TC + color --> dot1p/DSCP.
+ * TC --> Egress Queue.
  */
 typedef struct _sai_qos_map_params_t
 {
@@ -502,7 +503,7 @@ typedef struct _sai_tunnel_map_list_t
 } sai_tunnel_map_list_t;
 
 /**
- * @brief Structure for acl attributes supported at each stage.
+ * @brief Structure for ACL attributes supported at each stage.
  * action_list alone is added now. Qualifier list can also be added
  * when needed.
  */

--- a/inc/saivlan.h
+++ b/inc/saivlan.h
@@ -109,7 +109,7 @@ typedef enum _sai_vlan_attr_t
     /**
      * @brief STP Instance that the VLAN is associated to
      *
-     * Ddefault to default stp instance id
+     * Ddefault to default STP instance id
      *
      * @type sai_object_id_t
      * @flags CREATE_AND_SET
@@ -122,7 +122,7 @@ typedef enum _sai_vlan_attr_t
      * @brief To disable learning on a VLAN
      *
      * This should override port learn settings. If this is set to true on a
-     * vlan, then the source mac learning is disabled for this vlan on a member
+     * vlan, then the source MAC learning is disabled for this vlan on a member
      * port even if learn is enable on the port(based on port learn attribute)
      *
      * @type bool
@@ -150,11 +150,11 @@ typedef enum _sai_vlan_attr_t
     SAI_VLAN_ATTR_IPV6_MCAST_LOOKUP_KEY_TYPE,
 
     /**
-     * @brief L2MC Group ID that unknown non-ip MACST packets forwarded to
+     * @brief L2MC Group ID that unknown non-IP MACST packets forwarded to
      *
-     * Indicating the output ports/LAGs for unknown non-ip multicast packets.
+     * Indicating the output ports/LAGs for unknown non-IP multicast packets.
      * This attribute only takes effect when one of the following conditions is met:
-     * (1)non-ip multicast packet
+     * (1)non-IP multicast packet
      * (2)IPv4 multicast packet && not linklocal && IPv4 mcast snooping disabled for vlan
      * (3)IPv6 multicast packet && not linklocal && IPv6 mcast snooping disabled for vlan
      * In case of SAI_NULL_OBJECT_ID, unknown multicast packets will be discarded.
@@ -169,7 +169,7 @@ typedef enum _sai_vlan_attr_t
     SAI_VLAN_ATTR_UNKNOWN_NON_IP_MCAST_OUTPUT_GROUP_ID,
 
     /**
-     * @brief L2MC Group ID that unknown ipv4 MACST packets forwarded to
+     * @brief L2MC Group ID that unknown IPv4 MACST packets forwarded to
      *
      * Indicating the output ports/LAGs for unknown IPv4 multicast packets.
      * This attribute only takes effect when the following condition is met:
@@ -186,7 +186,7 @@ typedef enum _sai_vlan_attr_t
     SAI_VLAN_ATTR_UNKNOWN_IPV4_MCAST_OUTPUT_GROUP_ID,
 
     /**
-     * @brief L2MC Group ID that unknown ipv6 MACST packets forwarded to
+     * @brief L2MC Group ID that unknown IPv6 MACST packets forwarded to
      *
      * Indicating the output ports/LAGs for unknown IPv6 multicast packets.
      * This attribute only takes effect when the following condition is met:
@@ -223,7 +223,7 @@ typedef enum _sai_vlan_attr_t
     /**
      * @brief VLAN bind point for ingress ACL object
      *
-     * Bind (or unbind) an ingress acl table or acl group on a VLAN. Enable/Update
+     * Bind (or unbind) an ingress ACL table or ACL group on a VLAN. Enable/Update
      * ingress ACL table or ACL group filtering by assigning the list of valid
      * object id. Disable ingress filtering by assigning SAI_NULL_OBJECT_ID
      * in the attribute value.
@@ -239,7 +239,7 @@ typedef enum _sai_vlan_attr_t
     /**
      * @brief VLAN bind point for egress ACL object
      *
-     * Bind (or unbind) an egress acl table or acl group on a VLAN. Enable/Update
+     * Bind (or unbind) an egress ACL table or ACL group on a VLAN. Enable/Update
      * egress ACL table or ACL group filtering by assigning the list of valid
      * object id. Disable egress filtering by assigning SAI_NULL_OBJECT_ID
      * in the attribute value.

--- a/inc/saiwred.h
+++ b/inc/saiwred.h
@@ -28,7 +28,7 @@
 #include "saitypes.h"
 
 /**
- * @defgroup SAIWRED SAI - Qos Wred specific API definitions
+ * @defgroup SAIWRED SAI - QOS Wred specific API definitions
  *
  * @{
  */

--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -2755,16 +2755,23 @@ sub CheckHeadersStyle
                 }
             }
 
-            if ($line =~ /\bsai\b/ )
+            my @magicWords = qw/SAI IP MAC L2 ACL L3 GRE ECMP EEE FDB FD FEC ICMP I2C HW IEEE IP2ME L2MC LAG
+            ARP ASIC BGP CAM CBS CB CIR CIDR CRC DLL CPU TTL TOS ECN DSCP TC MACST MTU NPU PFC PBS PCI PIR
+            QOS RFC RFP SDK RSPAN ERSPAN SPAN SNMP SSH STP TCAM TCP UDP TPID UDF UOID VNI VR VRRP WCMP/;
+
+            my $pattern = join"|",@magicWords;
+
+            while ($line =~ /\b($pattern)\b/ig)
             {
-                # force sai word to be capital
+                # force special word to be capital
 
-                while ($line =~ /\b(sai)\b(.h)/ig)
-                {
-                    next if $1 eq "SAI" or $2 eq ".h";
+                my $word = $1;
 
-                    LogWarning "Sai word $1 should use capital letters $header $n:$line";
-                }
+                next if $word =~ /^($pattern)$/;
+                next if $line =~ /$word.h/;
+                next if not $line =~ /\*/; # must contain star, so will be comment
+
+                LogWarning "Word $word should use capital letters $header $n:$line";
             }
 
             if ($line =~ /\\/ and not $line =~ /\\[0\[\]]/)


### PR DESCRIPTION
All marked keywords should be written in capital letters