### PR TITLE
Fix hash objects meta data - allow setting hash objects

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -971,9 +971,10 @@ typedef enum _sai_switch_attr_t
      * @brief The hash object for IPv4 packets going through ECMP
      *
      * @type sai_object_id_t
-     * @flags READ_ONLY
+     * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
-     * @default internal
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
      */
     SAI_SWITCH_ATTR_ECMP_HASH_IPV4,
 
@@ -981,9 +982,10 @@ typedef enum _sai_switch_attr_t
      * @brief The hash object for IPv4 in IPv4 packets going through ECMP
      *
      * @type sai_object_id_t
-     * @flags READ_ONLY
+     * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
-     * @default internal
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
      */
     SAI_SWITCH_ATTR_ECMP_HASH_IPV4_IN_IPV4,
 
@@ -991,9 +993,10 @@ typedef enum _sai_switch_attr_t
      * @brief The hash object for IPv6 packets going through ECMP
      *
      * @type sai_object_id_t
-     * @flags READ_ONLY
+     * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
-     * @default internal
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
      */
     SAI_SWITCH_ATTR_ECMP_HASH_IPV6,
 
@@ -1032,9 +1035,10 @@ typedef enum _sai_switch_attr_t
      * @brief The hash object for IPv4 packets going through LAG
      *
      * @type sai_object_id_t
-     * @flags READ_ONLY
+     * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
-     * @default internal
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
      */
     SAI_SWITCH_ATTR_LAG_HASH_IPV4,
 
@@ -1042,9 +1046,10 @@ typedef enum _sai_switch_attr_t
      * @brief The hash object for IPv4 in IPv4 packets going through LAG
      *
      * @type sai_object_id_t
-     * @flags READ_ONLY
+     * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
-     * @default internal
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
      */
     SAI_SWITCH_ATTR_LAG_HASH_IPV4_IN_IPV4,
 
@@ -1052,9 +1057,10 @@ typedef enum _sai_switch_attr_t
      * @brief The hash object for IPv6 packets going through LAG
      *
      * @type sai_object_id_t
-     * @flags READ_ONLY
+     * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
-     * @default internal
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
      */
     SAI_SWITCH_ATTR_LAG_HASH_IPV6,
 

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -974,7 +974,7 @@ typedef enum _sai_switch_attr_t
      * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
      * @allownull true
-     * @default SAI_NULL_OBJECT_ID
+     * @default internal
      */
     SAI_SWITCH_ATTR_ECMP_HASH_IPV4,
 
@@ -985,7 +985,7 @@ typedef enum _sai_switch_attr_t
      * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
      * @allownull true
-     * @default SAI_NULL_OBJECT_ID
+     * @default internal
      */
     SAI_SWITCH_ATTR_ECMP_HASH_IPV4_IN_IPV4,
 
@@ -996,7 +996,7 @@ typedef enum _sai_switch_attr_t
      * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
      * @allownull true
-     * @default SAI_NULL_OBJECT_ID
+     * @default internal
      */
     SAI_SWITCH_ATTR_ECMP_HASH_IPV6,
 
@@ -1038,7 +1038,7 @@ typedef enum _sai_switch_attr_t
      * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
      * @allownull true
-     * @default SAI_NULL_OBJECT_ID
+     * @default internal
      */
     SAI_SWITCH_ATTR_LAG_HASH_IPV4,
 
@@ -1049,7 +1049,7 @@ typedef enum _sai_switch_attr_t
      * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
      * @allownull true
-     * @default SAI_NULL_OBJECT_ID
+     * @default internal
      */
     SAI_SWITCH_ATTR_LAG_HASH_IPV4_IN_IPV4,
 
@@ -1060,7 +1060,7 @@ typedef enum _sai_switch_attr_t
      * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
      * @allownull true
