### PR TITLE
Update metadata for SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID

### DIFF
--- a/inc/sainexthop.h
+++ b/inc/sainexthop.h
@@ -135,6 +135,7 @@ typedef enum _sai_next_hop_attr_t
      * @type sai_object_id_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
      * @objects SAI_OBJECT_TYPE_ROUTER_INTERFACE
+     * @condition SAI_NEXT_HOP_ATTR_TYPE == SAI_NEXT_HOP_TYPE_IP or SAI_NEXT_HOP_ATTR_TYPE == SAI_NEXT_HOP_TYPE_MPLS
      */
     SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID,
 


### PR DESCRIPTION
SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID is not needed when
SAI_NEXT_HOP_ATTR_TYPE is SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP or
SAI_NEXT_HOP_TYPE_SEGMENTROUTE_SIDLIST or
SAI_NEXT_HOP_TYPE_SEGMENTROUTE_ENDPOINT.