### PR TITLE
add oper speed

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -412,6 +412,9 @@ typedef enum _sai_port_attr_t
     /**
      * @brief Operational speed in Mbps
      *
+     * If port is down, the returned value should be zero.
+     * If auto negotiation is on, the returned value should be the negotiated speed.
+     *
      * @type sai_uint32_t
      * @flags READ_ONLY
      */

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -409,6 +409,14 @@ typedef enum _sai_port_attr_t
      */
     SAI_PORT_ATTR_EYE_VALUES,
 
+    /**
+     * @brief Operational speed in Mbps
+     *
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_PORT_ATTR_OPER_SPEED,
+
     /* READ-WRITE */
 
     /**
@@ -421,6 +429,8 @@ typedef enum _sai_port_attr_t
 
     /**
      * @brief Speed in Mbps
+     *
+     * On get, returns the configured port speed.
      *
      * @type sai_uint32_t
      * @flags MANDATORY_ON_CREATE | CREATE_AND_SET


### PR DESCRIPTION
Current port speed attribute means configured speed
Added new read only attribute for operational speed, which is the actual speed the port is working, depending on configuration, peer, cable, and can be zero if port is down.