### PR TITLE
Added LAG to monitor port in mirror attribute

### DIFF
--- a/inc/saimirror.h
+++ b/inc/saimirror.h
@@ -84,7 +84,7 @@ typedef enum _sai_mirror_session_attr_t
      *
      * @type sai_object_id_t
      * @flags MANDATORY_ON_CREATE | CREATE_AND_SET
-     * @objects SAI_OBJECT_TYPE_PORT
+     * @objects SAI_OBJECT_TYPE_PORT, SAI_OBJECT_TYPE_LAG
      */
     SAI_MIRROR_SESSION_ATTR_MONITOR_PORT,
 


### PR DESCRIPTION
The monitor port can also be a LAG apart from physical port. Modified the comments to update the same