### PR TITLE
Add return flag in notification data structure.

### DIFF
--- a/inc/saiqueue.h
+++ b/inc/saiqueue.h
@@ -318,7 +318,8 @@ typedef struct _sai_queue_deadlock_notification_data_t
     /** Deadlock event */
     sai_queue_pfc_deadlock_event_type_t event;
 
-    /** @brief Application based recovery management indicator.
+    /**
+     * @brief Application based recovery management indicator.
      *
      * This is a return value from host adapter.
      * If set to TRUE then host application will manage deadlock recovery

--- a/inc/saiqueue.h
+++ b/inc/saiqueue.h
@@ -317,7 +317,7 @@ typedef struct _sai_queue_deadlock_notification_data_t
 
     /** Deadlock event */
     sai_queue_pfc_deadlock_event_type_t event;
-    
+
     /** @brief Application based recovery management indicator.
      *
      * This is a return value from host adapter.

--- a/inc/saiqueue.h
+++ b/inc/saiqueue.h
@@ -317,6 +317,15 @@ typedef struct _sai_queue_deadlock_notification_data_t
 
     /** Deadlock event */
     sai_queue_pfc_deadlock_event_type_t event;
+    
+    /** @brief Application based recovery management indicator.
+     *
+     * This is a return value from host adapter.
+     * If set to TRUE then host application will manage deadlock recovery
+     * else SAI adapter or SDK will manage deadlock recovery
+     * and also generate recovery ended notification.
+     */
+    bool *app_managed_recovery;
 
 } sai_queue_deadlock_notification_data_t;
 

--- a/inc/saiqueue.h
+++ b/inc/saiqueue.h
@@ -325,6 +325,7 @@ typedef struct _sai_queue_deadlock_notification_data_t
      * If set to TRUE then host application will manage deadlock recovery
      * else SAI adapter or SDK will manage deadlock recovery
      * and also generate recovery ended notification.
+     * Applicable only when event is == SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED.
      */
     bool app_managed_recovery;
 

--- a/inc/saiqueue.h
+++ b/inc/saiqueue.h
@@ -325,7 +325,7 @@ typedef struct _sai_queue_deadlock_notification_data_t
      * else SAI adapter or SDK will manage deadlock recovery
      * and also generate recovery ended notification.
      */
-    bool *app_managed_recovery;
+    bool app_managed_recovery;
 
 } sai_queue_deadlock_notification_data_t;
 

--- a/meta/saiserializetest.c
+++ b/meta/saiserializetest.c
@@ -1048,7 +1048,7 @@ void test_serialize_notifications()
     memset(&data2, 0, sizeof(data2));
 
     res = sai_serialize_queue_pfc_deadlock_notification(buf, 1, &data2);
-    ret = "{\"count\":1,\"data\":[{\"queue_id\":\"oid:0x0\",\"event\":\"SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED\"}],\"app_managed_recovery\":false}";
+    ret = "{\"count\":1,\"data\":[{\"queue_id\":\"oid:0x0\",\"event\":\"SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED\",\"app_managed_recovery\":false}}]";
     ASSERT_STR_EQ(buf, ret, res);
 
     res = sai_serialize_switch_shutdown_request_notification(buf, switch_id);

--- a/meta/saiserializetest.c
+++ b/meta/saiserializetest.c
@@ -1048,7 +1048,7 @@ void test_serialize_notifications()
     memset(&data2, 0, sizeof(data2));
 
     res = sai_serialize_queue_pfc_deadlock_notification(buf, 1, &data2);
-    ret = "{\"count\":1,\"data\":[{\"queue_id\":\"oid:0x0\",\"event\":\"SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED\",\"app_managed_recovery\":false}}]";
+    ret = "{\"count\":1,\"data\":[{\"queue_id\":\"oid:0x0\",\"event\":\"SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED\",\"app_managed_recovery\":false}]}";
     ASSERT_STR_EQ(buf, ret, res);
 
     res = sai_serialize_switch_shutdown_request_notification(buf, switch_id);

--- a/meta/saiserializetest.c
+++ b/meta/saiserializetest.c
@@ -1048,7 +1048,7 @@ void test_serialize_notifications()
     memset(&data2, 0, sizeof(data2));
 
     res = sai_serialize_queue_pfc_deadlock_notification(buf, 1, &data2);
-    ret = "{\"count\":1,\"data\":[{\"queue_id\":\"oid:0x0\",\"event\":\"SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED\"}]}";
+    ret = "{\"count\":1,\"data\":[{\"queue_id\":\"oid:0x0\",\"event\":\"SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED\"}],\"app_managed_recovery\":false}";
     ASSERT_STR_EQ(buf, ret, res);
 
     res = sai_serialize_switch_shutdown_request_notification(buf, switch_id);


### PR DESCRIPTION
Add return flag in notification data structure to indicate app behavior on every deadlock situation.