### PR TITLE
Add extended statistics get functions

### DIFF
--- a/inc/saibfd.h
+++ b/inc/saibfd.h
@@ -498,7 +498,7 @@ typedef sai_status_t (*sai_get_bfd_session_attribute_fn)(
         _Inout_ sai_attribute_t *attr_list);
 
 /**
- * @brief Get BFD session statistics counters.
+ * @brief Get BFD session statistics counters. Deprecated for backward compatibility.
  *
  * @param[in] bfd_session_id BFD session id
  * @param[in] number_of_counters Number of counters in the array
@@ -511,6 +511,24 @@ typedef sai_status_t (*sai_get_bfd_session_stats_fn)(
         _In_ sai_object_id_t bfd_session_id,
         _In_ uint32_t number_of_counters,
         _In_ const sai_bfd_session_stat_t *counter_ids,
+        _Out_ uint64_t *counters);
+
+/**
+ * @brief Get BFD session statistics counters extended.
+ *
+ * @param[in] bfd_session_id BFD session id
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Specifies the array of counter ids
+ * @param[in] mode Statistics mode
+ * @param[out] counters Array of resulting counter values.
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_bfd_session_stats_ext_fn)(
+        _In_ sai_object_id_t bfd_session_id,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_bfd_session_stat_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
 /**
@@ -551,6 +569,7 @@ typedef struct _sai_bfd_api_t
     sai_set_bfd_session_attribute_fn     set_bfd_session_attribute;
     sai_get_bfd_session_attribute_fn     get_bfd_session_attribute;
     sai_get_bfd_session_stats_fn         get_bfd_session_stats;
+    sai_get_bfd_session_stats_ext_fn     get_bfd_session_stats_ext;
     sai_clear_bfd_session_stats_fn       clear_bfd_session_stats;
 
 } sai_bfd_api_t;

--- a/inc/saibridge.h
+++ b/inc/saibridge.h
@@ -330,7 +330,7 @@ typedef sai_status_t (*sai_get_bridge_port_attribute_fn)(
         _Inout_ sai_attribute_t *attr_list);
 
 /**
- * @brief Get bridge port statistics counters.
+ * @brief Get bridge port statistics counters. Deprecated for backward compatibility.
  *
  * @param[in] bridge_port_id Bridge port id
  * @param[in] number_of_counters Number of counters in the array
@@ -343,6 +343,24 @@ typedef sai_status_t (*sai_get_bridge_port_stats_fn)(
         _In_ sai_object_id_t bridge_port_id,
         _In_ uint32_t number_of_counters,
         _In_ const sai_bridge_port_stat_t *counter_ids,
+        _Out_ uint64_t *counters);
+
+/**
+ * @brief Get bridge port statistics counters extended.
+ *
+ * @param[in] bridge_port_id Bridge port id
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Specifies the array of counter ids
+ * @param[in] mode Statistics mode
+ * @param[out] counters Array of resulting counter values.
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_bridge_port_stats_ext_fn)(
+        _In_ sai_object_id_t bridge_port_id,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_bridge_port_stat_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
 /**
@@ -608,7 +626,7 @@ typedef sai_status_t (*sai_get_bridge_attribute_fn)(
         _Inout_ sai_attribute_t *attr_list);
 
 /**
- * @brief Get bridge statistics counters.
+ * @brief Get bridge statistics counters. Deprecated for backward compatibility.
  *
  * @param[in] bridge_id Bridge id
  * @param[in] number_of_counters Number of counters in the array
@@ -621,6 +639,24 @@ typedef sai_status_t (*sai_get_bridge_stats_fn)(
         _In_ sai_object_id_t bridge_id,
         _In_ uint32_t number_of_counters,
         _In_ const sai_bridge_stat_t *counter_ids,
+        _Out_ uint64_t *counters);
+
+/**
+ * @brief Get bridge statistics counters extended.
+ *
+ * @param[in] bridge_id Bridge id
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Specifies the array of counter ids
+ * @param[in] mode Statistics mode
+ * @param[out] counters Array of resulting counter values.
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_bridge_stats_ext_fn)(
+        _In_ sai_object_id_t bridge_id,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_bridge_stat_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
 /**
@@ -647,12 +683,14 @@ typedef struct _sai_bridge_api_t
     sai_set_bridge_attribute_fn         set_bridge_attribute;
     sai_get_bridge_attribute_fn         get_bridge_attribute;
     sai_get_bridge_stats_fn             get_bridge_stats;
+    sai_get_bridge_stats_ext_fn         get_bridge_stats_ext;
     sai_clear_bridge_stats_fn           clear_bridge_stats;
     sai_create_bridge_port_fn           create_bridge_port;
     sai_remove_bridge_port_fn           remove_bridge_port;
     sai_set_bridge_port_attribute_fn    set_bridge_port_attribute;
     sai_get_bridge_port_attribute_fn    get_bridge_port_attribute;
     sai_get_bridge_port_stats_fn        get_bridge_port_stats;
+    sai_get_bridge_port_stats_ext_fn    get_bridge_port_stats_ext;
     sai_clear_bridge_port_stats_fn      clear_bridge_port_stats;
 } sai_bridge_api_t;
 

--- a/inc/saibuffer.h
+++ b/inc/saibuffer.h
@@ -176,7 +176,7 @@ typedef sai_status_t (*sai_get_ingress_priority_group_attribute_fn)(
         _Inout_ sai_attribute_t *attr_list);
 
 /**
- * @brief Get ingress priority group statistics counters.
+ * @brief Get ingress priority group statistics counters. Deprecated for backward compatibility.
  *
  * @param[in] ingress_priority_group_id Ingress priority group id
  * @param[in] number_of_counters Number of counters in the array
@@ -189,6 +189,24 @@ typedef sai_status_t (*sai_get_ingress_priority_group_stats_fn)(
         _In_ sai_object_id_t ingress_priority_group_id,
         _In_ uint32_t number_of_counters,
         _In_ const sai_ingress_priority_group_stat_t *counter_ids,
+        _Out_ uint64_t *counters);
+
+/**
+ * @brief Get ingress priority group statistics counters extended.
+ *
+ * @param[in] ingress_priority_group_id Ingress priority group id
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Specifies the array of counter ids
+ * @param[in] mode Statistics mode
+ * @param[out] counters Array of resulting counter values.
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_ingress_priority_group_stats_ext_fn)(
+        _In_ sai_object_id_t ingress_priority_group_id,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_ingress_priority_group_stat_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
 /**
@@ -437,7 +455,7 @@ typedef sai_status_t (*sai_get_buffer_pool_attribute_fn)(
         _Inout_ sai_attribute_t *attr_list);
 
 /**
- * @brief Get buffer pool statistics counters.
+ * @brief Get buffer pool statistics counters. Deprecated for backward compatibility.
  *
  * @param[in] buffer_pool_id Buffer pool id
  * @param[in] number_of_counters Number of counters in the array
@@ -450,6 +468,24 @@ typedef sai_status_t (*sai_get_buffer_pool_stats_fn)(
         _In_ sai_object_id_t buffer_pool_id,
         _In_ uint32_t number_of_counters,
         _In_ const sai_buffer_pool_stat_t *counter_ids,
+        _Out_ uint64_t *counters);
+
+/**
+ * @brief Get buffer pool statistics counters extended.
+ *
+ * @param[in] buffer_pool_id Buffer pool id
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Specifies the array of counter ids
+ * @param[in] mode Statistics mode
+ * @param[out] counters Array of resulting counter values.
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_buffer_pool_stats_ext_fn)(
+        _In_ sai_object_id_t buffer_pool_id,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_buffer_pool_stat_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
 /**
@@ -675,12 +711,14 @@ typedef struct _sai_buffer_api_t
     sai_set_buffer_pool_attribute_fn                set_buffer_pool_attribute;
     sai_get_buffer_pool_attribute_fn                get_buffer_pool_attribute;
     sai_get_buffer_pool_stats_fn                    get_buffer_pool_stats;
+    sai_get_buffer_pool_stats_ext_fn                get_buffer_pool_stats_ext;
     sai_clear_buffer_pool_stats_fn                  clear_buffer_pool_stats;
     sai_create_ingress_priority_group_fn            create_ingress_priority_group;
     sai_remove_ingress_priority_group_fn            remove_ingress_priority_group;
     sai_set_ingress_priority_group_attribute_fn     set_ingress_priority_group_attribute;
     sai_get_ingress_priority_group_attribute_fn     get_ingress_priority_group_attribute;
     sai_get_ingress_priority_group_stats_fn         get_ingress_priority_group_stats;
+    sai_get_ingress_priority_group_stats_ext_fn     get_ingress_priority_group_stats_ext;
     sai_clear_ingress_priority_group_stats_fn       clear_ingress_priority_group_stats;
     sai_create_buffer_profile_fn                    create_buffer_profile;
     sai_remove_buffer_profile_fn                    remove_buffer_profile;

--- a/inc/saipolicer.h
+++ b/inc/saipolicer.h
@@ -300,7 +300,7 @@ typedef sai_status_t (*sai_get_policer_attribute_fn)(
         _Inout_ sai_attribute_t *attr_list);
 
 /**
- * @brief Get Policer Statistics
+ * @brief Get Policer Statistics. Deprecated for backward compatibility.
  *
  * @param[in] policer_id Policer id
  * @param[in] number_of_counters Number of counters in the array
@@ -313,6 +313,24 @@ typedef sai_status_t (*sai_get_policer_stats_fn)(
         _In_ sai_object_id_t policer_id,
         _In_ uint32_t number_of_counters,
         _In_ const sai_policer_stat_t *counter_ids,
+        _Out_ uint64_t *counters);
+
+/**
+ * @brief Get Policer Statistics extended
+ *
+ * @param[in] policer_id Policer id
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Array of counter ids
+ * @param[in] mode Statistics mode
+ * @param[out] counters Array of resulting counter values.
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_policer_stats_ext_fn)(
+        _In_ sai_object_id_t policer_id,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_policer_stat_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
 /**
@@ -339,6 +357,7 @@ typedef struct _sai_policer_api_t
     sai_set_policer_attribute_fn          set_policer_attribute;
     sai_get_policer_attribute_fn          get_policer_attribute;
     sai_get_policer_stats_fn              get_policer_stats;
+    sai_get_policer_stats_ext_fn          get_policer_stats_ext;
     sai_clear_policer_stats_fn            clear_policer_stats;
 
 } sai_policer_api_t;

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -1651,7 +1651,7 @@ typedef sai_status_t (*sai_get_port_attribute_fn)(
         _Inout_ sai_attribute_t *attr_list);
 
 /**
- * @brief Get port statistics counters.
+ * @brief Get port statistics counters. Deprecated for backward compatibility.
  *
  * @param[in] port_id Port id
  * @param[in] number_of_counters Number of counters in the array
@@ -1664,6 +1664,24 @@ typedef sai_status_t (*sai_get_port_stats_fn)(
         _In_ sai_object_id_t port_id,
         _In_ uint32_t number_of_counters,
         _In_ const sai_port_stat_t *counter_ids,
+        _Out_ uint64_t *counters);
+
+/**
+ * @brief Get port statistics counters extended.
+ *
+ * @param[in] port_id Port id
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Specifies the array of counter ids
+ * @param[in] mode Statistics mode
+ * @param[out] counters Array of resulting counter values.
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_port_stats_ext_fn)(
+        _In_ sai_object_id_t port_id,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_port_stat_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
 /**
@@ -1889,7 +1907,7 @@ typedef sai_status_t (*sai_get_port_pool_attribute_fn)(
         _Inout_ sai_attribute_t *attr_list);
 
 /**
- * @brief Get port pool statistics counters.
+ * @brief Get port pool statistics counters. Deprecated for backward compatibility.
  *
  * @param[in] port_pool_id Port pool id
  * @param[in] number_of_counters Number of counters in the array
@@ -1902,6 +1920,24 @@ typedef sai_status_t (*sai_get_port_pool_stats_fn)(
         _In_ sai_object_id_t port_pool_id,
         _In_ uint32_t number_of_counters,
         _In_ const sai_port_pool_stat_t *counter_ids,
+        _Out_ uint64_t *counters);
+
+/**
+ * @brief Get port pool statistics counters extended.
+ *
+ * @param[in] port_pool_id Port pool id
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Specifies the array of counter ids
+ * @param[in] mode Statistics mode
+ * @param[out] counters Array of resulting counter values.
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_port_pool_stats_ext_fn)(
+        _In_ sai_object_id_t port_pool_id,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_port_pool_stat_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
 /**
@@ -1928,6 +1964,7 @@ typedef struct _sai_port_api_t
     sai_set_port_attribute_fn         set_port_attribute;
     sai_get_port_attribute_fn         get_port_attribute;
     sai_get_port_stats_fn             get_port_stats;
+    sai_get_port_stats_ext_fn         get_port_stats_ext;
     sai_clear_port_stats_fn           clear_port_stats;
     sai_clear_port_all_stats_fn       clear_port_all_stats;
     sai_create_port_pool_fn           create_port_pool;
@@ -1935,6 +1972,7 @@ typedef struct _sai_port_api_t
     sai_set_port_pool_attribute_fn    set_port_pool_attribute;
     sai_get_port_pool_attribute_fn    get_port_pool_attribute;
     sai_get_port_pool_stats_fn        get_port_pool_stats;
+    sai_get_port_pool_stats_ext_fn    get_port_pool_stats_ext;
     sai_clear_port_pool_stats_fn      clear_port_pool_stats;
 
 } sai_port_api_t;

--- a/inc/saiqueue.h
+++ b/inc/saiqueue.h
@@ -396,7 +396,7 @@ typedef sai_status_t (*sai_get_queue_attribute_fn)(
         _Inout_ sai_attribute_t *attr_list);
 
 /**
- * @brief Get queue statistics counters.
+ * @brief Get queue statistics counters. Deprecated for backward compatibility.
  *
  * @param[in] queue_id Queue id
  * @param[in] number_of_counters Number of counters in the array
@@ -409,6 +409,24 @@ typedef sai_status_t (*sai_get_queue_stats_fn)(
         _In_ sai_object_id_t queue_id,
         _In_ uint32_t number_of_counters,
         _In_ const sai_queue_stat_t *counter_ids,
+        _Out_ uint64_t *counters);
+
+/**
+ * @brief Get queue statistics counters extended.
+ *
+ * @param[in] queue_id Queue id
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Specifies the array of counter ids
+ * @param[in] mode Statistics mode
+ * @param[out] counters Array of resulting counter values.
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_queue_stats_ext_fn)(
+        _In_ sai_object_id_t queue_id,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_queue_stat_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
 /**
@@ -449,6 +467,7 @@ typedef struct _sai_queue_api_t
     sai_set_queue_attribute_fn   set_queue_attribute;
     sai_get_queue_attribute_fn   get_queue_attribute;
     sai_get_queue_stats_fn       get_queue_stats;
+    sai_get_queue_stats_ext_fn   get_queue_stats_ext;
     sai_clear_queue_stats_fn     clear_queue_stats;
 
 } sai_queue_api_t;

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -1643,7 +1643,7 @@ typedef enum _sai_switch_attr_t
      * @type sai_s32_list_t sai_stats_mode_t
      * @flags READ_ONLY
      */
