### PR TITLE
saibridge: Add note that CPU port is not a member of any bridge

### DIFF
--- a/inc/saibridge.h
+++ b/inc/saibridge.h
@@ -108,6 +108,8 @@ typedef enum _sai_bridge_port_attr_t
     /**
      * @brief Associated Port or LAG object id
      *
+     * The CPU port is not a member of any bridge.
+     *
      * @type sai_object_id_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
      * @objects SAI_OBJECT_TYPE_PORT, SAI_OBJECT_TYPE_LAG


### PR DESCRIPTION
Add a small comment for SAI_BRIDGE_PORT_ATTR_PORT_ID attribute that CPU
is not a member of any bridge.

Signed-off-by: Vadim Kochan <vadymk@mellanox.com>