### PR TITLE
saithrift: tests: Fix LAG ECMP mini test

### DIFF
--- a/test/saithrift/tests/sail3.py
+++ b/test/saithrift/tests/sail3.py
@@ -1106,6 +1106,8 @@ class L3EcmpLagTestMini(sai_base_test.ThriftInterfaceDataPlane):
 
         lag_id1 = self.client.sai_thrift_create_lag([])
 
+        sai_thrift_vlan_remove_ports(self.client, switch.default_vlan.oid, [port1, port2])
+
         lag_member11 = sai_thrift_create_lag_member(self.client, lag_id1, port1)
         lag_member12 = sai_thrift_create_lag_member(self.client, lag_id1, port2)
 


### PR DESCRIPTION
Remove ports from default vlan before add them to the LAG

Signed-off-by: Vadim Kochan <vadymk@mellanox.com>