### PR TITLE
Make saiacl.BindAclTableInGroupTest use 4 ports instead of 5 ports

### DIFF
--- a/test/saithrift/tests/saiacl.py
+++ b/test/saithrift/tests/saiacl.py
@@ -867,14 +867,13 @@ class BindAclTableInGroupTest(sai_base_test.ThriftInterfaceDataPlane):
     def runTest(self):
         print
         print '----------------------------------------------------------------------------------------------'
-        print "Sending packet [ptf_intf 1, ptf_intf 2, ptf_intf 3, ptf_intf 4] -> ptf_intf 5 (192.168.0.1 ---> 10.10.10.1 [id = 105])"
+        print "Sending packet [ptf_intf 1, ptf_intf 2, ptf_intf 3] -> ptf_intf 4 (192.168.0.1 ---> 10.10.10.1 [id = 105])"
 
         switch_init(self.client)
-        port1 = port_list[1]
-        port2 = port_list[2]
-        port3 = port_list[3]
-        port4 = port_list[4]
-        port5 = port_list[5]
+        port1 = port_list[0]
+        port2 = port_list[1]
+        port3 = port_list[2]
+        port4 = port_list[3]
         v4_enabled = 1
         v6_enabled = 1
         mac = ''
@@ -884,53 +883,48 @@ class BindAclTableInGroupTest(sai_base_test.ThriftInterfaceDataPlane):
         rif_id2 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_PORT, port2, 0, v4_enabled, v6_enabled, mac)
         rif_id3 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_PORT, port3, 0, v4_enabled, v6_enabled, mac)
         rif_id4 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_PORT, port4, 0, v4_enabled, v6_enabled, mac)
-        rif_id5 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_PORT, port5, 0, v4_enabled, v6_enabled, mac)
-
 
         addr_family = SAI_IP_ADDR_FAMILY_IPV4
         ip_addr1 = '10.10.10.1'
+        ip_subnet1 = '10.10.10.0'
         ip_mask1 = '255.255.255.0'
         dmac1 = '00:11:22:33:44:55'
-        sai_thrift_create_neighbor(self.client, addr_family, rif_id5, ip_addr1, dmac1)
+        sai_thrift_create_neighbor(self.client, addr_family, rif_id4, ip_addr1, dmac1)
         nhop1 = sai_thrift_create_nhop(self.client, addr_family, ip_addr1, rif_id4)
-        sai_thrift_create_route(self.client, vr_id, addr_family, ip_addr1, ip_mask1, rif_id5)
+        sai_thrift_create_route(self.client, vr_id, addr_family, ip_subnet1, ip_mask1, rif_id4)
 
         # send the test packet(s)
         pkt = simple_tcp_packet(eth_dst=router_mac,
             eth_src='00:22:22:22:22:22',
-            ip_dst='10.10.10.1',
+            ip_dst=ip_addr1,
             ip_src='192.168.0.1',
             ip_id=105,
             ip_ttl=64)
         exp_pkt = simple_tcp_packet(
             eth_dst='00:11:22:33:44:55',
             eth_src=router_mac,
-            ip_dst='10.10.10.1',
+            ip_dst=ip_addr1,
             ip_src='192.168.0.1',
             ip_id=105,
             ip_ttl=63)
         try:
             print '#### NO ACL Applied ####'
             print '#### Sending  ', router_mac, '| 00:22:22:22:22:22 | 10.10.10.1 | 192.168.0.1 | @ ptf_intf 1'
-            send_packet(self, 1, str(pkt))
-            print '#### Expecting 00:11:22:33:44:55 |', router_mac, '| 10.10.10.1 | 192.168.0.1 | @ ptf_intf 5'
-            verify_packet(self, exp_pkt, 5)
+            send_packet(self, 0, str(pkt))
+            print '#### Expecting 00:11:22:33:44:55 |', router_mac, '| 10.10.10.1 | 192.168.0.1 | @ ptf_intf 4'
+            verify_packet(self, exp_pkt, 3)
             print '#### Sending  ', router_mac, '| 00:22:22:22:22:22 | 10.10.10.1 | 192.168.0.1 | @ ptf_intf 2'
-            send_packet(self, 2, str(pkt))
-            print '#### Expecting 00:11:22:33:44:55 |', router_mac, '| 10.10.10.1 | 192.168.0.1 | @ ptf_intf 5'
-            verify_packet(self, exp_pkt, 5)
+            send_packet(self,1, str(pkt))
+            print '#### Expecting 00:11:22:33:44:55 |', router_mac, '| 10.10.10.1 | 192.168.0.1 | @ ptf_intf 4'
+            verify_packet(self, exp_pkt, 3)
             print '#### Sending  ', router_mac, '| 00:22:22:22:22:22 | 10.10.10.1 | 192.168.0.1 | @ ptf_intf 3'
