### PR TITLE
Add SAI_OBJECT_TYPE_LAG match for entry field IN_PORTS/OUT_PORTS

### DIFF
--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -1208,7 +1208,7 @@ typedef enum _sai_acl_entry_attr_t
      *
      * @type sai_acl_field_data_t sai_object_list_t
      * @flags CREATE_AND_SET
-     * @objects SAI_OBJECT_TYPE_PORT
+     * @objects SAI_OBJECT_TYPE_PORT, SAI_OBJECT_TYPE_LAG
      * @default disabled
      */
     SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS,
@@ -1218,7 +1218,7 @@ typedef enum _sai_acl_entry_attr_t
      *
      * @type sai_acl_field_data_t sai_object_list_t
      * @flags CREATE_AND_SET
-     * @objects SAI_OBJECT_TYPE_PORT
+     * @objects SAI_OBJECT_TYPE_PORT, SAI_OBJECT_TYPE_LAG
      * @default disabled
      */
     SAI_ACL_ENTRY_ATTR_FIELD_OUT_PORTS,


### PR DESCRIPTION
Right now only SAI_ACL_ENTRY_ATTR_FIELD_IN_PORT and
SAI_ACL_ENTRY_ATTR_FIELD_OUT_PORT support SAI_OBJECT_TYPE_LAG. This
It is desired to have IN_PORTS and OUT_PORTS to match a specific list
of ports and/or LAGs.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>