-     * @default SAI_NULL_OBJECT_ID
+     * @default internal
      */
     SAI_SWITCH_ATTR_LAG_HASH_IPV6,
 

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -974,7 +974,7 @@ typedef enum _sai_switch_attr_t
      * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
      * @allownull true
-     * @default internal
+     * @default SAI_NULL_OBJECT_ID
      */
     SAI_SWITCH_ATTR_ECMP_HASH_IPV4,
 
@@ -985,7 +985,7 @@ typedef enum _sai_switch_attr_t
      * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
      * @allownull true
-     * @default internal
+     * @default SAI_NULL_OBJECT_ID
      */
     SAI_SWITCH_ATTR_ECMP_HASH_IPV4_IN_IPV4,
 
@@ -996,7 +996,7 @@ typedef enum _sai_switch_attr_t
      * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
      * @allownull true
-     * @default internal
+     * @default SAI_NULL_OBJECT_ID
      */
     SAI_SWITCH_ATTR_ECMP_HASH_IPV6,
 
@@ -1038,7 +1038,7 @@ typedef enum _sai_switch_attr_t
      * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
      * @allownull true
-     * @default internal
+     * @default SAI_NULL_OBJECT_ID
      */
     SAI_SWITCH_ATTR_LAG_HASH_IPV4,
 
@@ -1049,7 +1049,7 @@ typedef enum _sai_switch_attr_t
      * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
      * @allownull true
-     * @default internal
+     * @default SAI_NULL_OBJECT_ID
      */
     SAI_SWITCH_ATTR_LAG_HASH_IPV4_IN_IPV4,
 
@@ -1060,7 +1060,7 @@ typedef enum _sai_switch_attr_t
      * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_HASH
      * @allownull true
-     * @default internal
+     * @default SAI_NULL_OBJECT_ID
      */
     SAI_SWITCH_ATTR_LAG_HASH_IPV6,
 

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -477,6 +477,9 @@ void check_attr_object_id_allownull(
                     /* default attr value from another attr may not support null */
                     break;
 
+                case SAI_DEFAULT_VALUE_TYPE_SWITCH_INTERNAL:
+                    break;
+
                 default:
                     META_MD_ASSERT_FAIL(md, "invalid default value type on object id when default is required");
                     break;
@@ -992,11 +995,6 @@ void check_attr_default_value_type(
             break;
 
         case SAI_DEFAULT_VALUE_TYPE_SWITCH_INTERNAL:
-
-            if (md->flags != SAI_ATTR_FLAGS_READ_ONLY)
-            {
-                META_MD_ASSERT_FAIL(md, "default internal currently can be set only on read only objects");
-            }
 
             if (md->objecttype != SAI_OBJECT_TYPE_SWITCH)
             {

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -477,9 +477,6 @@ void check_attr_object_id_allownull(
                     /* default attr value from another attr may not support null */
                     break;
 
-                case SAI_DEFAULT_VALUE_TYPE_SWITCH_INTERNAL:
-                    break;
-
                 default:
                     META_MD_ASSERT_FAIL(md, "invalid default value type on object id when default is required");
                     break;
@@ -995,6 +992,11 @@ void check_attr_default_value_type(
             break;
 
         case SAI_DEFAULT_VALUE_TYPE_SWITCH_INTERNAL:
+
+            if (md->flags != SAI_ATTR_FLAGS_READ_ONLY)
+            {
+                META_MD_ASSERT_FAIL(md, "default internal currently can be set only on read only objects");
+            }
 
             if (md->objecttype != SAI_OBJECT_TYPE_SWITCH)
             {


### PR DESCRIPTION
Switch has 2 default objects - SAI_SWITCH_ATTR_ECMP_HASH,
SAI_SWITCH_ATTR_LAG_HASH. They are read only objects created on system
initialization, with the attributres modifiable
The rest of the hash objects matching specific traffic types for
ECMP/LAG, should be editable and null by default, otherwise
create/remove hash API has no usage as the hash object can't be assigned