### PR TITLE
Add attribute bridge id for router interface of type SAI_ROUTER_INTERFACE_TYPE_BRIDGE

### DIFF
--- a/inc/sairouterinterface.h
+++ b/inc/sairouterinterface.h
@@ -130,6 +130,16 @@ typedef enum _sai_router_interface_attr_t
      */
     SAI_ROUTER_INTERFACE_ATTR_INNER_VLAN_ID,
 
+    /**
+     * @brief Associated 1D Bridge
+     *
+     * @type sai_object_id_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @objects SAI_OBJECT_TYPE_BRIDGE
+     * @condition SAI_ROUTER_INTERFACE_ATTR_TYPE == SAI_ROUTER_INTERFACE_TYPE_BRIDGE
+     */
+    SAI_ROUTER_INTERFACE_ATTR_BRIDGE_ID,
+
     /* READ-WRITE */
 
     /**


### PR DESCRIPTION
This pull request adds the bridge id attribute for router interface of type SAI_ROUTER_INTERFACE_TYPE_BRIDGE. This is similar to VLAN id which is needed when the router interface is of type SAI_ROUTER_INTERFACE_TYPE_VLAN.

Motivation for this pull request:

a)  A bridge router interface can be connected only to one bridge. Adding bridge id
     attribute in bridge router interface would ensure that a bridge router interface can be
     connected only one bridge. If this attribute is not present, the bridge router interface can be
     connected to multiple bridges  which is invalid.

b)  All the router interfaces type have a key which need to be given during creation. 
     Example: For VLAN router interface, VLAN object ID is the key.
                    For Port router interface, Port/LAG object ID is the key.
    However for bridge router interface, currently there is no key.  So  
    bridge id is added as a key attribute for bridge router interface.
    This makes creation of all router interface types consistent.
