### PR TITLE
Add HostIf traps for CISCO MCAST packet types

### DIFF
--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -201,6 +201,18 @@ typedef enum _sai_hostif_trap_type_t
     /** Default action is drop */
     SAI_HOSTIF_TRAP_TYPE_UDLD = 0x0000000b,
 
+    /** Default action is drop */
+    SAI_HOSTIF_TRAP_TYPE_CDP = 0x0000000c,
+
+    /** Default action is drop */
+    SAI_HOSTIF_TRAP_TYPE_VTP = 0x0000000d,
+
+    /** Default action is drop */
+    SAI_HOSTIF_TRAP_TYPE_DTP = 0x0000000e,
+
+    /** Default action is drop */
+    SAI_HOSTIF_TRAP_TYPE_PAGP = 0x0000000f,
+
     /** Switch traps custom range start */
     SAI_HOSTIF_TRAP_TYPE_SWITCH_CUSTOM_RANGE_BASE = 0x00001000,
 


### PR DESCRIPTION
This PR request was to add CISCO MCast types other than UDLD to SAI header, so we can trap individual types to CPU.  Also,  one common Mcast DMAC trap is added in case you wanted to use a single trap for CISCO Mcast DMAC (01-00-0c-cc-cc-cc).

