### PR TITLE
Add a comment about port PVID matching LAG PVID before adding it to LAG

### DIFF
--- a/inc/sailag.h
+++ b/inc/sailag.h
@@ -90,6 +90,8 @@ typedef enum _sai_lag_attr_t
      * @brief Port VLAN ID
      *
      * Untagged ingress frames are tagged with Port VLAN ID (PVID)
+     * Before adding a port as LAG member, the port PVID #SAI_PORT_ATTR_PORT_VLAN_ID
+     * has to be identical to the LAG PVID, otherwise it will be rejected.
      *
      * @type sai_uint16_t
      * @flags CREATE_AND_SET

--- a/inc/sailag.h
+++ b/inc/sailag.h
@@ -91,18 +91,18 @@ typedef enum _sai_lag_attr_t
      *
      * Untagged ingress frames are tagged with Port VLAN ID (PVID)
      *
-     * When a port joins a LAG :
+     * When a port joins a LAG:
      * SAI automatically sets the joining port PVID to that of the LAG.
      * SAI also saves in its internal database the original PVID state of the port.
      *
      * While a port is a member of a LAG, it is not possible to change the value of
-     * the following 4 attributes for the port :
+     * the following 4 attributes for the port:
      * SAI_PORT_ATTR_PORT_VLAN_ID
      * SAI_PORT_ATTR_DEFAULT_VLAN_PRIORITY
      * SAI_PORT_ATTR_DROP_UNTAGGED
      * SAI_PORT_ATTR_DROP_TAGGED
      *
-     * When a port leaves the LAG :
+     * When a port leaves the LAG:
      * PVID is set to the original PVID by SAI
      * Since the port is not associated with a bridge port or a router port at that
      * point, it will not transfer traffic, until such object is attached to it.

--- a/inc/sailag.h
+++ b/inc/sailag.h
@@ -90,8 +90,22 @@ typedef enum _sai_lag_attr_t
      * @brief Port VLAN ID
      *
      * Untagged ingress frames are tagged with Port VLAN ID (PVID)
-     * Before adding a port as LAG member, the port PVID #SAI_PORT_ATTR_PORT_VLAN_ID
-     * has to be identical to the LAG PVID, otherwise it will be rejected.
+     *
+     * When a port joins a LAG :
+     * SAI automatically sets the joining port PVID to that of the LAG.
+     * SAI also saves in its internal database the original PVID state of the port.
+     *
+     * While a port is a member of a LAG, it is not possible to change the value of
+     * the following 4 attributes for the port :
+     * SAI_PORT_ATTR_PORT_VLAN_ID
+     * SAI_PORT_ATTR_DEFAULT_VLAN_PRIORITY
+     * SAI_PORT_ATTR_DROP_UNTAGGED
+     * SAI_PORT_ATTR_DROP_TAGGED
+     *
+     * When a port leaves the LAG :
+     * PVID is set to the original PVID by SAI
+     * Since the port is not associated with a bridge port or a router port at that
+     * point, it will not transfer traffic, until such object is attached to it.
      *
      * @type sai_uint16_t
      * @flags CREATE_AND_SET


### PR DESCRIPTION
Application should set the port PVID to the same of the lag PVID before
adding the port as a LAG member. This simplifies SAI implementation,
since SAI does not need to bookkeep the port original PVID, and to reset
the port PVID to the original value after removing the port from the LAG