### PR TITLE
Acl utilization

### DIFF
--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -1050,6 +1050,23 @@ typedef enum _sai_acl_table_attr_t
     SAI_ACL_TABLE_ATTR_CUSTOM_RANGE_START = 0x10000000,
 
     /**
+     * @brief Number of used entries for all pipes
+     *        1st entry in the list points to pipe-0,next points to pipe-1 and so on.
+     * @type sai_u32_list_t
+     * @flags READ_ONLY
+     */
+    SAI_ACL_TABLE_ATTR_USED_ACL_ENTRY_LIST,
+
+    /**
+     * @brief Number of free entry space available in
+     *        the current table for all pipes
+     *        1st entry in the list points to pipe-0,next points to pipe-1 and so on.
+     * @type sai_u32_list_t
+     * @flags READ_ONLY
+     */
+    SAI_ACL_TABLE_ATTR_AVAILABLE_ACL_ENTRY_LIST,
+
+    /**
      * @brief End of Custom range base
      */
     SAI_ACL_TABLE_ATTR_CUSTOM_RANGE_END
@@ -2249,6 +2266,70 @@ typedef enum _sai_acl_range_attr_t
 } sai_acl_range_attr_t;
 
 /**
+ * @brief Attribute Id for sai_acl_slice
+ *
+ * @flags Contains flags
+ */
+typedef enum _sai_acl_slice_attr_t
+{
+    /**
+     * @brief Table attributes start
+     */
+    SAI_ACL_SLICE_ATTR_RANGE_START,
+
+    /**
+     * @brief Get the ACL slice id
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_ACL_SLICE_ATTR_SLICE_ID,
+
+    /**
+     * @brief Get the ACL slice pipe id
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_ACL_SLICE_ATTR_SLICE_PIPE_ID,
+    /**
+     * @brief Get the ACL slice stage
+     * @type sai_acl_stage_t
+     * @flags READ_ONLY
+     */
+    SAI_ACL_SLICE_ATTR_ACL_STAGE,
+
+    /**
+     * @brief Get the object_id list of the ACL table present
+     *        in the current slice
+     * @type sai_object_list_t
+     * @flags READ_ONLY
+     * @objects SAI_OBJECT_TYPE_ACL_TABLE
+     * @default internal
+     */
+    SAI_ACL_SLICE_ATTR_ACL_TABLE_LIST,
+
+    /**
+     * @brief Number of entries used in the slice
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_ACL_SLICE_ATTR_USED_ACL_ENTRY,
+
+    /**
+     * @brief Number of free entry space available in
+     *        the current slice
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_ACL_SLICE_ATTR_AVAILABLE_ACL_ENTRY,
+
+    /**
+     * @brief End of ACL slice attributes
+     */
+    SAI_ACL_SLICE_ATTR_RANGE_END,
+
+} sai_acl_slice_attr_t;
+
+/**
  * @brief Create an ACL table
  *
  * @param[out] acl_table_id The ACL table id
@@ -2588,6 +2669,7 @@ typedef struct _sai_acl_api_t
     sai_remove_acl_table_group_member_fn        remove_acl_table_group_member;
     sai_set_acl_table_group_member_attribute_fn set_acl_table_group_member_attribute;
     sai_get_acl_table_group_member_attribute_fn get_acl_table_group_member_attribute;
+    sai_get_acl_slice_attribute_fn              get_acl_slice_attribute;
 } sai_acl_api_t;
 
 /**

--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -2275,7 +2275,7 @@ typedef enum _sai_acl_slice_attr_t
     /**
      * @brief Table attributes start
      */
-    SAI_ACL_SLICE_ATTR_RANGE_START,
+    SAI_ACL_SLICE_ATTR_START,
 
     /**
      * @brief Get the ACL slice id
@@ -2326,7 +2326,7 @@ typedef enum _sai_acl_slice_attr_t
     /**
      * @brief End of ACL slice attributes
      */
-    SAI_ACL_SLICE_ATTR_RANGE_END,
+    SAI_ACL_SLICE_ATTR_END,
 
 } sai_acl_slice_attr_t;
 

--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -2651,9 +2651,9 @@ typedef sai_status_t (*sai_get_acl_table_group_member_attribute_fn)(
  * @return #SAI_STATUS_SUCCESS on success, failure status code on error
  */
 typedef sai_status_t (*sai_get_acl_slice_attribute_fn)(
-        _In_ sai_object_id_t acl_entry_id,
+        _In_ sai_object_id_t acl_slice_id,
         _In_ uint32_t attr_count,
-        _Out_ sai_attribute_t *attr_list);
+        _Inout_ sai_attribute_t *attr_list);
 
 /**
  * @brief Port methods table retrieved with sai_api_query()

--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -2290,7 +2290,7 @@ typedef enum _sai_acl_slice_attr_t
      * @flags READ_ONLY
      */
     SAI_ACL_SLICE_ATTR_SLICE_PIPE_ID,
