### PR TITLE
Revert "IGMP snooping enable/disable control for VLAN"

### DIFF
--- a/inc/saivlan.h
+++ b/inc/saivlan.h
@@ -274,18 +274,6 @@ typedef enum _sai_vlan_attr_t
     SAI_VLAN_ATTR_FLOOD_DISABLE,
 
     /**
-     * @brief IGMP Snooping enable or disable control for VLAN
-     *
-     * IGMP Snooping enable control for VLAN. Default is
-     * disabled
-     *
-     * @type bool
-     * @flags CREATE_AND_SET
-     * @default false
-     */
-    SAI_VLAN_ATTR_CUSTOM_IGMP_SNOOPING_ENABLE,
-
-    /**
      * @brief End of attributes
      */
     SAI_VLAN_ATTR_END,

--- a/meta/acronyms.txt
+++ b/meta/acronyms.txt
@@ -76,4 +76,3 @@ WWW - World Wide Web
 XG - (*,G) Any-source Multicast
 XOFF - Transmitter Off
 XON - Transmitter On
-IGMP - Internet Group Management Protocol


### PR DESCRIPTION
Reverts opencomputeproject/SAI#648

Discussed in morning meeting, Dell will move the attribute to the custom range as a temporary solution to be merged in 1.2.