-            send_packet(self, 3, str(pkt))
-            print '#### Expecting 00:11:22:33:44:55 |', router_mac, '| 10.10.10.1 | 192.168.0.1 | @ ptf_intf 5'
-            verify_packet(self, exp_pkt, 5)
-            print '#### Sending  ', router_mac, '| 00:22:22:22:22:22 | 10.10.10.1 | 192.168.0.1 | @ ptf_intf 4'
-            send_packet(self, 4, str(pkt))
-            print '#### Expecting 00:11:22:33:44:55 |', router_mac, '| 10.10.10.1 | 192.168.0.1 | @ ptf_intf 5'
-            verify_packet(self, exp_pkt, 5)
+            send_packet(self, 2, str(pkt))
+            print '#### Expecting 00:11:22:33:44:55 |', router_mac, '| 10.10.10.1 | 192.168.0.1 | @ ptf_intf 4'
+            verify_packet(self, exp_pkt, 3)
         finally:
             print '----------------------------------------------------------------------------------------------'
 
-        print "Sending packet [ptf_intf 1, ptf_intf 2, ptf_intf 3, ptf_intf 4] -> ptf_intf 5 (192.168.0.1 ---> 10.10.10.1 [id = 105])"
+        print "Sending packet [ptf_intf 1, ptf_intf 2, ptf_intf 3] -> ptf_intf 4 (192.168.0.1 ---> 10.10.10.1 [id = 105])"
 
         # setup ACL table group
         group_stage = SAI_ACL_STAGE_INGRESS
@@ -948,15 +942,23 @@ class BindAclTableInGroupTest(sai_base_test.ThriftInterfaceDataPlane):
         table_bind_point_list = [SAI_ACL_BIND_POINT_TYPE_PORT]
         entry_priority = 1
         action = SAI_PACKET_ACTION_DROP
-        in_ports = [port1, port2, port3, port4, port5]
+        in_ports1 = [port1]
+        in_ports2 = [port2]
+        in_ports3 = [port3]
         mac_src = '00:22:22:22:22:22'
         mac_dst = None
-        mac_src_mask = None
+        mac_src_mask = 'ff:ff:ff:ff:ff:ff'
         mac_dst_mask = None
+        ip_src = None
+        ip_src_mask = None
+        ip_dst = None
+        ip_dst_mask = None
         ip_proto = None
         in_port = None
         out_port = None
         out_ports = None
+        src_l4_port = None
+        dst_l4_port = None
         ingress_mirror_id = None
         egress_mirror_id = None
 
@@ -970,14 +972,14 @@ class BindAclTableInGroupTest(sai_base_test.ThriftInterfaceDataPlane):
             ip_src,
             ip_dst,
             ip_proto,
