### PR TITLE
Missed thrift commit from master

### DIFF
--- a/debian/python-saithrift.install
+++ b/debian/python-saithrift.install
@@ -1,1 +1,1 @@
-debian/usr/lib/python2.7/site-packages/* usr/include/lib/python2.7/site-packages
+debian/usr/lib/python2.7/site-packages/*  /usr/lib/python2.7/dist-packages/

--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -2833,6 +2833,9 @@ public:
               case SAI_SCHEDULER_ATTR_MAX_BANDWIDTH_BURST_RATE:
                   attr_list[i].value.u64 = attribute.value.u64;
                   break;
+              case SAI_SCHEDULER_ATTR_SCHEDULING_TYPE:
+                  attr_list[i].value.s32 = attribute.value.s32;
+                  break;
           }
       }
   }


### PR DESCRIPTION
The PR consists missed commit for SAI thrift from the master branch.
The saithrift won't work correctly without those commits. 