### PR TITLE
[python-saithrift]: Change library instalation path.

### DIFF
--- a/debian/python-saithrift.install
+++ b/debian/python-saithrift.install
@@ -1,1 +1,1 @@
-debian/usr/local/lib/python2.7/site-packages/* usr/include/local/lib/python2.7/site-packages
+debian/usr/local/lib/python2.7/site-packages/* /usr/lib/python2.7/dist-packages/


### PR DESCRIPTION
Change library instalation path to make it available in PYTHON_PATH.