### PR TITLE
saithrift: tests: Fix removing LAG member in LAG Ecmp mini test

### DIFF
--- a/test/saithrift/tests/sail3.py
+++ b/test/saithrift/tests/sail3.py
@@ -1198,8 +1198,8 @@ class L3EcmpLagTestMini(sai_base_test.ThriftInterfaceDataPlane):
             self.client.sai_thrift_remove_router_interface(rif_id2)
             self.client.sai_thrift_remove_router_interface(rif_id3)
 
-            self.client.sai_thrift_remove_lag_member(lag_member11)
-            self.client.sai_thrift_remove_lag_member(lag_member12)
+            sai_thrift_remove_lag_member(self.client, lag_member11)
+            sai_thrift_remove_lag_member(self.client, lag_member12)
 
             self.client.sai_thrift_remove_lag(lag_id1)
 


### PR DESCRIPTION
Use the helper which removes the LAG member and automatically adds the
port to the bridge.

Signed-off-by: Vadim Kochan <vadymk@mellanox.com>