### PR TITLE
Static FDB move action

### DIFF
--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -307,6 +307,12 @@ typedef enum _sai_hostif_trap_type_t
      */
     SAI_HOSTIF_TRAP_TYPE_TTL_ERROR = 0x00006001,
 
+    /**
+     * @brief Packets trapped when station move is observed with static FDB entry
+     * (default packet action is drop)
+     */
+    SAI_HOSTIF_TRAP_TYPE_STATIC_FDB_MOVE = 0x00006002,
+
     /* Pipeline discards. For the following traps, packet action is either drop or trap */
 
     /**

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -947,15 +947,6 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_FDB_MULTICAST_MISS_PACKET_ACTION,
 
     /**
-     * @brief Action to be taken on packets when station move is observed with static FDB entry
-     *
-     * @type sai_packet_action_t
-     * @flags CREATE_AND_SET
-     * @default SAI_PACKET_ACTION_DROP
-     */
-    SAI_SWITCH_ATTR_STATIC_FDB_MOVE_PACKET_ACTION,
-
-    /**
      * @brief SAI ECMP default hash algorithm
      *
      * @type sai_hash_algorithm_t

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -947,6 +947,15 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_FDB_MULTICAST_MISS_PACKET_ACTION,
 
     /**
+     * @brief Action to be taken when a station movement is detected on static FDB entry
+     *
+     * @type sai_packet_action_t
+     * @flags CREATE_AND_SET
+     * @default SAI_PACKET_ACTION_DROP
+     */
+    SAI_SWITCH_ATTR_STATIC_FDB_MOVE_ACTION,
+
+    /**
      * @brief SAI ECMP default hash algorithm
      *
      * @type sai_hash_algorithm_t

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -947,13 +947,13 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_FDB_MULTICAST_MISS_PACKET_ACTION,
 
     /**
-     * @brief Action to be taken when a station movement is detected on static FDB entry
+     * @brief Action to be taken on packets when station move is observed with static FDB entry
      *
      * @type sai_packet_action_t
      * @flags CREATE_AND_SET
      * @default SAI_PACKET_ACTION_DROP
      */
-    SAI_SWITCH_ATTR_STATIC_FDB_MOVE_ACTION,
+    SAI_SWITCH_ATTR_STATIC_FDB_MOVE_PACKET_ACTION,
 
     /**
      * @brief SAI ECMP default hash algorithm


### PR DESCRIPTION
When a static movement is detected on a static FDB entry installed in a switch certain applications may require certain action to be taken depending on the scenario. For instance an application may trap the packets to CPU while in certain scenarios it can be a log action. By default the action must be to drop.