### PR TITLE
Fixed SAI tunnel attributes definitions

### DIFF
--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -451,7 +451,6 @@ typedef enum _sai_tunnel_attr_t
      * @type sai_object_id_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
      * @objects SAI_OBJECT_TYPE_ROUTER_INTERFACE
-     * @condition SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_IPINIP or SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_IPINIP_GRE
      */
     SAI_TUNNEL_ATTR_UNDERLAY_INTERFACE,
 
@@ -463,7 +462,6 @@ typedef enum _sai_tunnel_attr_t
      * @type sai_object_id_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
      * @objects SAI_OBJECT_TYPE_ROUTER_INTERFACE
-     * @condition SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_IPINIP or SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_IPINIP_GRE
      */
     SAI_TUNNEL_ATTR_OVERLAY_INTERFACE,
 
@@ -480,8 +478,6 @@ typedef enum _sai_tunnel_attr_t
 
     /**
      * @brief Tunnel TTL mode (pipe or uniform model)
-     *
-     * Default would be
      *
      * @type sai_tunnel_ttl_mode_t
      * @flags CREATE_ONLY
@@ -578,22 +574,18 @@ typedef enum _sai_tunnel_attr_t
     /**
      * @brief Tunnel TTL mode (pipe or uniform model)
      *
-     * Default SAI_TUNNEL_TTL_MODE_UNIFORM_MODEL
-     *
      * @type sai_tunnel_ttl_mode_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
-     * @condition SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_IPINIP or SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_IPINIP_GRE
+     * @default SAI_TUNNEL_TTL_MODE_UNIFORM_MODEL
      */
     SAI_TUNNEL_ATTR_DECAP_TTL_MODE,
 
     /**
      * @brief Tunnel DSCP mode (pipe or uniform model)
      *
-     * Default SAI_TUNNEL_DSCP_MODE_UNIFORM_MODEL
-     *
      * @type sai_tunnel_dscp_mode_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
-     * @condition SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_IPINIP or SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_IPINIP_GRE
+     * @default SAI_TUNNEL_DSCP_MODE_UNIFORM_MODEL
      */
     SAI_TUNNEL_ATTR_DECAP_DSCP_MODE,
 


### PR DESCRIPTION
Fixed definitions for SAI tunnel attributes:
SAI_TUNNEL_ATTR_UNDERLAY_INTERFACE,
SAI_TUNNEL_ATTR_OVERLAY_INTERFACE,
SAI_TUNNEL_ATTR_DECAP_TTL_MODE,
SAI_TUNNEL_ATTR_DECAP_DSCP_MODE.