### PR TITLE
Change SAI_MIRROR_SESSION_ATTR_VLAN_HEADER_VALID to CREATE_AND_SET

### DIFF
--- a/inc/saimirror.h
+++ b/inc/saimirror.h
@@ -162,9 +162,10 @@ typedef enum _sai_mirror_session_attr_t
      * Valid for RSPAN or ERSPAN with valid Vlan header.
      *
      * @type sai_uint16_t
-     * @flags MANDATORY_ON_CREATE | CREATE_AND_SET
+     * @flags CREATE_AND_SET
      * @isvlan true
-     * @condition SAI_MIRROR_SESSION_ATTR_VLAN_HEADER_VALID == true or SAI_MIRROR_SESSION_ATTR_TYPE == SAI_MIRROR_SESSION_TYPE_REMOTE
+     * @default 0
+     * @validonly SAI_MIRROR_SESSION_ATTR_VLAN_HEADER_VALID == true or SAI_MIRROR_SESSION_ATTR_TYPE == SAI_MIRROR_SESSION_TYPE_REMOTE
      */
     SAI_MIRROR_SESSION_ATTR_VLAN_ID,
 
@@ -201,7 +202,7 @@ typedef enum _sai_mirror_session_attr_t
      * @brief Vlan header valid
      *
      * @type bool
-     * @flags CREATE_ONLY
+     * @flags CREATE_AND_SET
      * @default false
      * @validonly SAI_MIRROR_SESSION_ATTR_TYPE == SAI_MIRROR_SESSION_TYPE_ENHANCED_REMOTE
      */


### PR DESCRIPTION
This attribute can be modified because the destination could be
updated to either within a VLAN or not.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>