### PR TITLE
SAI Get Stats function counter_id data-type

### DIFF
--- a/inc/saibfd.h
+++ b/inc/saibfd.h
@@ -510,7 +510,7 @@ typedef sai_status_t (*sai_get_bfd_session_attribute_fn)(
 typedef sai_status_t (*sai_get_bfd_session_stats_fn)(
         _In_ sai_object_id_t bfd_session_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_bfd_session_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _Out_ uint64_t *counters);
 
 /**
@@ -527,7 +527,7 @@ typedef sai_status_t (*sai_get_bfd_session_stats_fn)(
 typedef sai_status_t (*sai_get_bfd_session_stats_ext_fn)(
         _In_ sai_object_id_t bfd_session_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_bfd_session_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
@@ -543,7 +543,7 @@ typedef sai_status_t (*sai_get_bfd_session_stats_ext_fn)(
 typedef sai_status_t (*sai_clear_bfd_session_stats_fn)(
         _In_ sai_object_id_t bfd_session_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_bfd_session_stat_t *counter_ids);
+        _In_ const sai_stat_id_t *counter_ids);
 
 /**
  * @brief BFD session state change notification

--- a/inc/saibridge.h
+++ b/inc/saibridge.h
@@ -357,7 +357,7 @@ typedef sai_status_t (*sai_get_bridge_port_attribute_fn)(
 typedef sai_status_t (*sai_get_bridge_port_stats_fn)(
         _In_ sai_object_id_t bridge_port_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_bridge_port_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _Out_ uint64_t *counters);
 
 /**
@@ -374,7 +374,7 @@ typedef sai_status_t (*sai_get_bridge_port_stats_fn)(
 typedef sai_status_t (*sai_get_bridge_port_stats_ext_fn)(
         _In_ sai_object_id_t bridge_port_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_bridge_port_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
@@ -390,7 +390,7 @@ typedef sai_status_t (*sai_get_bridge_port_stats_ext_fn)(
 typedef sai_status_t (*sai_clear_bridge_port_stats_fn)(
         _In_ sai_object_id_t bridge_port_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_bridge_port_stat_t *counter_ids);
+        _In_ const sai_stat_id_t *counter_ids);
 
 /**
  * @brief Attribute data for #SAI_BRIDGE_ATTR_TYPE
@@ -653,7 +653,7 @@ typedef sai_status_t (*sai_get_bridge_attribute_fn)(
 typedef sai_status_t (*sai_get_bridge_stats_fn)(
         _In_ sai_object_id_t bridge_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_bridge_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _Out_ uint64_t *counters);
 
 /**
@@ -670,7 +670,7 @@ typedef sai_status_t (*sai_get_bridge_stats_fn)(
 typedef sai_status_t (*sai_get_bridge_stats_ext_fn)(
         _In_ sai_object_id_t bridge_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_bridge_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
@@ -686,7 +686,7 @@ typedef sai_status_t (*sai_get_bridge_stats_ext_fn)(
 typedef sai_status_t (*sai_clear_bridge_stats_fn)(
         _In_ sai_object_id_t bridge_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_bridge_stat_t *counter_ids);
+        _In_ const sai_stat_id_t *counter_ids);
 
 /**
  * @brief Bridge methods table retrieved with sai_api_query()

--- a/inc/saibuffer.h
+++ b/inc/saibuffer.h
@@ -188,7 +188,7 @@ typedef sai_status_t (*sai_get_ingress_priority_group_attribute_fn)(
 typedef sai_status_t (*sai_get_ingress_priority_group_stats_fn)(
         _In_ sai_object_id_t ingress_priority_group_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_ingress_priority_group_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _Out_ uint64_t *counters);
 
 /**
@@ -205,7 +205,7 @@ typedef sai_status_t (*sai_get_ingress_priority_group_stats_fn)(
 typedef sai_status_t (*sai_get_ingress_priority_group_stats_ext_fn)(
         _In_ sai_object_id_t ingress_priority_group_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_ingress_priority_group_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
@@ -221,7 +221,7 @@ typedef sai_status_t (*sai_get_ingress_priority_group_stats_ext_fn)(
 typedef sai_status_t (*sai_clear_ingress_priority_group_stats_fn)(
         _In_ sai_object_id_t ingress_priority_group_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_ingress_priority_group_stat_t *counter_ids);
+        _In_ const sai_stat_id_t *counter_ids);
 
 /**
  * @brief Enum defining buffer pool types.
@@ -467,7 +467,7 @@ typedef sai_status_t (*sai_get_buffer_pool_attribute_fn)(
 typedef sai_status_t (*sai_get_buffer_pool_stats_fn)(
         _In_ sai_object_id_t buffer_pool_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_buffer_pool_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _Out_ uint64_t *counters);
 
 /**
@@ -484,7 +484,7 @@ typedef sai_status_t (*sai_get_buffer_pool_stats_fn)(
 typedef sai_status_t (*sai_get_buffer_pool_stats_ext_fn)(
         _In_ sai_object_id_t buffer_pool_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_buffer_pool_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
@@ -500,7 +500,7 @@ typedef sai_status_t (*sai_get_buffer_pool_stats_ext_fn)(
 typedef sai_status_t (*sai_clear_buffer_pool_stats_fn)(
         _In_ sai_object_id_t buffer_pool_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_buffer_pool_stat_t *counter_ids);
+        _In_ const sai_stat_id_t *counter_ids);
 
 /**
  * @brief Enum defining buffer profile threshold modes

--- a/inc/saipolicer.h
+++ b/inc/saipolicer.h
@@ -312,7 +312,7 @@ typedef sai_status_t (*sai_get_policer_attribute_fn)(
 typedef sai_status_t (*sai_get_policer_stats_fn)(
         _In_ sai_object_id_t policer_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_policer_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _Out_ uint64_t *counters);
 
 /**
@@ -329,7 +329,7 @@ typedef sai_status_t (*sai_get_policer_stats_fn)(
 typedef sai_status_t (*sai_get_policer_stats_ext_fn)(
         _In_ sai_object_id_t policer_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_policer_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
@@ -345,7 +345,7 @@ typedef sai_status_t (*sai_get_policer_stats_ext_fn)(
 typedef sai_status_t (*sai_clear_policer_stats_fn)(
         _In_ sai_object_id_t policer_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_policer_stat_t *counter_ids);
+        _In_ const sai_stat_id_t *counter_ids);
 
 /**
  * @brief Policer methods table retrieved with sai_api_query()

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -1707,7 +1707,7 @@ typedef sai_status_t (*sai_get_port_attribute_fn)(
 typedef sai_status_t (*sai_get_port_stats_fn)(
         _In_ sai_object_id_t port_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_port_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _Out_ uint64_t *counters);
 
 /**
@@ -1724,7 +1724,7 @@ typedef sai_status_t (*sai_get_port_stats_fn)(
 typedef sai_status_t (*sai_get_port_stats_ext_fn)(
         _In_ sai_object_id_t port_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_port_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
@@ -1740,7 +1740,7 @@ typedef sai_status_t (*sai_get_port_stats_ext_fn)(
 typedef sai_status_t (*sai_clear_port_stats_fn)(
         _In_ sai_object_id_t port_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_port_stat_t *counter_ids);
+        _In_ const sai_stat_id_t *counter_ids);
 
 /**
  * @brief Clear port's all statistics counters.

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -1963,7 +1963,7 @@ typedef sai_status_t (*sai_get_port_pool_attribute_fn)(
 typedef sai_status_t (*sai_get_port_pool_stats_fn)(
         _In_ sai_object_id_t port_pool_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_port_pool_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _Out_ uint64_t *counters);
 
 /**
@@ -1980,7 +1980,7 @@ typedef sai_status_t (*sai_get_port_pool_stats_fn)(
 typedef sai_status_t (*sai_get_port_pool_stats_ext_fn)(
         _In_ sai_object_id_t port_pool_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_port_pool_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
@@ -1996,7 +1996,7 @@ typedef sai_status_t (*sai_get_port_pool_stats_ext_fn)(
 typedef sai_status_t (*sai_clear_port_pool_stats_fn)(
         _In_ sai_object_id_t port_pool_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_port_pool_stat_t *counter_ids);
+        _In_ const sai_stat_id_t *counter_ids);
 
 /**
  * @brief Port methods table retrieved with sai_api_query()

--- a/inc/saiqueue.h
+++ b/inc/saiqueue.h
@@ -412,7 +412,7 @@ typedef sai_status_t (*sai_get_queue_attribute_fn)(
 typedef sai_status_t (*sai_get_queue_stats_fn)(
         _In_ sai_object_id_t queue_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_queue_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _Out_ uint64_t *counters);
 
 /**
@@ -429,7 +429,7 @@ typedef sai_status_t (*sai_get_queue_stats_fn)(
 typedef sai_status_t (*sai_get_queue_stats_ext_fn)(
         _In_ sai_object_id_t queue_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_queue_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
@@ -445,7 +445,7 @@ typedef sai_status_t (*sai_get_queue_stats_ext_fn)(
 typedef sai_status_t (*sai_clear_queue_stats_fn)(
         _In_ sai_object_id_t queue_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_queue_stat_t *counter_ids);
+        _In_ const sai_stat_id_t *counter_ids);
 
 /**
  * @brief Queue PFC deadlock event notification

--- a/inc/sairouterinterface.h
+++ b/inc/sairouterinterface.h
@@ -367,7 +367,7 @@ typedef sai_status_t (*sai_get_router_interface_attribute_fn)(
 typedef sai_status_t (*sai_get_router_interface_stats_fn)(
         _In_ sai_object_id_t router_interface_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_router_interface_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _Out_ uint64_t *counters);
 
 /**
@@ -384,7 +384,7 @@ typedef sai_status_t (*sai_get_router_interface_stats_fn)(
 typedef sai_status_t (*sai_get_router_interface_stats_ext_fn)(
         _In_ sai_object_id_t router_interface_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_router_interface_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
@@ -400,7 +400,7 @@ typedef sai_status_t (*sai_get_router_interface_stats_ext_fn)(
 typedef sai_status_t (*sai_clear_router_interface_stats_fn)(
         _In_ sai_object_id_t router_interface_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_router_interface_stat_t *counter_ids);
+        _In_ const sai_stat_id_t *counter_ids);
 
 /**
  * @brief Routing interface methods table retrieved with sai_api_query()

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -703,7 +703,7 @@ typedef sai_status_t (*sai_get_tunnel_attribute_fn)(
 typedef sai_status_t (*sai_get_tunnel_stats_fn)(
         _In_ sai_object_id_t tunnel_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_tunnel_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _Out_ uint64_t *counters);
 
 /**
@@ -720,7 +720,7 @@ typedef sai_status_t (*sai_get_tunnel_stats_fn)(
 typedef sai_status_t (*sai_get_tunnel_stats_ext_fn)(
         _In_ sai_object_id_t tunnel_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_tunnel_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
@@ -736,7 +736,7 @@ typedef sai_status_t (*sai_get_tunnel_stats_ext_fn)(
 typedef sai_status_t (*sai_clear_tunnel_stats_fn)(
         _In_ sai_object_id_t tunnel_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_tunnel_stat_t *counter_ids);
+        _In_ const sai_stat_id_t *counter_ids);
 
 /**
  * @brief Defines tunnel termination table entry type

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -55,6 +55,7 @@ typedef UINT32  sai_ip4_t;
 typedef UINT8   sai_ip6_t[16];
 typedef UINT32  sai_switch_hash_seed_t;
 typedef UINT32  sai_label_id_t;
+typedef UINT32  sai_stat_id_t;
 
 #include <ws2def.h>
 #include <ws2ipdef.h>
@@ -94,6 +95,7 @@ typedef uint32_t sai_ip4_t;
 typedef uint8_t  sai_ip6_t[16];
 typedef uint32_t sai_switch_hash_seed_t;
 typedef uint32_t sai_label_id_t;
+typedef uint32_t sai_stat_id_t;
 
 #define _In_
 #define _Out_

--- a/inc/saiuburst.h
+++ b/inc/saiuburst.h
@@ -383,7 +383,7 @@ typedef sai_status_t (*sai_get_tam_histogram_attribute_fn)(
 typedef sai_status_t (*sai_get_tam_histogram_stats_fn)(
         _In_ sai_object_id_t tam_histogram_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_tam_microburst_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _Out_ uint64_t *counters);
 
 typedef struct _sai_uburst_api_t

--- a/inc/saivlan.h
+++ b/inc/saivlan.h
@@ -582,7 +582,7 @@ typedef sai_status_t (*sai_get_vlan_member_attribute_fn)(
 typedef sai_status_t (*sai_get_vlan_stats_fn)(
         _In_ sai_object_id_t vlan_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_vlan_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _Out_ uint64_t *counters);
 
 /**
@@ -599,7 +599,7 @@ typedef sai_status_t (*sai_get_vlan_stats_fn)(
 typedef sai_status_t (*sai_get_vlan_stats_ext_fn)(
         _In_ sai_object_id_t vlan_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_vlan_stat_t *counter_ids,
+        _In_ const sai_stat_id_t *counter_ids,
         _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters);
 
@@ -615,7 +615,7 @@ typedef sai_status_t (*sai_get_vlan_stats_ext_fn)(
 typedef sai_status_t (*sai_clear_vlan_stats_fn)(
         _In_ sai_object_id_t vlan_id,
         _In_ uint32_t number_of_counters,
-        _In_ const sai_vlan_stat_t *counter_ids);
+        _In_ const sai_stat_id_t *counter_ids);
 
 /**
  * @brief VLAN methods table retrieved with sai_api_query()


### PR DESCRIPTION
This commit is to use a common data type for all the SAI Stat Get APIs (sai_get_xxxx_stats_ext_fn) uniformly. Updated just the SAI Port Stat Get API to discuss this first in the community. 
Will update the same for other SAI objects after the discussion.