### PR TITLE
Added MLD Snooping attribute to saivlan.h

### DIFF
--- a/inc/saivlan.h
+++ b/inc/saivlan.h
@@ -386,6 +386,18 @@ typedef enum _sai_vlan_attr_t
      */
     SAI_VLAN_ATTR_CUSTOM_IGMP_SNOOPING_ENABLE,
 
+    /**
+     * @brief MLD Snooping enable or disable control for VLAN
+     *
+     * MLD Snooping enable control for VLAN. Default is
+     * disabled
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_VLAN_ATTR_CUSTOM_MLD_SNOOPING_ENABLE,
+
     /** End of custom range base */
     SAI_VLAN_ATTR_CUSTOM_RANGE_END
 


### PR DESCRIPTION
As per discussion with Ragu Raman attribute for MLD Snooping was missed while designing. This attribute is required for L2/L3 Multicast features to control IPv6 IGMP control packets.

@ragu-raman 
@kcudnik 
@lguohan 