### PR TITLE
NH Attribute IP is applicable for NH Type MPLS and TUNNEL Encaps

### DIFF
--- a/inc/sainexthop.h
+++ b/inc/sainexthop.h
@@ -125,7 +125,7 @@ typedef enum _sai_next_hop_attr_t
      *
      * @type sai_ip_address_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
-     * @condition SAI_NEXT_HOP_ATTR_TYPE == SAI_NEXT_HOP_TYPE_IP
+     * @condition SAI_NEXT_HOP_ATTR_TYPE == SAI_NEXT_HOP_TYPE_IP or SAI_NEXT_HOP_ATTR_TYPE == SAI_NEXT_HOP_TYPE_MPLS or SAI_NEXT_HOP_ATTR_TYPE == SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP
      */
     SAI_NEXT_HOP_ATTR_IP,
 


### PR DESCRIPTION
Modified the condition to accept Tunnel Encap and MPLS Nexthop types. 