### PR TITLE
SAI Neighbor entry VRF leaking

### DIFF
--- a/inc/saineighbor.h
+++ b/inc/saineighbor.h
@@ -128,6 +128,13 @@ typedef struct _sai_neighbor_entry_t
     sai_object_id_t switch_id;
 
     /**
+     * @brief Virtual Router ID
+     *
+     * @objects SAI_OBJECT_TYPE_VIRTUAL_ROUTER
+     */
+    sai_object_id_t vr_id;
+
+    /**
      * @brief Router interface ID
      *
      * @objects SAI_OBJECT_TYPE_ROUTER_INTERFACE


### PR DESCRIPTION
Added virtual router id into sai_neighbor_entry_t structure to fit the VRF leaking use-case that needs to leak the neighbor entry learnt on a egress RIF from one VRF into another VRF context. Details discussed on the email forum.