### PR TITLE
saithrift: l3: Fix sail3 tests (most of them) according to the SAI 1.0

### DIFF
--- a/test/saithrift/src/switch_sai.thrift
+++ b/test/saithrift/src/switch_sai.thrift
@@ -230,6 +230,7 @@ service switch_sai_rpc {
                              2: list<sai_thrift_vlan_stat_counter_t> counter_ids,
                              3: i32 number_of_counters);
     sai_thrift_object_id_t sai_thrift_create_vlan_member(1: list<sai_thrift_attribute_t> thrift_attr_list);
+    sai_thrift_attribute_list_t sai_thrift_get_vlan_member_attribute(1: sai_thrift_object_id_t vlan_member_id);
     sai_thrift_status_t sai_thrift_remove_vlan_member(1: sai_thrift_object_id_t vlan_member_id);
     sai_thrift_attribute_list_t sai_thrift_get_vlan_attribute(1: sai_thrift_object_id_t vlan_id);
     sai_thrift_result_t sai_thrift_get_vlan_id(1: sai_thrift_object_id_t vlan_id);
@@ -290,6 +291,8 @@ service switch_sai_rpc {
     sai_thrift_status_t sai_thrift_remove_bridge_port(1: sai_thrift_object_id_t bridge_port_id);
     sai_thrift_result_t sai_thrift_get_bridge_port_list(1: sai_thrift_object_id_t bridge_id);
     sai_thrift_attribute_list_t sai_thrift_get_bridge_port_attribute(1: sai_thrift_object_id_t bridge_port_id);
+    sai_thrift_status_t sai_thrift_set_bridge_port_attribute(1: sai_thrift_object_id_t bridge_port_id,
+                                                             2: sai_thrift_attribute_t thrift_attr);
 
     //Trap API
     sai_thrift_object_id_t sai_thrift_create_hostif(1: list<sai_thrift_attribute_t> thrift_attr_list);

--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -796,6 +796,34 @@ public:
       }
   }
 
+  void sai_thrift_get_vlan_member_attribute(sai_thrift_attribute_list_t& thrift_attr_list, const sai_thrift_object_id_t vlan_member_id) {
+      sai_status_t status = SAI_STATUS_SUCCESS;
+      sai_vlan_api_t *vlan_api;
+      sai_attribute_t attr[3];
+
+      SAI_THRIFT_FUNC_LOG();
+
+      thrift_attr_list.attr_count = 0;
+
+      status = sai_api_query(SAI_API_VLAN, (void **) &vlan_api);
+      if (status != SAI_STATUS_SUCCESS) {
+          SAI_THRIFT_LOG_ERR("failed to obtain vlan_api, status:%d", status);
+          return;
+      }
+
+      attr[0].id = SAI_VLAN_MEMBER_ATTR_VLAN_ID;
+      attr[1].id = SAI_VLAN_MEMBER_ATTR_BRIDGE_PORT_ID;
+      attr[2].id = SAI_VLAN_MEMBER_ATTR_VLAN_TAGGING_MODE;
+
+      status = vlan_api->get_vlan_member_attribute(vlan_member_id, 3, attr);
+      if (status != SAI_STATUS_SUCCESS) {
+          SAI_THRIFT_LOG_ERR("failed to obtain vlan member attributes, status:%d", status);
+          return;
+      }
+
+      sai_attributes_to_sai_thrift_list(attr, 3, thrift_attr_list.attr_list);
+  }
+
   sai_thrift_status_t sai_thrift_remove_vlan_member(const sai_thrift_object_id_t vlan_member_id) {
       printf("sai_thrift_remove_vlan_member\n");
       sai_status_t status = SAI_STATUS_SUCCESS;
@@ -1543,6 +1571,27 @@ public:
           port_list.push_back((sai_thrift_object_id_t) attr.value.objlist.list[index]);
       }
       free(attr.value.objlist.list);
+  }
+
+  sai_thrift_status_t sai_thrift_set_bridge_port_attribute(const sai_thrift_object_id_t bridge_port_id,
+                                                           const sai_thrift_attribute_t& thrift_attr)
+  {
+      sai_status_t status = SAI_STATUS_SUCCESS;
+      sai_bridge_api_t *bridge_api;
+      sai_attribute_t attr;
+
+      SAI_THRIFT_FUNC_LOG();
+
+      status = sai_api_query(SAI_API_BRIDGE, (void **) &bridge_api);
+      if (status != SAI_STATUS_SUCCESS) {
+          SAI_THRIFT_LOG_ERR("failed to obtain bridge_api, status:%d", status);
+          return status;
+      }
+
+      attr.id = thrift_attr.id;
+      attr.value.oid = thrift_attr.value.oid;
+
+      return bridge_api->set_bridge_port_attribute(bridge_port_id, &attr);
   }
 
   void sai_thrift_get_bridge_port_attribute(sai_thrift_attribute_list_t& thrift_attr_list, const sai_thrift_object_id_t bridge_port_id) {


### PR DESCRIPTION
Fixed some L3 tests with:

    1) Removing ports from the vlan & bridge before add them to the LAG
    2) Add ports to the bridge after removing port from the LAG
    3) Use bridge port instead of the port for FDB attr setting
    4) for IPv6PrefixTest the default route was removed which is nor needed

The tests (3 ones) which uses more than 4 ports are not fixed.