-    SAI_SWITCH_ATTR_SUPPORTED_STATISTICS_EXTENDED_MODES,
+    SAI_SWITCH_ATTR_SUPPORTED_EXTENDED_STATS_MODE,
 
     /**
      * @brief End of attributes

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -1637,6 +1637,7 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_MAX_SAMPLED_MIRROR_SESSION,
 
     /**
+     * @brief Get the list of supported get statistics extended modes
      *        Empty list should be returned if get statistics extended is not supported at all
      *
      * @type sai_s32_list_t sai_stats_mode_t

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -1637,6 +1637,14 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_MAX_SAMPLED_MIRROR_SESSION,
 
     /**
+     *        Empty list should be returned if get statistics extended is not supported at all
+     *
+     * @type sai_s32_list_t sai_stats_mode_t
+     * @flags READ_ONLY
+     */
+    SAI_SWITCH_ATTR_SUPPORTED_STATISTICS_EXTENDED_MODES,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -691,7 +691,7 @@ typedef sai_status_t (*sai_get_tunnel_attribute_fn)(
         _Inout_ sai_attribute_t *attr_list);
 
 /**
- * @brief Get tunnel statistics counters.
+ * @brief Get tunnel statistics counters. Deprecated for backward compatibility.
  *
  * @param[in] tunnel_id Tunnel id
  * @param[in] number_of_counters Number of counters in the array
@@ -704,6 +704,24 @@ typedef sai_status_t (*sai_get_tunnel_stats_fn)(
         _In_ sai_object_id_t tunnel_id,
         _In_ uint32_t number_of_counters,
         _In_ const sai_tunnel_stat_t *counter_ids,
+        _Out_ uint64_t *counters);
+
+/**
+ * @brief Get tunnel statistics counters extended.
+ *
+ * @param[in] tunnel_id Tunnel id
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Specifies the array of counter ids
+ * @param[in] mode Statistics mode
+ * @param[out] counters Array of resulting counter values.
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_tunnel_stats_ext_fn)(
+        _In_ sai_object_id_t tunnel_id,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_tunnel_stat_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
 /**
@@ -925,6 +943,7 @@ typedef struct _sai_tunnel_api_t
     sai_set_tunnel_attribute_fn                  set_tunnel_attribute;
     sai_get_tunnel_attribute_fn                  get_tunnel_attribute;
     sai_get_tunnel_stats_fn                      get_tunnel_stats;
+    sai_get_tunnel_stats_ext_fn                  get_tunnel_stats_ext;
     sai_clear_tunnel_stats_fn                    clear_tunnel_stats;
     sai_create_tunnel_term_table_entry_fn        create_tunnel_term_table_entry;
     sai_remove_tunnel_term_table_entry_fn        remove_tunnel_term_table_entry;

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -802,6 +802,19 @@ typedef sai_status_t (*sai_bulk_object_remove_fn)(
         _In_ sai_bulk_op_error_mode_t mode,
         _Out_ sai_status_t *object_statuses);
 
+typedef enum _sai_stats_mode_t
+{
+    /**
+     * @brief Read statistics
+     */
+    SAI_STATS_MODE_READ,
+
+    /**
+     * @brief Read and clear after reading
+     */
+    SAI_STATS_MODE_READ_AND_CLEAR,
+} sai_stats_mode_t;
+
 /**
  * @}
  */

