### PR TITLE
add following vlan related attribute for LAG port in order to keep

### DIFF
--- a/inc/sailag.h
+++ b/inc/sailag.h
@@ -130,15 +130,6 @@ typedef enum _sai_lag_attr_t
     SAI_LAG_ATTR_DEFAULT_VLAN_PRIORITY,
 
     /**
-     * @brief Ingress Filtering (Drop Frames with Unknown VLANs)
-     *
-     * @type bool
-     * @flags CREATE_AND_SET
-     * @default false
-     */
-    SAI_LAG_ATTR_INGRESS_FILTERING,
-
-    /**
      * @brief Dropping of untagged frames on ingress
      *
      * @type bool

--- a/inc/sailag.h
+++ b/inc/sailag.h
@@ -34,6 +34,19 @@
  */
 
 /**
+ * @brief Attribute data for #SAI_LAG_ATTR_BIND_MODE
+ */
+typedef enum _sai_lag_bind_mode_t
+{
+    /** Port */
+    SAI_LAG_BIND_MODE_PORT,
+
+    /** Sub port */
+    SAI_LAG_BIND_MODE_SUB_PORT,
+
+} sai_lag_bind_mode_t;
+
+/**
  * @brief LAG attribute: List of attributes for LAG object
  */
 typedef enum _sai_lag_attr_t
@@ -85,6 +98,63 @@ typedef enum _sai_lag_attr_t
      * @default SAI_NULL_OBJECT_ID
      */
     SAI_LAG_ATTR_EGRESS_ACL,
+
+    /**
+     * @brief LAG bind mode
+     *
+     * @type sai_lag_bind_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_LAG_BIND_MODE_PORT
+     */
+    SAI_LAG_ATTR_BIND_MODE,
+
+    /**
+     * @brief Port VLAN ID
+     *
+     * Untagged ingress frames are tagged with Port VLAN ID (PVID)
+     *
+     * @type sai_uint16_t
+     * @flags CREATE_AND_SET
+     * @isvlan true
+     * @default 1
+     */
+    SAI_LAG_ATTR_PORT_VLAN_ID,
+
+    /**
+     * @brief Default VLAN Priority
+     *
+     * @type sai_uint8_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_LAG_ATTR_DEFAULT_VLAN_PRIORITY,
+
+    /**
+     * @brief Ingress Filtering (Drop Frames with Unknown VLANs)
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_LAG_ATTR_INGRESS_FILTERING,
+
+    /**
+     * @brief Dropping of untagged frames on ingress
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_LAG_ATTR_DROP_UNTAGGED,
+
+    /**
+     * @brief Dropping of tagged frames on ingress
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_LAG_ATTR_DROP_TAGGED,
 
     /**
      * @brief End of attributes

--- a/inc/sailag.h
+++ b/inc/sailag.h
@@ -34,19 +34,6 @@
  */
 
 /**
- * @brief Attribute data for #SAI_LAG_ATTR_BIND_MODE
- */
-typedef enum _sai_lag_bind_mode_t
-{
-    /** Port */
-    SAI_LAG_BIND_MODE_PORT,
-
-    /** Sub port */
-    SAI_LAG_BIND_MODE_SUB_PORT,
-
-} sai_lag_bind_mode_t;
-
-/**
  * @brief LAG attribute: List of attributes for LAG object
  */
 typedef enum _sai_lag_attr_t
@@ -98,15 +85,6 @@ typedef enum _sai_lag_attr_t
      * @default SAI_NULL_OBJECT_ID
      */
     SAI_LAG_ATTR_EGRESS_ACL,
-
-    /**
-     * @brief LAG bind mode
-     *
-     * @type sai_lag_bind_mode_t
-     * @flags CREATE_AND_SET
-     * @default SAI_LAG_BIND_MODE_PORT
-     */
-    SAI_LAG_ATTR_BIND_MODE,
 
     /**
      * @brief Port VLAN ID


### PR DESCRIPTION
add following vlan related attribute for LAG port in order to keep consistency among all the ports within the LAG.

When a port joins a LAG, it should use these LAG attributes instead
of its corresponding port attributes. When it leaves the LAG, corresponding
attributes should be restored to the SAI default value.

1. SAI_LAG_ATTR_PORT_VLAN_ID
2. SAI_LAG_ATTR_DEFAULT_VLAN_PRIORITY
3. SAI_LAG_ATTR_DROP_UNTAGGED
4. SAI_LAG_ATTR_DROP_TAGGED