### PR TITLE
l2mc/ipmc support multi-NPU

### DIFF
--- a/inc/saiipmcgroup.h
+++ b/inc/saiipmcgroup.h
@@ -61,6 +61,16 @@ typedef enum _sai_ipmc_group_attr_t
     SAI_IPMC_GROUP_ATTR_IPMC_MEMBER_LIST,
 
     /**
+     * @brief IPMC group id
+     *
+     * This attribute only takes effect when the value(type is SAI_OBJECT_TYPE_IPMC_GROUP) is not equal to SAI_NULL_OBJECT_ID
+     * @type sai_uint64_t
+     * @flags CREATE_ONLY
+     * @default 0
+     */
+    SAI_IPMC_GROUP_ATTR_IPMC_GROUP_ID,
+
+    /**
      * @brief End of attributes
      */
     SAI_IPMC_GROUP_ATTR_END,
@@ -113,6 +123,23 @@ typedef enum _sai_ipmc_group_member_attr_t
 
 /**
  * @brief Create IPMC group
+ *
+ * In multiple NPU scenario,the ingress NPU need to allocate a H/W resource
+ * called the IPMC index which will be indexed into table to give the ports
+ * list on which a multicast packet should go out, the other egress NPUs will
+ * use the IPMC index to read H/W table directly without going through the
+ * lookup process based on packet's (S,G/x,G).From the point of view of the
+ * upper users(SONIC),the IPMC member are sets of router interface,and the
+ * same IPMC member can share a group,but from the point of view of NPU,i
+ * finally,the group member need to convert to port list,so the relationship
+ * between IPMC Group and IPMC entry must be 1:1
+ *
+ * If there is no SAI_IPMC_GROUP_ATTR_IPMC_GROUP_ID in attribute list, or
+ * the value of SAI_IPMC_GROUP_ATTR_IPMC_GROUP_ID attribute is zero, It
+ * means that the upper layer user(usually SONIC) wants to create a new
+ * IPMC group object id. If there is SAI_IPMC_GROUP_ATTR_IPMC_GROUP_ID
+ * in attribute list, the expected behavior is that the
+ * sai_create_ipmc_group_fn reuse the IPMC group object id
  *
  * @param[out] ipmc_group_id IPMC group id
  * @param[in] switch_id Switch id

--- a/inc/sail2mcgroup.h
+++ b/inc/sail2mcgroup.h
@@ -61,6 +61,16 @@ typedef enum _sai_l2mc_group_attr_t
     SAI_L2MC_GROUP_ATTR_L2MC_MEMBER_LIST,
 
     /**
+     * @brief L2MC group id
+     *
+     * This attribute only takes effect when the value(type is SAI_OBJECT_TYPE_L2MC_GROUP) is not equal to SAI_NULL_OBJECT_ID
+     * @type sai_uint64_t
+     * @flags CREATE_ONLY
+     * @default 0
+     */
+    SAI_L2MC_GROUP_ATTR_L2MC_GROUP_ID,
+
+    /**
      * @brief End of attributes
      */
     SAI_L2MC_GROUP_ATTR_END,
@@ -123,6 +133,17 @@ typedef enum _sai_l2mc_group_member_attr_t
 
 /**
  * @brief Create L2MC group
+ *
+ * There is no problem with sharing member group mechanism in L2MC
+ * entry,but we suggest to use 1:1 mechanism because of the
+ * convenience of the L2MC member to be updated
+ *
+ * If there is no SAI_L2MC_GROUP_ATTR_L2MC_GROUP_ID in attribute list,
+ * or the value of SAI_L2MC_GROUP_ATTR_L2MC_GROUP_ID attribute is zero,
+ * It means that the upper layer user(usually SONIC) wants to create
+ * a new L2MC group object id. If there is SAI_L2MC_GROUP_ATTR_L2MC_GROUP_ID
+ * in attribute list, the expected behavior is that the sai_create_l2mc_group_fn
+ * reuse the L2MC group object id
  *
  * @param[out] l2mc_group_id L2MC group id
  * @param[in] switch_id Switch id

--- a/inc/sairpfgroup.h
+++ b/inc/sairpfgroup.h
@@ -61,6 +61,16 @@ typedef enum _sai_rpf_group_attr_t
     SAI_RPF_GROUP_ATTR_RPF_MEMBER_LIST,
 
     /**
+     * @brief RPF interface group id
+     *
+     * This attribute only takes effect when the value(SAI_OBJECT_TYPE_RPF_GROUP) is not equal to SAI_NULL_OBJECT_ID
+     * @type sai_uint64_t
+     * @flags CREATE_ONLY
+     * @default 0
+     */
+    SAI_RPF_GROUP_ATTR_RPF_GROUP_ID,
+
+    /**
      * @brief End of attributes
      */
     SAI_RPF_GROUP_ATTR_END,
@@ -113,6 +123,13 @@ typedef enum _sai_rpf_group_member_attr_t
 
 /**
  * @brief Create RPF interface group
+ *
+ * If there is no SAI_RPF_GROUP_ATTR_RPF_GROUP_ID in attribute list,
+ * or the value of SAI_RPF_GROUP_ATTR_RPF_GROUP_ID attribute is zero,
+ * It means that the upper layer user(usually SONIC) wants to create
+ * a new RPF interface group object id. If there is SAI_RPF_GROUP_ATTR_RPF_GROUP_ID
+ * in attribute list, the expected behavior is that the sai_create_rpf_group_fn
+ * reuse the RPF interface group object id
  *
  * @param[out] rpf_group_id RPF interface group id
  * @param[in] switch_id Switch id


### PR DESCRIPTION
I have discussed these revision with @MaruthamuthuP through email,the detail information refer to http://lists.opencompute.org/pipermail/opencompute-sai/2018-May/subject.html. 

In multiple NPU scenario,the ingress NPU need to allocate a H/W resource called the IPMC index which will be indexed into table to give the ports list on which a multicast packet should go out, the other egress NPUs will use the IPMC index to read H/W table directly without going through the lookup process based on packet's (S,G/x,G).From the point of view of the upper users(SONIC),the IPMC member are sets of router interface,and the same IPMC member can share a group,but from the point of view of NPU,finally,the group member need to convert to port list,so the relationship between IPMC Group and IPMC entry must be 1:1