### PR TITLE
ACL CRM changes

### DIFF
--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -34,44 +34,6 @@
  */
 
 /**
- * @brief Attribute data for SAI_ACL_TABLE_ATTR_STAGE
- */
-typedef enum _sai_acl_stage_t
-{
-    /** Ingress Stage */
-    SAI_ACL_STAGE_INGRESS,
-
-    /** Egress Stage */
-    SAI_ACL_STAGE_EGRESS,
-
-} sai_acl_stage_t;
-
-/**
- * @brief Attribute data for SAI_ACL_TABLE_ATTR_BIND_POINT
- */
-typedef enum _sai_acl_bind_point_type_t
-{
-    /** Bind Point Type Port */
-    SAI_ACL_BIND_POINT_TYPE_PORT,
-
-    /** Bind Point Type LAG */
-    SAI_ACL_BIND_POINT_TYPE_LAG,
-
-    /** Bind Point Type VLAN */
-    SAI_ACL_BIND_POINT_TYPE_VLAN,
-
-    /** Bind Point Type RIF */
-    SAI_ACL_BIND_POINT_TYPE_ROUTER_INTFERFACE,
-
-    /** @ignore - for backward compatibility */
-    SAI_ACL_BIND_POINT_TYPE_ROUTER_INTF = SAI_ACL_BIND_POINT_TYPE_ROUTER_INTFERFACE,
-
-    /** Bind Point Type Switch */
-    SAI_ACL_BIND_POINT_TYPE_SWITCH
-
-} sai_acl_bind_point_type_t;
-
-/**
  * @brief ACL IP Type
  */
 typedef enum _sai_acl_ip_type_t
@@ -373,20 +335,6 @@ typedef enum _sai_acl_table_group_member_attr_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
      */
     SAI_ACL_TABLE_GROUP_MEMBER_ATTR_PRIORITY,
-
-    /**
-     * @brief Available ACL entries for this table
-     * @type sai_uint32_t
-     * @flags READ_ONLY
-     */
-    SAI_ACL_TABLE_GROUP_MEMBER_ATTR_AVAILABLE_ACL_ENTRY,
-
-    /**
-     * @brief Available ACL counters for this table
-     * @type sai_uint32_t
-     * @flags READ_ONLY
-     */
-    SAI_ACL_TABLE_GROUP_MEMBER_ATTR_AVAILABLE_ACL_COUNTER,
 
     /**
      * @brief End of attributes
@@ -980,6 +928,20 @@ typedef enum _sai_acl_table_attr_t
      * @objects SAI_OBJECT_TYPE_ACL_ENTRY
      */
     SAI_ACL_TABLE_ATTR_ENTRY_LIST,
+
+    /**
+     * @brief Available ACL entries for this table
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_ACL_TABLE_ATTR_AVAILABLE_ACL_ENTRY,
+
+    /**
+     * @brief Available ACL counters for this table
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_ACL_TABLE_ATTR_AVAILABLE_ACL_COUNTER,
 
     /**
      * @brief End of ACL Table attributes

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -736,7 +736,7 @@ typedef enum _sai_switch_attr_t
     /**
      * @brief Available ACL Tables
      *
-     * @type sai_uint32_t
+     * @type sai_acl_resource_list_t
      * @flags READ_ONLY
      */
     SAI_SWITCH_ATTR_AVAILABLE_ACL_TABLE,
@@ -744,7 +744,7 @@ typedef enum _sai_switch_attr_t
     /**
      * @brief Available ACL Table groups
      *
-     * @type sai_uint32_t
+     * @type sai_acl_resource_list_t
      * @flags READ_ONLY
      */
     SAI_SWITCH_ATTR_AVAILABLE_ACL_TABLE_GROUP,

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -543,6 +543,73 @@ typedef struct _sai_acl_capability_t
 } sai_acl_capability_t;
 
 /**
+ * @brief Attribute data for SAI_ACL_TABLE_ATTR_STAGE
+ */
+typedef enum _sai_acl_stage_t
+{
+    /** Ingress Stage */
+    SAI_ACL_STAGE_INGRESS,
+
+    /** Egress Stage */
+    SAI_ACL_STAGE_EGRESS,
+
+} sai_acl_stage_t;
+
+/**
+ * @brief Attribute data for SAI_ACL_TABLE_ATTR_BIND_POINT
+ */
+typedef enum _sai_acl_bind_point_type_t
+{
+    /** Bind Point Type Port */
+    SAI_ACL_BIND_POINT_TYPE_PORT,
+
+    /** Bind Point Type LAG */
+    SAI_ACL_BIND_POINT_TYPE_LAG,
+
+    /** Bind Point Type VLAN */
+    SAI_ACL_BIND_POINT_TYPE_VLAN,
+
+    /** Bind Point Type RIF */
+    SAI_ACL_BIND_POINT_TYPE_ROUTER_INTF,
+
+    /** Bind Point Type Switch */
+    SAI_ACL_BIND_POINT_TYPE_SWITCH
+
+} sai_acl_bind_point_type_t;
+
+/**
+ * @brief Structure for ACL Resource Count
+ */
+typedef struct _sai_acl_resource_t
+{
+    /** ACL stage */
+    sai_acl_stage_t stage;
+
+    /** ACL Bind point */
+    sai_acl_bind_point_type_t bind_point;
+
+    /** Available number of entries */
+    sai_uint32_t avail_num;
+
+} sai_acl_resource_t;
+
+/**
+ * @brief List of available ACL resources at each stage and
+ * each binding point. This shall be returned when queried for
+ * SAI_SWITCH_ATTR_AVAILABLE_ACL_TABLE or
+ * SAI_SWITCH_ATTR_AVAILABLE_ACL_TABLE_GROUP
+ */
+typedef struct _sai_acl_resource_list_t
+{
+    /** Number of entries */
+    uint32_t count;
+
+    /** Resource list */
+    sai_acl_resource_t *list;
+
+} sai_acl_resource_list_t;
+
+/**
  * @brief Segment Routing Tag Length Value Types
  */
 typedef enum _sai_tlv_type_t
