### PR TITLE
Unitialize data plane on switch removal

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -1637,6 +1637,21 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_MAX_SAMPLED_MIRROR_SESSION,
 
     /**
+     * @brief Uninitialize data plane upon removal of switch object
+     *
+     * Typical use case for tear down of the host adapter, is to remove the switch ID,
+     * which will stop all data and control plane, as leaving data plane open without
+     * control can be a security risk.
+     * However, on some scenarios, such as fast boot, host adapter would like to set
+     * this value to false, call remove switch, and have the data plane still running.
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default true
+     */
+    SAI_SWITCH_ATTR_UNINIT_DATA_PLANE_ON_REMOVAL,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,


### PR DESCRIPTION
Controls whether data plane is unitialized upon removal
Typically, host adapter will want that, as leaving traffic running
without control is risky
However, on some scenarios, such as fast boot, it is needed to leave the
data plane running
Host adapter will call this attribute if needed, and then call remove
switch