### PR TITLE
saithrift: rpc: Set bridge type for FDB entry

### DIFF
--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -218,6 +218,7 @@ public:
 
   void sai_thrift_parse_fdb_entry(const sai_thrift_fdb_entry_t &thrift_fdb_entry, sai_fdb_entry_t *fdb_entry) {
       fdb_entry->vlan_id = (sai_vlan_id_t) thrift_fdb_entry.vlan_id;
+      fdb_entry->bridge_type = SAI_FDB_ENTRY_BRIDGE_TYPE_1Q;
       sai_thrift_string_to_mac(thrift_fdb_entry.mac_address, fdb_entry->mac_address);
   }
 


### PR DESCRIPTION
After bridge model was introduced the sai_fdb_entry_t was extended with
bridge_id & bridge_type fields.

So set bridge_type as .1Q for a while to let tests pass.

Signed-off-by: Vadim Kochan <vadymk@mellanox.com>