### PR TITLE
Force all unions to be named

### DIFF
--- a/inc/saiobject.h
+++ b/inc/saiobject.h
@@ -46,7 +46,7 @@
  */
 typedef struct _sai_object_key_t
 {
-    union {
+    union _object_key {
         sai_object_id_t           object_id;
         sai_fdb_entry_t           fdb_entry;
         sai_neighbor_entry_t      neighbor_entry;

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -311,7 +311,7 @@ typedef enum _sai_ip_addr_family_t
 typedef struct _sai_ip_address_t
 {
     sai_ip_addr_family_t addr_family;
-    union {
+    union _ip_addr {
         sai_ip4_t ip4;
         sai_ip6_t ip6;
     } addr;
@@ -320,11 +320,11 @@ typedef struct _sai_ip_address_t
 typedef struct _sai_ip_prefix_t
 {
     sai_ip_addr_family_t addr_family;
-    union {
+    union _ip_prefix_addr {
         sai_ip4_t ip4;
         sai_ip6_t ip6;
     } addr;
-    union {
+    union _ip_prefix_mask {
         sai_ip4_t ip4;
         sai_ip6_t ip6;
     } mask;
@@ -345,7 +345,7 @@ typedef struct _sai_acl_field_data_t
     /**
      * @brief Field match mask
      */
-    union {
+    union _mask {
         sai_uint8_t u8;
         sai_int8_t s8;
         sai_uint16_t u16;
@@ -362,7 +362,7 @@ typedef struct _sai_acl_field_data_t
      * @brief Expected AND result using match mask above with packet field
      * value where applicable.
      */
-    union {
+    union _data {
         bool booldata;
         sai_uint8_t u8;
         sai_int8_t s8;
@@ -394,7 +394,7 @@ typedef struct _sai_acl_action_data_t
     /**
      * @brief Action parameter
      */
-    union {
+    union _parameter {
         sai_uint8_t u8;
         sai_int8_t s8;
         sai_uint16_t u16;
@@ -556,7 +556,7 @@ typedef struct _sai_acl_capability_t
  *
  * To use enum values as attribute value is sai_int32_t s32
  */
-typedef union
+typedef union _sai_attribute_value_t
 {
     bool booldata;
     char chardata[32];

--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -2225,7 +2225,7 @@ sub CreateApisQuery
     WriteSource "}";
 
     WriteHeader "extern int sai_metadata_apis_query(";
-    WriteHeader "       _In_ const sai_api_query_fn api_query);";
+    WriteHeader "        _In_ const sai_api_query_fn api_query);";
 }
 
 sub CreateObjectInfo
@@ -3464,6 +3464,11 @@ sub CheckHeadersStyle
                 LogWarning "move '{' to new line in typedef $header $n:$line";
             }
 
+            if ($line =~ /^[^*]*union/ and not $line =~ /union _\w+/)
+            {
+                LogError "all unions must be named $header $n:$line";
+            }
+
             CheckDoxygenStyle($header, $line, $n);
 
             next if $line =~ /^ \*($|[ \/])/;       # doxygen comment
@@ -3768,7 +3773,7 @@ sub CreateListCountTest
 
     WriteTest "{";
 
-    my %Union = ExtractStructInfo("sai_attribute_value_t", "union");
+    my %Union = ExtractStructInfo("sai_attribute_value_t", "union_");
 
     WriteTest "    size_t size_ref = sizeof(sai_object_list_t);";
 
@@ -3989,7 +3994,7 @@ sub CheckAttributeValueUnion
     # object dependencies via metadata and comparison logic
     #
 
-    my %Union = ExtractStructInfo("sai_attribute_value_t", "union");
+    my %Union = ExtractStructInfo("sai_attribute_value_t", "union_");
 
     my @primitives = qw/sai_acl_action_data_t sai_acl_field_data_t sai_pointer_t sai_object_id_t sai_object_list_t char/;
 


### PR DESCRIPTION
Doxygen skips anonymous unions and it's not possible to determine from xml output which item is member of anonymous union. When union is named its possible to determine which item in struct belongs to which union. This functionality will be required for automatic generation of serialization functions.