### PR TITLE
saithrift: tests: Set bridge port admin state to UP by default

### DIFF
--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -1635,7 +1635,16 @@ public:
       }
 
       attr.id = thrift_attr.id;
-      attr.value.oid = thrift_attr.value.oid;
+
+      switch (attr.id) {
+          case SAI_BRIDGE_PORT_ATTR_ADMIN_STATE:
+              attr.value.booldata = thrift_attr.value.booldata;
+              break;
+
+          default:
+              attr.value.oid = thrift_attr.value.oid;
+              break;
+      }
 
       return bridge_api->set_bridge_port_attribute(bridge_port_id, &attr);
   }

--- a/test/saithrift/tests/switch.py
+++ b/test/saithrift/tests/switch.py
@@ -174,6 +174,11 @@ def sai_thrift_create_bridge_port(client, port_id):
     ret = client.sai_thrift_create_bridge_port(bport_attr_list)
     assert (ret.status == SAI_STATUS_SUCCESS)
     assert (ret.data.oid != SAI_NULL_OBJECT_ID)
+
+    attr_value = sai_thrift_attribute_value_t(booldata=1)
+    attr = sai_thrift_attribute_t(id=SAI_BRIDGE_PORT_ATTR_ADMIN_STATE, value=attr_value)
+    client.sai_thrift_set_bridge_port_attribute(ret.data.oid, attr)
+
     return ret.data.oid
 
 def sai_thrift_get_cpu_port_id(client):


### PR DESCRIPTION
To make bridge port work it is needed to set it UP.

Signed-off-by: Vadim Kochan <vadymk@mellanox.com>