### PR TITLE
Add mirror sample rate in mirror session attributes

### DIFF
--- a/inc/saimirror.h
+++ b/inc/saimirror.h
@@ -101,6 +101,18 @@ typedef enum _sai_mirror_session_attr_t
     SAI_MIRROR_SESSION_ATTR_TRUNCATE_SIZE,
 
     /**
+     * @brief Mirror sample rate. Every 1/sample_rate the packets will be mirrored.
+     *
+     * Value 0 to no sampling
+     * Value 1 to every packet sampling (normal mirror)
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 1
+     */
+    SAI_MIRROR_SESSION_ATTR_SAMPLE_RATE,
+
+    /**
      * @brief Class-of-Service (Traffic Class)
      *
      * @type sai_uint8_t


### PR DESCRIPTION
This PR is to add the mirror sample rate attribute for mirror session, so we could do 1: N mirror/sampling instead of 1:1 in some cases.  This does not change the default behavior. 