@@ -646,6 +713,7 @@ typedef union _sai_attribute_value_t
     sai_acl_field_data_t aclfield;
     sai_acl_action_data_t aclaction;
     sai_acl_capability_t aclcapability;
+    sai_acl_resource_list_t aclresource;
     sai_tlv_list_t tlvlist;
     sai_segment_list_t segmentlist;
 

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -570,7 +570,10 @@ typedef enum _sai_acl_bind_point_type_t
     SAI_ACL_BIND_POINT_TYPE_VLAN,
 
     /** Bind Point Type RIF */
-    SAI_ACL_BIND_POINT_TYPE_ROUTER_INTF,
+    SAI_ACL_BIND_POINT_TYPE_ROUTER_INTFERFACE,
+
+    /** @ignore - for backward compatibility */
+    SAI_ACL_BIND_POINT_TYPE_ROUTER_INTF = SAI_ACL_BIND_POINT_TYPE_ROUTER_INTFERFACE,
 
     /** Bind Point Type Switch */
     SAI_ACL_BIND_POINT_TYPE_SWITCH

--- a/meta/saimetadatatypes.h
+++ b/meta/saimetadatatypes.h
@@ -315,6 +315,11 @@ typedef enum _sai_attr_value_type_t
     SAI_ATTR_VALUE_TYPE_ACL_CAPABILITY,
 
     /**
+     * @brief Attribute value is ACL resource.
+     */
+    SAI_ATTR_VALUE_TYPE_ACL_RESOURCE_LIST,
+
+    /**
      * @brief Attribute value is generic map list.
      */
     SAI_ATTR_VALUE_TYPE_MAP_LIST,

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -542,6 +542,7 @@ void check_attr_object_type_provided(
         case SAI_ATTR_VALUE_TYPE_QOS_MAP_LIST:
         case SAI_ATTR_VALUE_TYPE_MAP_LIST:
         case SAI_ATTR_VALUE_TYPE_ACL_CAPABILITY:
+        case SAI_ATTR_VALUE_TYPE_ACL_RESOURCE_LIST:
         case SAI_ATTR_VALUE_TYPE_TLV_LIST:
         case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
 
@@ -2258,6 +2259,7 @@ void check_attr_is_primitive(
         case SAI_ATTR_VALUE_TYPE_UINT8_LIST:
         case SAI_ATTR_VALUE_TYPE_VLAN_LIST:
         case SAI_ATTR_VALUE_TYPE_ACL_CAPABILITY:
+        case SAI_ATTR_VALUE_TYPE_ACL_RESOURCE_LIST:
         case SAI_ATTR_VALUE_TYPE_TLV_LIST:
         case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
 


### PR DESCRIPTION
The following are the changes as part of this commit for ACL Critical Resource Monitoring:

1. Available ACL_ENTRY and ACL_COUNTER are moved from Table Group Member attribute to be a Table attribute.
2. For the Switch attributes, AVAILABLE_ACL_TABLE and AVAILABLE_ACL_TABLE_GROUP, modified the API to return a _list_ of resources available instead of a single _uint32_ value. ACL_TABLE and ACL_GROUP can be associated to different _stage_ and _bind_points_. Hence a single global _uint32_ value could be ambiguous in this scenario. The callee shall return a list of entries with the 'available_numbers' at each 'stage' and 'bind_point'.
3. ACL _enums_ for 'stage' and 'bind_point' are moved to `saitypes.h`.

Notes: 

1. If the acl table is in different acl table group members, then the available acl entry should be the minimum free entries of all acl table group members.
2. For AVAILABLE_ACL_TABLE and AVAILABLE_ACL_TABLE_GROUP, if certain 'stage' and 'bind_point' are _not supported_, then the implementation is not required to include the combinations in the _list_. If the implementation include the combinations in the list, then the avail_num must be 0.