### PR TITLE
Allow null for scheduler group sched profile (#663) - merge to v1.0

### DIFF
--- a/inc/saischedulergroup.h
+++ b/inc/saischedulergroup.h
@@ -89,8 +89,10 @@ typedef enum _sai_scheduler_group_attr_t
      * @brief Scheduler id
      *
      * @type sai_object_id_t
-     * @flags MANDATORY_ON_CREATE | CREATE_AND_SET
+     * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_SCHEDULER
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
      */
     SAI_SCHEDULER_GROUP_ATTR_SCHEDULER_PROFILE_ID = 0x00000005,
 


### PR DESCRIPTION
This is symmetric to queue sched profile
In addition, after system initialization, it is possible to query all
scheduler groups
The default hierarchy is well defined - port, 8 SGs, each SG having a
pair of queues
Each SG has default working out of the box vendor behavior, so if the
application doesn't do settings on the SGs, traffic will still work fine
Instead of creating syntethic profile to reflect the SDK defaults, null
profile will be allowed, and reflect SDK defaults