### PR TITLE
WRED support to buffer pool and port.

### DIFF
--- a/inc/saibuffer.h
+++ b/inc/saibuffer.h
@@ -269,7 +269,7 @@ typedef enum _sai_buffer_pool_attr_t
      * @brief Attach WRED ID to pool
      *
      * WRED Drop/ECN marking based on pool thresholds will happen only
-     * when atleast one of queue refering to this buffer pool configured
+     * when one of queue referring to this buffer pool configured
      * with non default value for SAI_QUEUE_ATTR_WRED_PROFILE_ID.
      * ID = #SAI_NULL_OBJECT_ID to disable WRED
      *

--- a/inc/saibuffer.h
+++ b/inc/saibuffer.h
@@ -266,6 +266,22 @@ typedef enum _sai_buffer_pool_attr_t
     SAI_BUFFER_POOL_ATTR_XOFF_SIZE,
 
     /**
+     * @brief Attach WRED ID to pool
+     *
+     * WRED Drop/ECN marking based on pool thresholds will happen only
+     * when atleast one of queue refering to this buffer pool configured
+     * with non default value for SAI_QUEUE_ATTR_WRED_PROFILE_ID.
+     * ID = #SAI_NULL_OBJECT_ID to disable WRED
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_WRED
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_BUFFER_POOL_ATTR_WRED_PROFILE_ID,
+
+    /**
      * @brief End of attributes
      */
     SAI_BUFFER_POOL_ATTR_END,

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -897,7 +897,6 @@ typedef enum _sai_port_attr_t
      * @type sai_object_list_t
      * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_WRED
-     * @allownull true
      * @default empty
      */
     SAI_PORT_ATTR_QOS_WRED_PROFILE_ID_LIST,

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -890,17 +890,17 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_QOS_PFC_PRIORITY_TO_QUEUE_MAP,
 
     /**
-     * @brief Attach WRED to port
+     * @brief WRED profiles for port
      *
-     * ID = #SAI_NULL_OBJECT_ID to disable WRED.
+     * There can be up to #SAI_SWITCH_ATTR_EGRESS_BUFFER_POOL_NUM profiles
      *
-     * @type sai_object_id_t
+     * @type sai_object_list_t
      * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_WRED
      * @allownull true
-     * @default SAI_NULL_OBJECT_ID
+     * @default empty
      */
-    SAI_PORT_ATTR_QOS_WRED_PROFILE_ID,
+    SAI_PORT_ATTR_QOS_WRED_PROFILE_ID_LIST,
 
     /**
      * @brief Scheduler for port, Default no limits.

--- a/inc/saiwred.h
+++ b/inc/saiwred.h
@@ -227,6 +227,20 @@ typedef enum _sai_wred_attr_t
     SAI_WRED_ATTR_ECN_MARK_MODE = 0x0000000d,
 
     /**
+     * @brief Pointer to buffer pool object id
+     *
+     * Pool id != #SAI_NULL_OBJECT_ID when profile is associated with port.
+     * with specific pool.
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_BUFFER_POOL
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_WRED_ATTR_POOL_ID = 0x0000000d,
+
+    /**
      * @brief End of attributes
      */
     SAI_WRED_ATTR_END,

--- a/inc/saiwred.h
+++ b/inc/saiwred.h
@@ -238,7 +238,7 @@ typedef enum _sai_wred_attr_t
      * @allownull true
      * @default SAI_NULL_OBJECT_ID
      */
-    SAI_WRED_ATTR_POOL_ID = 0x0000000d,
+    SAI_WRED_ATTR_POOL_ID = 0x0000000e,
 
     /**
      * @brief End of attributes


### PR DESCRIPTION
At present WRED supports in queue level. As part of this proposal we are extending WRED/ECN support to buffer pools and port.

Buffer Pool WRED: 
WRED thresholds are allowed to configure per each buffer pool. When WRED thresholds crosses the pool level WRD threshold, system will start drop/mark packets. 

Port Level WRED:
Port is part of multiple buffer pools (SAI_PORT_ATTR_QOS_EGRESS_BUFFER_PROFILE_LIST) with different buffer limits, extending the WRED also to per port per buffer pool i.e Key for port WRED are port oid and buffer pool oid.

WRED configuration are supported at multiple level now but DROP/MARK will be controlled at more granular level i.e Queue.  i.e Even though wred/ecn is enabled at buffer pool/port level, drop or marking will happen only on WRED/ECN  enabled queues referring to port/buffer pool. 