### PR TITLE
Fix failed to obtain bridge port type

### DIFF
--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -1802,8 +1802,7 @@ public:
       }
 
       attr[0].id = SAI_BRIDGE_PORT_ATTR_TYPE;
-      attr[1].id = SAI_BRIDGE_PORT_ATTR_BRIDGE_ID;
-      attr_count = 2;
+      attr_count = 1;
 
       status = bridge_api->get_bridge_port_attribute(bridge_port_id, attr_count, attr);
       if (status != SAI_STATUS_SUCCESS) {


### PR DESCRIPTION
Remove the arrtibute SAI_BRIDGE_PORT_ATTR_BRIDGE_ID when get bridge port type.

Signed-off-by: Chenchen Qi  chenchen.qcc@alibaba-inc.com