### PR TITLE
Tunnel encap SRC IP fix meta data - not mandatory on create (#653) - merge to v1.0

### DIFF
--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -449,7 +449,8 @@ typedef enum _sai_tunnel_attr_t
      * @brief Tunnel src IP
      *
      * @type sai_ip_address_t
-     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @flags CREATE_ONLY
+     * @default 0.0.0.0
      */
     SAI_TUNNEL_ATTR_ENCAP_SRC_IP,
 


### PR DESCRIPTION
For unidirectonal decap only tunnel, encap src ip isn't mandatory