-    
+
     /**
      * @brief Get the ACL slice stage
      * @type sai_acl_stage_t

--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -2642,6 +2642,20 @@ typedef sai_status_t (*sai_get_acl_table_group_member_attribute_fn)(
         _Inout_ sai_attribute_t *attr_list);
 
 /**
+ * @brief Get ACL slice attribute
+ *
+ * @param[in] sai_object_id_t SAI ACL slice object id
+ * @param[in] attr_count Number of attributes
+ * @param[out] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_acl_slice_attribute_fn)(
+        _In_ sai_object_id_t acl_entry_id,
+        _In_ uint32_t attr_count,
+        _Out_ sai_attribute_t *attr_list);
+
+/**
  * @brief Port methods table retrieved with sai_api_query()
  */
 typedef struct _sai_acl_api_t

--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -2644,7 +2644,7 @@ typedef sai_status_t (*sai_get_acl_table_group_member_attribute_fn)(
 /**
  * @brief Get ACL slice attribute
  *
- * @param[in] sai_object_id_t SAI ACL slice object id
+ * @param[in] acl_slice_id ACL slice id
  * @param[in] attr_count Number of attributes
  * @param[inout] attr_list Array of attributes
  *

--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -2646,7 +2646,7 @@ typedef sai_status_t (*sai_get_acl_table_group_member_attribute_fn)(
  *
  * @param[in] sai_object_id_t SAI ACL slice object id
  * @param[in] attr_count Number of attributes
- * @param[out] attr_list Array of attributes
+ * @param[inout] attr_list Array of attributes
  *
  * @return #SAI_STATUS_SUCCESS on success, failure status code on error
  */

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -1684,6 +1684,16 @@ typedef enum _sai_switch_attr_t
     /** Custom range base value */
     SAI_SWITCH_ATTR_CUSTOM_RANGE_START = 0x10000000,
 
+    /**
+     * @brief Get the ACL slice list
+     *
+     * @type sai_object_list_t
+     * @flags READ_ONLY
+     * @objects SAI_OBJECT_TYPE_ACL_SLICE
+     * @default internal
+     */
+    SAI_SWITCH_ATTR_ACL_SLICE_LIST,
+
     /** End of custom range base */
     SAI_SWITCH_ATTR_CUSTOM_RANGE_END
 

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -252,7 +252,8 @@ typedef enum _sai_object_type_t
     SAI_OBJECT_TYPE_BFD_SESSION              = 75,
     SAI_OBJECT_TYPE_ISOLATION_GROUP          = 76,
     SAI_OBJECT_TYPE_ISOLATION_GROUP_MEMBER   = 77,
-    SAI_OBJECT_TYPE_MAX                      = 78,
+    SAI_OBJECT_TYPE_ACL_SLICE                = 78,
+    SAI_OBJECT_TYPE_MAX                      = 79,
 } sai_object_type_t;
 
 typedef struct _sai_u8_list_t


### PR DESCRIPTION
Added following ACL table attributes,

SAI_ACL_TABLE_ATTR_USED_ACL_ENTRY_LIST - Number of used entries in the ACL table. Its defined as list to account number of used entries in all pipes corresponding to the same ACL table.
SAI_ACL_TABLE_ATTR_AVAILABLE_ACL_ENTRY_LIST - Number of free entries in the ACL table. Its defined as list to account number of free entries in all pipes corresponding to the same ACL table.
Added following ACL SLICE related attributes,

SAI_ACL_SLICE_ATTR_SLICE_ID - Slice number of the ACL hardware slice.
SAI_ACL_SLICE_ATTR_SLICE_PIPE_ID - Pipe number in which this ACL hardware slice is present.
SAI_ACL_SLICE_ATTR_SLICE_STAGE - Stage (INGRESS/EGRESS).
SAI_ACL_SLICE_ATTR_ACL_TABLE_LIST - Object ID of the ACL table present in this hardware slice.
SAI_ACL_SLICE_ATTR_USED_ACL_ENTRY - Number of entries used in the current hardware slice.
6)SAI_ACL_SLICE_ATTR_AVAILABLE_ACL_ENTRY - Number of free entry space available in the current hardware slice.
Added following switch attribute,

SAI_SWITCH_ATTR_ACL_SLICE_LIST - Object ID of all hardware ACL slices present.

SAI_OBJECT_TYPE_ACL_SLICE - Added new object for ACL hardware slices.