### PR TITLE
SAI Port attributes for preemphasis setting

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -1140,7 +1140,7 @@ typedef enum _sai_port_attr_t
      *
      * @type sai_u32_list_t
      * @flags CREATE_AND_SET
-     * @default empty
+     * @default internal
      */
     SAI_PORT_ATTR_SERDES_PREEMPHASIS,
 
@@ -1153,7 +1153,7 @@ typedef enum _sai_port_attr_t
      *
      * @type sai_u32_list_t
      * @flags CREATE_AND_SET
-     * @default empty
+     * @default internal
      */
     SAI_PORT_ATTR_SERDES_IDRIVER,
 
@@ -1166,7 +1166,7 @@ typedef enum _sai_port_attr_t
      *
      * @type sai_u32_list_t
      * @flags CREATE_AND_SET
-     * @default empty
+     * @default internal
      */
     SAI_PORT_ATTR_SERDES_IPREDRIVER,
 

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -1132,6 +1132,45 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_PKT_TX_ENABLE,
 
     /**
+     * @brief Port serdes control pre-emphasis
+     *
+     * List of port serdes pre-emphasis values. The values are of type sai_u32_list_t
+     * where the count is number lanes in a port and the list specifies list of values
+     * to be applied to each lane.
+     *
+     * @type sai_u32_list_t
+     * @flags CREATE_AND_SET
+     * @default empty
+     */
+    SAI_PORT_ATTR_SERDES_PREEMPHASIS,
+
+    /**
+     * @brief Port serdes control idriver
+     *
+     * List of port serdes idriver values. The values are of type sai_u32_list_t
+     * where the count is number lanes in a port and the list specifies list of values
+     * to be applied to each lane.
+     *
+     * @type sai_u32_list_t
+     * @flags CREATE_AND_SET
+     * @default empty
+     */
+    SAI_PORT_ATTR_SERDES_IDRIVER,
+
+    /**
+     * @brief Port serdes control ipredriver
+     *
+     * List of port serdes ipredriver values. The values are of type sai_u32_list_t
+     * where the count is number lanes in a port and the list specifies list of values
+     * to be applied to each lane.
+     *
+     * @type sai_u32_list_t
+     * @flags CREATE_AND_SET
+     * @default empty
+     */
+    SAI_PORT_ATTR_SERDES_IPREDRIVER,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_ATTR_END,

--- a/meta/aspell.en.pws
+++ b/meta/aspell.en.pws
@@ -131,3 +131,6 @@ watchlist
 wildcard
 www
 pre
+serdes
+idriver
+ipredriver


### PR DESCRIPTION
Defined SAI Port attributes for setting preemphasis and other serdes driver settings