### PR TITLE
VRRP support in RIF create call

### DIFF
--- a/inc/sairouterinterface.h
+++ b/inc/sairouterinterface.h
@@ -240,6 +240,19 @@ typedef enum _sai_router_interface_attr_t
     SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION,
 
     /**
+     * @brief RIF creation is a virtual RIF.
+     *
+     * Create a Virtual RIF object, which only programs the ingress router mac.
+     * This simplifies the management of VRRP backup role/master role as defined
+     * by RFC 5798 (or similar proprietary protocols).
+     *
+     * @type bool
+     * @flags CREATE_ONLY
+     * @default false
+     */
+    SAI_ROUTER_INTERFACE_ATTR_IS_VIRTUAL,
+
+    /**
      * @brief End of attributes
      */
     SAI_ROUTER_INTERFACE_ATTR_END,

--- a/inc/sairouterinterface.h
+++ b/inc/sairouterinterface.h
@@ -243,7 +243,7 @@ typedef enum _sai_router_interface_attr_t
      * @brief RIF creation is a virtual RIF.
      *
      * Create a Virtual RIF object, which only programs the ingress router MAC.
-     * This simplifies the management of VRRP's master role configuration to the
+     * This simplifies the management of VRRP master router's configuration in
      * SAI adapter, as defined by RFC 5798 (or similar proprietary protocols).
      *
      * @type bool

--- a/inc/sairouterinterface.h
+++ b/inc/sairouterinterface.h
@@ -245,6 +245,12 @@ typedef enum _sai_router_interface_attr_t
      * Create a Virtual RIF object, which only programs the ingress router MAC.
      * This simplifies the management of VRRP master router's configuration in
      * SAI adapter, as defined by RFC 5798 (or similar proprietary protocols).
+     * Using a Virtual RIF allows SAI to optimize resources, so neighbor entries
+     * cannot be learned on a Virtual RIF. On a virtual RIF following attributes
+     * are invalid: ADMIN state, MTU size, packet action and multicast enable.
+     * Alternatively VRRP can also be configured using native RIF objects without
+     * using VIRTUAL attribute, with the expectation that SAI adapter will consume
+     * resources that will not be used.
      *
      * @type bool
      * @flags CREATE_ONLY

--- a/inc/sairouterinterface.h
+++ b/inc/sairouterinterface.h
@@ -242,9 +242,9 @@ typedef enum _sai_router_interface_attr_t
     /**
      * @brief RIF creation is a virtual RIF.
      *
-     * Create a Virtual RIF object, which only programs the ingress router mac.
-     * This simplifies the management of VRRP backup role/master role as defined
-     * by RFC 5798 (or similar proprietary protocols).
+     * Create a Virtual RIF object, which only programs the ingress router MAC.
+     * This simplifies the management of VRRP's master role configuration to the
+     * SAI adapter, as defined by RFC 5798 (or similar proprietary protocols).
      *
      * @type bool
      * @flags CREATE_ONLY


### PR DESCRIPTION
VRRP support during RIF create calls. Currently it seems we don't have a way to manage multiple Virtual MAC entries to be added for Native RIF entries. This addition in the router_interface attributes will allow NOS to pass in a Port or VLAN rif -- create_router_interface call, and only use the SRC_MAC to program the ingress MAC entry for routing and avoid using this Virtual MAC for any other purpose in the SAI adapter. 