--- a/inc/saivlan.h
+++ b/inc/saivlan.h
@@ -570,7 +570,7 @@ typedef sai_status_t (*sai_get_vlan_member_attribute_fn)(
         _Inout_ sai_attribute_t *attr_list);
 
 /**
- * @brief Get vlan statistics counters.
+ * @brief Get vlan statistics counters. Deprecated for backward compatibility.
  *
  * @param[in] vlan_id VLAN id
  * @param[in] number_of_counters Number of counters in the array
@@ -583,6 +583,24 @@ typedef sai_status_t (*sai_get_vlan_stats_fn)(
         _In_ sai_object_id_t vlan_id,
         _In_ uint32_t number_of_counters,
         _In_ const sai_vlan_stat_t *counter_ids,
+        _Out_ uint64_t *counters);
+
+/**
+ * @brief Get vlan statistics counters extended.
+ *
+ * @param[in] vlan_id VLAN id
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Specifies the array of counter ids
+ * @param[in] mode Statistics mode
+ * @param[out] counters Array of resulting counter values.
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_vlan_stats_ext_fn)(
+        _In_ sai_object_id_t vlan_id,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_vlan_stat_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
 /**
@@ -615,6 +633,7 @@ typedef struct _sai_vlan_api_t
     sai_bulk_object_create_fn           create_vlan_members;
     sai_bulk_object_remove_fn           remove_vlan_members;
     sai_get_vlan_stats_fn               get_vlan_stats;
+    sai_get_vlan_stats_ext_fn           get_vlan_stats_ext;
     sai_clear_vlan_stats_fn             clear_vlan_stats;
 
 } sai_vlan_api_t;

--- a/meta/style.pm
+++ b/meta/style.pm
@@ -224,13 +224,13 @@ sub CheckFunctionsParams
         next if not $fname =~ /_fn$/; # below don't apply for global functions
 
         if (not $fnparams =~ /^(\w+)(| attr| attr_count attr_list| switch_id attr_count attr_list)$/ and
-            not $fname =~ /_(stats|notification)_fn$|^sai_(send|recv|bulk)_|^sai_meta/)
+            not $fname =~ /_(stats|stats_ext|notification)_fn$|^sai_(send|recv|bulk)_|^sai_meta/)
         {
             LogWarning "wrong param names: $fnparams: $fname";
             LogWarning " expected: $params[0](| attr| attr_count attr_list| switch_id attr_count attr_list)";
         }
 
-        if ($fname =~ /^sai_(get|set|create|remove)_(\w+?)(_attribute)?(_stats)?_fn/)
+        if ($fname =~ /^sai_(get|set|create|remove)_(\w+?)(_attribute)?(_stats|_stats_ext)?_fn/)
         {
             my $pattern = $2;
             my $first = $params[0];
@@ -372,7 +372,7 @@ sub CheckFunctionNaming
     {
         # ok
     }
-    elsif ($name =~/^(get|clear)_(\w+?)_(all_)?stats$/)
+    elsif ($name =~/^(get|clear)_(\w+?)_(all_)?stats(_ext)?$/)
     {
         LogWarning "not object name $2 in $name" if not IsObjectName($2);
     }


### PR DESCRIPTION
Extended funtions have extra mode paramter. For now the options are
regular read and read with clear. Read and clear allows atomic operation
without loosing counters in the gap between the read and clear functions
in existing API.
Mode can be furthermore extended upon future need.
Old get statistics functions are deprecated but left for backward
compatability