-            in_ports,
+            in_ports1,
             out_ports,
             in_port,
             out_port,
             src_l4_port,
             dst_l4_port)
         acl_entry_id1 = sai_thrift_create_acl_entry(self.client,
-            acl_table_id,
+            acl_table_id1,
             entry_priority,
             action, addr_family,
             mac_src, mac_src_mask,
@@ -985,7 +987,7 @@ class BindAclTableInGroupTest(sai_base_test.ThriftInterfaceDataPlane):
             ip_src, ip_src_mask,
             ip_dst, ip_dst_mask,
             ip_proto,
-            in_ports, out_ports,
+            in_ports1, out_ports,
             in_port, out_port,
             src_l4_port, dst_l4_port,
             ingress_mirror_id,
@@ -1001,14 +1003,14 @@ class BindAclTableInGroupTest(sai_base_test.ThriftInterfaceDataPlane):
             ip_src,
             ip_dst,
             ip_proto,
-            in_ports,
+            in_ports2,
             out_ports,
             in_port,
             out_port,
             src_l4_port,
             dst_l4_port)
         acl_entry_id2 = sai_thrift_create_acl_entry(self.client,
-            acl_table_id,
+            acl_table_id2,
             entry_priority,
             action, addr_family,
             mac_src, mac_src_mask,
@@ -1016,7 +1018,38 @@ class BindAclTableInGroupTest(sai_base_test.ThriftInterfaceDataPlane):
             ip_src, ip_src_mask,
             ip_dst, ip_dst_mask,
             ip_proto,
-            in_ports, out_ports,
+            in_ports2, out_ports,
+            in_port, out_port,
+            src_l4_port, dst_l4_port,
+            ingress_mirror_id,
+            egress_mirror_id)
+
+        # create ACL table #3
+        acl_table_id3 = sai_thrift_create_acl_table(self.client,
+            table_stage,
+            table_bind_point_list,
+            addr_family,
+            mac_src,
+            mac_dst,
+            ip_src,
+            ip_dst,
+            ip_proto,
+            in_ports3,
+            out_ports,
+            in_port,
+            out_port,
+            src_l4_port,
+            dst_l4_port)
+        acl_entry_id3 = sai_thrift_create_acl_entry(self.client,
+            acl_table_id3,
+            entry_priority,
+            action, addr_family,
+            mac_src, mac_src_mask,
+            mac_dst, mac_dst_mask,
+            ip_src, ip_src_mask,
+            ip_dst, ip_dst_mask,
+            ip_proto,
+            in_ports3, out_ports,
             in_port, out_port,
             src_l4_port, dst_l4_port,
             ingress_mirror_id,
@@ -1025,53 +1058,54 @@ class BindAclTableInGroupTest(sai_base_test.ThriftInterfaceDataPlane):
         # setup ACL table group members
         group_member_priority1 = 1
         group_member_priority2 = 100
+        group_member_priority3 = 50
 
         # create ACL table group members
-        acl_table_group_member_id1 = sai_thrift_create_acl_table_group(self.client,
+        acl_table_group_member_id1 = sai_thrift_create_acl_table_group_member(self.client,
             acl_table_group_id,
             acl_table_id1,
             group_member_priority1)
-        acl_table_group_member_id2 = sai_thrift_create_acl_table_group(self.client,
+        acl_table_group_member_id2 = sai_thrift_create_acl_table_group_member(self.client,
             acl_table_group_id,
             acl_table_id2,
             group_member_priority2)
+        acl_table_group_member_id3 = sai_thrift_create_acl_table_group_member(self.client,
+            acl_table_group_id,
+            acl_table_id3,
+            group_member_priority3)
 
-        # bind this ACL table group to port1, port2, port3, port4 object id
+        # bind this ACL table group to port1, port2, port3 object id
         attr_value = sai_thrift_attribute_value_t(oid=acl_table_group_id)
         attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_INGRESS_ACL, value=attr_value)
-        attr_value1 = sai_thrift_attribute_value_t(oid=acl_table_id2)
-        attr1 = sai_thrift_attribute_t(id=SAI_PORT_ATTR_INGRESS_ACL, value=attr_value)
         self.client.sai_thrift_set_port_attribute(port1, attr)
         self.client.sai_thrift_set_port_attribute(port2, attr)
         self.client.sai_thrift_set_port_attribute(port3, attr)
-        self.client.sai_thrift_set_port_attribute(port4, attr1)
 
         try:
             assert acl_table_group_id > 0, 'acl_table_group_id is <= 0'
-            assert acl_table_id1 > 0, 'acl_entry_id1 is <= 0'
+            assert acl_table_id1 > 0, 'acl_table_id1 is <= 0'
             assert acl_entry_id1 > 0, 'acl_entry_id1 is <= 0'
-            assert acl_table_id2 > 0, 'acl_entry_id2 is <= 0'
+            assert acl_table_id2 > 0, 'acl_table_id2 is <= 0'
             assert acl_entry_id2 > 0, 'acl_entry_id2 is <= 0'
+            assert acl_table_id3 > 0, 'acl_table_id3 is <= 0'
+            assert acl_entry_id3 > 0, 'acl_entry_id3 is <= 0'
             assert acl_table_group_member_id1 > 0, 'acl_table_group_member_id1 is <= 0'
             assert acl_table_group_member_id2 > 0, 'acl_table_group_member_id2 is <= 0'
+            assert acl_table_group_member_id3 > 0, 'acl_table_group_member_id3 is <= 0'
 
-            print '#### ACL \'DROP, src mac 00:22:22:22:22:22, in_ports[ptf_intf_1,2,3,4]\' Applied ####'
+            print '#### ACL \'DROP, src mac 00:22:22:22:22:22, in_ports[ptf_intf_1,2,3]\' Applied ####'
             print '#### Sending      ', router_mac, '| 00:22:22:22:22:22 | 10.10.10.1 | 192.168.0.1 | @ ptf_intf 1'
-            send_packet(self, 1, str(pkt))
-            print '#### NOT Expecting 00:11:22:33:44:55 |', router_mac, '| 10.10.10.1 | 192.168.0.1 | @ ptf_intf 5'
-            verify_no_packet(self, exp_pkt, 5)
+            send_packet(self, 0, str(pkt))
+            print '#### NOT Expecting 00:11:22:33:44:55 |', router_mac, '| 10.10.10.1 | 192.168.0.1 | @ ptf_intf 4'
+            verify_no_packet(self, exp_pkt, 3)
             print '#### Sending      ', router_mac, '| 00:22:22:22:22:22 | 10.10.10.1 | 192.168.0.1 | @ ptf_intf 2'
-            send_packet(self, 2, str(pkt))
-            print '#### NOT Expecting 00:11:22:33:44:55 |', router_mac, '| 10.10.10.1 | 192.168.0.1 | @ ptf_intf 5'
-            verify_no_packet(self, exp_pkt, 5)
+            send_packet(self, 1, str(pkt))
+            print '#### NOT Expecting 00:11:22:33:44:55 |', router_mac, '| 10.10.10.1 | 192.168.0.1 | @ ptf_intf 4'
+            verify_no_packet(self, exp_pkt, 3)
             print '#### Sending      ', router_mac, '| 00:22:22:22:22:22 | 10.10.10.1 | 192.168.0.1 | @ ptf_intf 3'
-            send_packet(self, 3, str(pkt))
-            print '#### NOT Expecting 00:11:22:33:44:55 |', router_mac, '| 10.10.10.1 | 192.168.0.1 | @ ptf_intf 5'
-            verify_no_packet(self, exp_pkt, 5)
-            print '#### Sending      ', router_mac, '| 00:22:22:22:22:22 | 10.10.10.1 | 192.168.0.1 | @ ptf_intf 4'
-            send_packet(self, 4, str(pkt))
-            print '#### NOT Expecting 00:11:22:33:44:55 |', router_mac, '| 10.10.10.1 | 192.168.0.1 | @ ptf_intf 5'
-            verify_no_packet(self, exp_pkt, 5)
+            send_packet(self, 2, str(pkt))
+            print '#### NOT Expecting 00:11:22:33:44:55 |', router_mac, '| 10.10.10.1 | 192.168.0.1 | @ ptf_intf 4'
+            verify_no_packet(self, exp_pkt, 3)
         finally:
             # unbind this ACL table from port1, port2, port3, port4 object id
             attr_value = sai_thrift_attribute_value_t(oid=SAI_NULL_OBJECT_ID)
@@ -1079,23 +1113,24 @@ class BindAclTableInGroupTest(sai_base_test.ThriftInterfaceDataPlane):
             self.client.sai_thrift_set_port_attribute(port1, attr)
             self.client.sai_thrift_set_port_attribute(port2, attr)
             self.client.sai_thrift_set_port_attribute(port3, attr)
-            self.client.sai_thrift_set_port_attribute(port4, attr)
             # cleanup ACL
             self.client.sai_thrift_remove_acl_table_group_member(acl_table_group_member_id1)
             self.client.sai_thrift_remove_acl_table_group_member(acl_table_group_member_id2)
+            self.client.sai_thrift_remove_acl_table_group_member(acl_table_group_member_id3)
             self.client.sai_thrift_remove_acl_entry(acl_entry_id1)
             self.client.sai_thrift_remove_acl_table(acl_table_id1)
             self.client.sai_thrift_remove_acl_entry(acl_entry_id2)
             self.client.sai_thrift_remove_acl_table(acl_table_id2)
+            self.client.sai_thrift_remove_acl_entry(acl_entry_id3)
+            self.client.sai_thrift_remove_acl_table(acl_table_id3)
             self.client.sai_thrift_remove_acl_table_group(acl_table_group_id)
             # cleanup
-            sai_thrift_remove_route(self.client, vr_id, addr_family, ip_addr1, ip_mask1, rif_id5)
+            sai_thrift_remove_route(self.client, vr_id, addr_family, ip_subnet1, ip_mask1, rif_id4)
             self.client.sai_thrift_remove_next_hop(nhop1)
-            sai_thrift_remove_neighbor(self.client, addr_family, rif_id5, ip_addr1, dmac1)
+            sai_thrift_remove_neighbor(self.client, addr_family, rif_id4, ip_addr1, dmac1)
 
             self.client.sai_thrift_remove_router_interface(rif_id1)
             self.client.sai_thrift_remove_router_interface(rif_id2)
             self.client.sai_thrift_remove_router_interface(rif_id3)
             self.client.sai_thrift_remove_router_interface(rif_id4)
-            self.client.sai_thrift_remove_router_interface(rif_id5)
             self.client.sai_thrift_remove_virtual_router(vr_id)


### PR DESCRIPTION
Update saiacl.BindAclTableInGroupTest to use 4 ports instead of 5 ports.
Fix some test errors.
Main contributor: @yakivh 
Reviewed by: @itaibaz and me. 