### PR TITLE
added p4_compiler submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "test/saithrift/ctypesgen"]
 	path = test/saithrift/ctypesgen
 	url = https://github.com/davidjamesca/ctypesgen
+[submodule "p4_compiler"]
+	path = p4_compiler
+	url = https://github.com/Mellanox/sai_p4_compiler.git


### PR DESCRIPTION
Added p4c backend p4_16 compiler for SAI target archtiecture.
This compiler autogenerates SAI headers based on p4_16 code.

