### PR TITLE
Adding SAI PTF scripts for Extended testcases

### DIFF
--- a/test/saithrift/src/switch_sai.thrift
+++ b/test/saithrift/src/switch_sai.thrift
@@ -278,6 +278,7 @@ service switch_sai_rpc {
     //neighbor API
     sai_thrift_status_t sai_thrift_create_neighbor_entry(1: sai_thrift_neighbor_entry_t thrift_neighbor_entry, 2: list<sai_thrift_attribute_t> thrift_attr_list);
     sai_thrift_status_t sai_thrift_remove_neighbor_entry(1: sai_thrift_neighbor_entry_t thrift_neighbor_entry);
+    sai_thrift_status_t sai_thrift_set_neighbor_entry_attribute(1: sai_thrift_neighbor_entry_t thrift_neighbor_entry, 2: list<sai_thrift_attribute_t> thrift_attr);
 
     //switch API
     sai_thrift_attribute_list_t sai_thrift_get_switch_attribute();

--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -403,6 +403,7 @@ public:
                   break;
               case SAI_ROUTER_INTERFACE_ATTR_INGRESS_ACL:
                   attr_list[i].value.oid = attribute.value.oid;
+                  break;
               case SAI_ROUTER_INTERFACE_ATTR_MTU:
                   attr_list[i].value.u32 = attribute.value.u32;
                   break;

--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -291,6 +291,9 @@ public:
               case SAI_PORT_ATTR_INGRESS_ACL:
                   attr_list[i].value.oid = attribute.value.oid;
                   break;
+              case SAI_PORT_ATTR_MTU:
+                  attr_list[i].value.u32 = attribute.value.u32;
+                  break;
               default:
                   break;
           }
@@ -400,6 +403,9 @@ public:
                   break;
               case SAI_ROUTER_INTERFACE_ATTR_INGRESS_ACL:
                   attr_list[i].value.oid = attribute.value.oid;
+              case SAI_ROUTER_INTERFACE_ATTR_MTU:
+                  attr_list[i].value.u32 = attribute.value.u32;
+                  break;
               default:
                   break;
           }
@@ -1338,6 +1344,23 @@ public:
       }
       sai_thrift_parse_neighbor_entry(thrift_neighbor_entry, &neighbor_entry);
       status = neighbor_api->remove_neighbor_entry(&neighbor_entry);
+      return status;
+  }
+
+  sai_thrift_status_t sai_thrift_set_neighbor_entry_attribute(const sai_thrift_neighbor_entry_t& thrift_neighbor_entry, const std::vector<sai_thrift_attribute_t> & thrift_attr) {
+      printf("sai_thrift_set_neighbor_entry_attribute\n");
+      sai_status_t status = SAI_STATUS_SUCCESS;
+      sai_neighbor_api_t *neighbor_api;
+      status = sai_api_query(SAI_API_NEIGHBOR, (void **) &neighbor_api);
+      sai_neighbor_entry_t neighbor_entry;
+      if (status != SAI_STATUS_SUCCESS) {
+          return status;
+      }
+      sai_thrift_parse_neighbor_entry(thrift_neighbor_entry, &neighbor_entry);
+      sai_attribute_t *attr= (sai_attribute_t *) malloc(sizeof(sai_attribute_t) * thrift_attr.size());
+      sai_thrift_parse_neighbor_attributes(thrift_attr, attr);
+      status = neighbor_api->set_neighbor_entry_attribute(&neighbor_entry, attr);
+      free(attr);
       return status;
   }
 
@@ -3088,6 +3111,16 @@ public:
       thrift_port_status.id = SAI_PORT_ATTR_OPER_STATUS;
       thrift_port_status.value.s32 =  port_oper_status_attribute.value.s32;
       attr_list.push_back(thrift_port_status);
+
+      sai_attribute_t port_mtu_status_attribute;
+      sai_thrift_attribute_t thrift_port_mtu;
+      port_mtu_status_attribute.id = SAI_PORT_ATTR_MTU;
+      port_api->get_port_attribute(port_id, 1, &port_mtu_status_attribute);
+
+      thrift_attr_list.attr_count = 6;
+      thrift_port_mtu.id = SAI_PORT_ATTR_MTU;
+      thrift_port_mtu.value.u32 =  port_mtu_status_attribute.value.u32;
+      attr_list.push_back(thrift_port_mtu);
   }
 
   void sai_thrift_get_queue_stats(std::vector<int64_t> & thrift_counters,

--- a/test/saithrift/tests/sail2.py
+++ b/test/saithrift/tests/sail2.py
@@ -959,7 +959,7 @@ class L2MacMoveTestI (sai_base_test.ThriftInterfaceDataPlane):
             ### Sending packet from Port1
             send_packet(self, 0, str(pkt1))
 
-            ### verify the packet @ Port2
+            ### verify the packet @ Port2 and Port3
             verify_packets(self, exp_pkt1, [1, 2])
 
             ### Sending packet from Port2
@@ -973,10 +973,10 @@ class L2MacMoveTestI (sai_base_test.ThriftInterfaceDataPlane):
             ### Sending packet from Port1
             send_packet(self, 0, str(pkt1))
 
-            ### verify the packet @ Port3
+            ### verify the packet @ Port2
             verify_packets(self, exp_pkt1, [1])
 
-            ### verify the packet @ Port3
+            ### verify no packet @ Port3
             verify_no_packet(self, exp_pkt1, 2)
 
             time.sleep(1)
@@ -992,7 +992,7 @@ class L2MacMoveTestI (sai_base_test.ThriftInterfaceDataPlane):
             ### Send packet (src_mac=MAC1 and dst_mac=MAC2) from port 1
             send_packet(self, 0, str(pkt1))
 
-            ### verify the packet @ Port3 & Port2
+            ### verify the packet @ Port3 & no packet @ Port2
             verify_packets(self, exp_pkt1, [2])
             verify_no_packet(self, exp_pkt1, 1)
 
@@ -1026,12 +1026,12 @@ class L2MacMoveTestII (sai_base_test.ThriftInterfaceDataPlane):
         forwarding and ensure that traffic is now forwarded to the newly learnt port.
 
         Steps:
-        1. Create VLAN 10 and associate 2 untagged ports (port 1,2) as the member port of VLAN 10.
-        2. Set attribute value of "Port VLAN ID 10" for the ports 1, 2
+        1. Create VLAN 10 and associate 3 untagged ports (port 1,2,3) as the member port of VLAN 10.
+        2. Set attribute value of "Port VLAN ID 10" for the ports 1,2,3
         3. Create Virtual router V1 and enable V4.
         4. Create  virtual router interfaces and set the interface type as VLAN for VLAN 10
-           and create one more port3 (RIF Id2).
-        5. Create IPv6 neighbor entry with MAC1 and asociate with "RIF Id1".
+           and create one more port4 (RIF Id2).
+        5. Create IPv4 neighbor entry with MAC1 and asociate with "RIF Id1".
         6. Send test packet from port 1 with src_mac = MAC1 address.
         7. Send IP packet from port 3 with dst_mac= MAC1 and observe traffic forwarding to port 1.
         8. Send IP packet from port 2 with src_mac = MAC1 and verify the FDB entry, which have learnt via Port 2.
@@ -1080,7 +1080,7 @@ class L2MacMoveTestII (sai_base_test.ThriftInterfaceDataPlane):
         rif_id1 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_VLAN, 0, vlan_oid, v4_enabled, v6_enabled, mac)
         rif_id2 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_PORT, port4, 0, v4_enabled, v6_enabled, mac)
 
-        ### create neighbor and next hop
+        ### create neighbor
         sai_thrift_create_neighbor(self.client, addr_family, rif_id1, ip_addr1, dmac1)
 
         try:
@@ -1118,7 +1118,7 @@ class L2MacMoveTestII (sai_base_test.ThriftInterfaceDataPlane):
             ### Send test packet from port 1 with src_mac = MAC1 address.
             send_packet(self, 0, str(pkt1))
 
-            ### Verifying the traffic received @ Port2
+            ### Verifying the traffic received @ Port2 and Port3
             verify_packets(self, exp_pkt1, [1 ,2])
 
             time.sleep(1)
@@ -1134,7 +1134,7 @@ class L2MacMoveTestII (sai_base_test.ThriftInterfaceDataPlane):
             ### Send IP packet from port 2 with src_mac = MAC1 and verify the FDB entry.
             send_packet(self, 1, str(pkt1))
 
-            ### Verifying the traffic @ Port3
+            ### Verifying the traffic @ Port1 and Port3
             verify_packets(self, exp_pkt1, [0, 2])
 
             time.sleep(1)
@@ -1185,9 +1185,9 @@ class L2MacMoveTestIII (sai_base_test.ThriftInterfaceDataPlane):
         Steps:
         1. Create VLAN 10 and associate 3 untagged ports (port 1,2,3) as the member port of VLAN 10.
         2. Set attribute value of "Port VLAN ID 10" for the ports 1, 2, 3
-        3. Create Virtual router V1 and enable V4.
+        3. Create Virtual router V1 and enable V6.
         4. Create  virtual router interfaces and set the interface type as VLAN
-        5. Create IPv4 neighbor entry with MAC1 and asociate with "RIF Id1".
+        5. Create IPv6 neighbor entry with MAC1 and asociate with "RIF Id1".
         6. Send test packet from port 1 with src_mac = MAC1 address.
         7. Send IP packet from port 3 with dst_mac= MAC1 and observe traffic forwarding to port 1.
         8. Send IP packet from port 2 with src_mac = MAC1 and verify the FDB entry.
@@ -1238,7 +1238,7 @@ class L2MacMoveTestIII (sai_base_test.ThriftInterfaceDataPlane):
         rif_id1 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_VLAN, 0, vlan_oid, v4_enabled, v6_enabled, mac)
         rif_id2 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_PORT, port4, 0, v4_enabled, v6_enabled, mac)
 
-        ### create neighbor and next hop
+        ### create neighbor
         sai_thrift_create_neighbor(self.client, addr_family, rif_id1, ip_addr1, dmac1)
 
         try:

--- a/test/saithrift/tests/sail2.py
+++ b/test/saithrift/tests/sail2.py
@@ -757,3 +757,570 @@ class L2BridgeSubPortFDBTest(sai_base_test.ThriftInterfaceDataPlane):
 
             for port in sai_port_list:
                 sai_thrift_create_vlan_member(self.client, switch.default_vlan.oid, port, SAI_VLAN_TAGGING_MODE_UNTAGGED)
+
+###########################################################
+###                 L2MtuTest                           ###
+###########################################################
+
+@group('l2')
+@group('mtu')
+class L2MtuTest(sai_base_test.ThriftInterfaceDataPlane):
+    def runTest(self):
+        """
+        Description:
+        Send untagged packet with max MTU size and verify forwarding. Add VLAN tag so
+        that the total packet size exceeds the MTU value and verify behavior. Default
+        action is to drop packets exceeding configured MTU value.
+
+        Steps:
+        1. Create VLAN 10 in the database.
+        2. Fetch the MTU for the port P1, P2, P3
+        3. Create three member port (port P1 and P2) as untagged port and port P3 as tagged port of vlan 10
+        4. Set the Port VLAN ID 10 for port P1, P2 and P3
+        5. Set MTU size 1500 for port P1, P2 and P3
+        6. Send untagged TCP packet of size 1400 bytes on port 1.
+        7. Untagged packet of size 1400 should be received at port 2 and tagged packet of vlan 10 should be received at port 2.
+        8. Send untagged TCP packet of size 1500 bytes on port 1.
+        9. Untagged packet of size 1500 should be received at port 2 and tagged packet of vlan 10 should not be received at port 2.
+        """
+
+        switch_init(self.client)
+        vlan_id = 10
+        port1 = port_list[0]
+        port2 = port_list[1]
+        port3 = port_list[2]
+        mac_action = SAI_PACKET_ACTION_FORWARD
+        port_mtu = 1500
+        port_mtu = int(port_mtu)
+        port_default_mtu = []
+        sai_port_list = [port1, port2, port3]
+
+        for port in sai_port_list:
+            port_attr_list = self.client.sai_thrift_get_port_attribute(port)
+            attr_list = port_attr_list.attr_list
+            for attribute in attr_list:
+                if attribute.id == SAI_PORT_ATTR_MTU:
+                    port_default_mtu.append(attribute.value.u32)
+
+        vlan_oid = sai_thrift_create_vlan(self.client, vlan_id)
+        vlan_member1 = sai_thrift_create_vlan_member(self.client, vlan_oid, port1, SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        vlan_member2 = sai_thrift_create_vlan_member(self.client, vlan_oid, port2, SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        vlan_member3 = sai_thrift_create_vlan_member(self.client, vlan_oid, port3, SAI_VLAN_TAGGING_MODE_TAGGED)
+
+        attr_value = sai_thrift_attribute_value_t(u16=vlan_id)
+        attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
+        for port in sai_port_list:
+            self.client.sai_thrift_set_port_attribute(port, attr)
+        """
+        Setting the MTU 1500 to port p1, p2,p3
+        """
+        attr_mtu_value = sai_thrift_attribute_value_t(u32=port_mtu)
+        attr_mtu = sai_thrift_attribute_t(id=SAI_PORT_ATTR_MTU, value=attr_mtu_value)
+        for port in sai_port_list:
+            self.client.sai_thrift_set_port_attribute(port, attr_mtu)
+
+        pkt = simple_tcp_packet(pktlen=1400,
+                                eth_dst='00:22:22:22:22:22',
+                                eth_src='00:11:11:11:11:11',
+                                ip_dst='10.0.0.1',
+                                ip_id=101,
+                                ip_ttl=64)
+
+        tag_pkt = simple_tcp_packet(pktlen=1404,
+                                eth_dst='00:22:22:22:22:22',
+                                eth_src='00:11:11:11:11:11',
+                                dl_vlan_enable=True,
+                                vlan_vid=vlan_id,
+                                ip_dst='10.0.0.1',
+                                ip_id=101,
+                                ip_ttl=64)
+
+        pkt1 = simple_tcp_packet(pktlen=1500,
+                                eth_dst='00:22:22:22:22:22',
+                                eth_src='00:11:11:11:11:11',
+                                ip_dst='10.0.0.1',
+                                ip_id=101,
+                                ip_ttl=64)
+
+        tag_pkt1 = simple_tcp_packet(pktlen=1504,
+                                eth_dst='00:22:22:22:22:22',
+                                eth_src='00:11:11:11:11:11',
+                                dl_vlan_enable=True,
+                                vlan_vid=vlan_id,
+                                ip_dst='10.0.0.1',
+                                ip_id=101,
+                                ip_ttl=64)
+
+        try:
+            send_packet(self, 0, str(pkt))
+            verify_packet(self, pkt, 1)
+            verify_packet(self, tag_pkt, 2)
+
+            send_packet(self, 0, str(pkt1))
+            verify_packet(self, pkt1, 1)
+            verify_no_packet(self, tag_pkt1, 2)
+
+        finally:
+            attr_value = sai_thrift_attribute_value_t(u16=1)
+            attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
+            for port in sai_port_list:
+                self.client.sai_thrift_set_port_attribute(port, attr)
+
+            for index, def_mtu in enumerate(port_default_mtu):
+                attr_mtu_value = sai_thrift_attribute_value_t(u32=def_mtu)
+                attr_mtu = sai_thrift_attribute_t(id=SAI_PORT_ATTR_MTU, value=attr_mtu_value)
+                self.client.sai_thrift_set_port_attribute(sai_port_list[index], attr_mtu)
+
+            sai_thrift_flush_fdb_by_vlan(self.client, vlan_oid)
+
+            self.client.sai_thrift_remove_vlan_member(vlan_member1)
+            self.client.sai_thrift_remove_vlan_member(vlan_member2)
+            self.client.sai_thrift_remove_vlan_member(vlan_member3)
+            self.client.sai_thrift_remove_vlan(vlan_oid)
+
+###########################################################
+###                 L2MacMoveTest-I                     ###
+###########################################################
+@group('l2')
+class L2MacMoveTestI (sai_base_test.ThriftInterfaceDataPlane):
+    def runTest(self):
+        '''
+        Description:
+        Create VLAN, e.g. 100 and add member ports 1, 2 and 3. Send packet on port 1 with
+        src_mac=MAC1 and dst_mac= MAC2. Verify MAC1 is learnt on port 1 and packet is flooded
+        to other member ports (2 and 3 in this example). Send packet on port 2 with src_mac=MAC2
+        and dst_mac= MAC1. Verify MAC2 is learnt on port 2. After learning, verify that packet
+        from port 1 is only forwarded to port 2 and not to port 3. Repeat the test by sending
+        same packet (src_mac=MAC2 and dst_mac= MAC1), on port 3. Verify that stationmovement
+        occurred and MAC2 is learnt on port 3. Packet from port 1 destined to MAC2 must be forwarded
+        to port 3 and not to port 2 after the MAC-movement.
+
+        Steps:
+        1. Create VLAN 100 and associate 3 untagged ports (port 1,2,3) as the member port of VLAN 100.
+        2. Set attribute value of "Port VLAN ID 100" for the ports 1, 2, 3
+        3. Send packet from port 1 with src_mac=MAC1 and dst_mac= MAC2
+        4. Send packet from port 2 with src_mac=MAC2 and dst_mac= MAC1.
+        5. After MAC learning, repeat step 3 and verify that packet from port 1 is only forwarded to port 2 and not to port 3.
+        6. Send packet (src_mac=MAC2 and dst_mac= MAC1) on port 3
+        7. Send packet (src_mac=MAC1 and dst_mac=MAC2) from port 1.
+        8. Clean up by remove the vlan members and the VLAN from the database.
+
+        '''
+        print 'L2 Mac Move test on Access ports 1,2 and 3'
+        switch_init(self.client)
+        vlan_id = 100
+        port1 = port_list[0]
+        port2 = port_list[1]
+        port3 = port_list[2]
+        mac1 = '00:11:11:11:11:11'
+        mac2 = '00:22:22:22:22:22'
+        ### create vlan
+        vlan_oid = sai_thrift_create_vlan(self.client, vlan_id)
+
+        ### create vlan membership with ports
+        vlan_member1 = sai_thrift_create_vlan_member(self.client, vlan_oid, port1, SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        vlan_member2 = sai_thrift_create_vlan_member(self.client, vlan_oid, port2, SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        vlan_member3 = sai_thrift_create_vlan_member(self.client, vlan_oid, port3, SAI_VLAN_TAGGING_MODE_UNTAGGED)
+
+        ### Assign PVLAN ID with ports
+        attr_value = sai_thrift_attribute_value_t(u16=vlan_id)
+        attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
+        self.client.sai_thrift_set_port_attribute(port1, attr)
+        self.client.sai_thrift_set_port_attribute(port2, attr)
+        self.client.sai_thrift_set_port_attribute(port3, attr)
+
+        pkt1 = simple_tcp_packet(eth_dst=mac2,
+                                eth_src=mac1,
+                                ip_dst='192.168.0.2',
+                                ip_src='192.168.0.1',
+                                ip_id=105,
+                                ip_ttl=64)
+        exp_pkt1 = simple_tcp_packet(eth_dst=mac2,
+                                eth_src=mac1,
+                                ip_dst='192.168.0.2',
+                                ip_src='192.168.0.1',
+                                ip_id=105,
+                                ip_ttl=64)
+
+        pkt2 = simple_tcp_packet(eth_dst=mac1,
+                                eth_src=mac2,
+                                ip_dst='192.168.0.1',
+                                ip_src='192.168.0.2',
+                                ip_id=105,
+                                ip_ttl=64)
+        exp_pkt2 = simple_tcp_packet(eth_dst=mac1,
+                                eth_src=mac2,
+                                ip_dst='192.168.0.1',
+                                ip_src='192.168.0.2',
+                                ip_id=105,
+                                ip_ttl=64)
+        try:
+
+            ### Sending packet from Port1
+            send_packet(self, 0, str(pkt1))
+
+            ### verify the packet @ Port2
+            verify_packets(self, exp_pkt1, [1, 2])
+
+            ### Sending packet from Port2
+            send_packet(self, 1, str(pkt2))
+
+            ### verify the packet @ Port1
+            verify_packets(self, exp_pkt2, [0])
+
+            time.sleep(1)
+
+            ### Sending packet from Port1
+            send_packet(self, 0, str(pkt1))
+
+            ### verify the packet @ Port3
+            verify_packets(self, exp_pkt1, [1])
+
+            ### verify the packet @ Port3
+            verify_no_packet(self, exp_pkt1, 2)
+
+            time.sleep(1)
+
+            ### Send packet (src_mac=MAC2 and dst_mac= MAC1) on port3
+            send_packet(self, 2, str(pkt2))
+
+            ### verify the packet @ Port1
+            verify_packets(self, exp_pkt2, [0])
+
+            time.sleep(1)
+
+            ### Send packet (src_mac=MAC1 and dst_mac=MAC2) from port 1
+            send_packet(self, 0, str(pkt1))
+
+            ### verify the packet @ Port3 & Port2
+            verify_packets(self, exp_pkt1, [2])
+            verify_no_packet(self, exp_pkt1, 1)
+
+        finally:
+            ### Assign ports into default vlan
+            sai_thrift_flush_fdb_by_vlan(self.client, vlan_oid)
+            attr_value = sai_thrift_attribute_value_t(u16=1)
+            attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
+            self.client.sai_thrift_set_port_attribute(port1, attr)
+            self.client.sai_thrift_set_port_attribute(port2, attr)
+            self.client.sai_thrift_set_port_attribute(port3, attr)
+
+            ### remove vlan membership from ports
+            self.client.sai_thrift_remove_vlan_member(vlan_member1)
+            self.client.sai_thrift_remove_vlan_member(vlan_member2)
+            self.client.sai_thrift_remove_vlan_member(vlan_member3)
+
+            ### remove valn
+            self.client.sai_thrift_remove_vlan(vlan_oid)
+
+################################################################
+###        L2MacMoveTest-II (With IPv4 Neighbor entry)       ###
+################################################################
+@group('l2')
+class L2MacMoveTestII (sai_base_test.ThriftInterfaceDataPlane):
+    def runTest(self):
+        '''
+        Description:
+        Create a neighbor entry with MAC1. Let MAC1 be learnt on port 1 and observe traffic
+        forwarding. Execute "L2MacMoveTest" and let MAC1 be learnt on 2nd port. Verify L3
+        forwarding and ensure that traffic is now forwarded to the newly learnt port.
+
+        Steps:
+        1. Create VLAN 10 and associate 2 untagged ports (port 1,2) as the member port of VLAN 10.
+        2. Set attribute value of "Port VLAN ID 10" for the ports 1, 2
+        3. Create Virtual router V1 and enable V4.
+        4. Create  virtual router interfaces and set the interface type as VLAN for VLAN 10
+           and create one more port3 (RIF Id2).
+        5. Create IPv6 neighbor entry with MAC1 and asociate with "RIF Id1".
+        6. Send test packet from port 1 with src_mac = MAC1 address.
+        7. Send IP packet from port 3 with dst_mac= MAC1 and observe traffic forwarding to port 1.
+        8. Send IP packet from port 2 with src_mac = MAC1 and verify the FDB entry, which have learnt via Port 2.
+        9. Send again the test packet from port 3 with dst_mac = MAC1 address and verify it
+            forward to port 2 and not port 1.
+        10. Remove the router interface and change the port attribute to default VLAN.
+        11. Remove the vlan members and VLAN 10 from the database.
+        '''
+
+        switch_init(self.client)
+        vlan_id = 10
+        port1 = port_list[0]
+        port2 = port_list[1]
+        port3 = port_list[2]
+        port4 = port_list[3]
+        dmac1 = '00:33:33:33:33:33'
+        dmac2 = '00:44:44:44:44:44'
+        v4_enabled = 1
+        v6_enabled = 0
+        mac = ''
+        addr_family = SAI_IP_ADDR_FAMILY_IPV4
+        ip_addr1 = '192.168.0.1'
+        ip_addr2 = '10.10.10.1'
+        ip_addr1_subnet = '192.168.0.0'
+        ip_mask1 = '255.255.255.0'
+
+        ### create vlan
+        vlan_oid = sai_thrift_create_vlan(self.client, vlan_id)
+
+        ### create vlan membership with ports
+        vlan_member1 = sai_thrift_create_vlan_member(self.client, vlan_oid, port1, SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        vlan_member2 = sai_thrift_create_vlan_member(self.client, vlan_oid, port2, SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        vlan_member3 = sai_thrift_create_vlan_member(self.client, vlan_oid, port3, SAI_VLAN_TAGGING_MODE_UNTAGGED)
+
+        ### Assign PVLAN ID with ports
+        attr_value = sai_thrift_attribute_value_t(u16=vlan_id)
+        attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
+        self.client.sai_thrift_set_port_attribute(port1, attr)
+        self.client.sai_thrift_set_port_attribute(port2, attr)
+        self.client.sai_thrift_set_port_attribute(port3, attr)
+
+        ### create virtual router
+        vr_id = sai_thrift_create_virtual_router(self.client, v4_enabled, v6_enabled)
+
+        ### create router interfaces
+        rif_id1 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_VLAN, 0, vlan_oid, v4_enabled, v6_enabled, mac)
+        rif_id2 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_PORT, port4, 0, v4_enabled, v6_enabled, mac)
+
+        ### create neighbor and next hop
+        sai_thrift_create_neighbor(self.client, addr_family, rif_id1, ip_addr1, dmac1)
+
+        try:
+            # send the test packet(s)
+            pkt1 = simple_tcp_packet(eth_dst=dmac2,
+                                eth_src=dmac1,
+                                ip_dst='192.168.0.2',
+                                ip_src='192.168.0.1',
+                                ip_id=105,
+                                ip_ttl=64)
+            exp_pkt1 = simple_tcp_packet(
+                                eth_dst=dmac2,
+                                eth_src=dmac1,
+                                ip_dst='192.168.0.2',
+                                ip_src='192.168.0.1',
+                                ip_id=105,
+                                ip_ttl=64)
+
+            pkt2 = simple_tcp_packet(eth_dst=router_mac,
+                                eth_src=dmac1,
+                                ip_dst='192.168.0.1',
+                                ip_src='10.10.10.1',
+                                ip_id=105,
+                                ip_ttl=64)
+
+            exp_pkt2 = simple_tcp_packet(
+                                eth_src=router_mac,
+                                eth_dst=dmac1,
+                                ip_dst='192.168.0.1',
+                                ip_src='10.10.10.1',
+                                ip_id=105,
+                                ip_ttl=63)
+
+
+            ### Send test packet from port 1 with src_mac = MAC1 address.
+            send_packet(self, 0, str(pkt1))
+
+            ### Verifying the traffic received @ Port2
+            verify_packets(self, exp_pkt1, [1 ,2])
+
+            time.sleep(1)
+
+            ### Send IP packet from port4 with dst_mac= MAC1 and observe traffic forwarding to port1.
+            send_packet(self, 3, str(pkt2))
+
+            ### Verifying the traffic @ Port1
+            verify_packets(self, exp_pkt2, [0])
+
+            time.sleep(1)
+
+            ### Send IP packet from port 2 with src_mac = MAC1 and verify the FDB entry.
+            send_packet(self, 1, str(pkt1))
+
+            ### Verifying the traffic @ Port3
+            verify_packets(self, exp_pkt1, [0, 2])
+
+            time.sleep(1)
+
+            ### Send again the test packet from port 4 with dst_mac = MAC1 address and verify it forward to port 2.
+            send_packet(self, 3, str(pkt2))
+
+            ### Verifying the traffic @ Port2
+            verify_packets(self, exp_pkt2, [1])
+
+        finally:
+            sai_thrift_flush_fdb_by_vlan(self.client, vlan_oid)
+
+            ### remove neighbor and next hop entries
+            sai_thrift_remove_neighbor(self.client, addr_family, rif_id1, ip_addr1, dmac1)
+
+            ### remove router interface
+            self.client.sai_thrift_remove_router_interface(rif_id1)
+            self.client.sai_thrift_remove_router_interface(rif_id2)
+
+            ### remove viratual router
+            self.client.sai_thrift_remove_virtual_router(vr_id)
+
+            ### Set the ports to default VLAN
+            attr_value = sai_thrift_attribute_value_t(u16=1)
+            attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
+            self.client.sai_thrift_set_port_attribute(port1, attr)
+            self.client.sai_thrift_set_port_attribute(port2, attr)
+            self.client.sai_thrift_set_port_attribute(port3, attr)
+
+            self.client.sai_thrift_remove_vlan_member(vlan_member1)
+            self.client.sai_thrift_remove_vlan_member(vlan_member2)
+            self.client.sai_thrift_remove_vlan_member(vlan_member3)
+            self.client.sai_thrift_remove_vlan(vlan_oid)
+
+
+################################################################
+###        L2MacMoveTest-III (With IPv6 Neighbor entry)       ###
+################################################################
+
+@group('l2')
+class L2MacMoveTestIII (sai_base_test.ThriftInterfaceDataPlane):
+    def runTest(self):
+        '''
+        Description:
+        Same as L2MacMoveTest II but for IPv6 neighbor.
+
+        Steps:
+        1. Create VLAN 10 and associate 3 untagged ports (port 1,2,3) as the member port of VLAN 10.
+        2. Set attribute value of "Port VLAN ID 10" for the ports 1, 2, 3
+        3. Create Virtual router V1 and enable V4.
+        4. Create  virtual router interfaces and set the interface type as VLAN
+        5. Create IPv4 neighbor entry with MAC1 and asociate with "RIF Id1".
+        6. Send test packet from port 1 with src_mac = MAC1 address.
+        7. Send IP packet from port 3 with dst_mac= MAC1 and observe traffic forwarding to port 1.
+        8. Send IP packet from port 2 with src_mac = MAC1 and verify the FDB entry.
+        9. Send again the test packet from port 3 with dst_mac = MAC1 address and verify it forward to port 2.
+        10.. Remove the router interface and change the port attribute to default VLAN.
+        11. Remove the vlan members and VLAN 10 from the database.
+
+        '''
+        print 'L2 Mac Move test on Access ports 1 and 2'
+        switch_init(self.client)
+        vlan_id = 10
+        port1 = port_list[0]
+        port2 = port_list[1]
+        port3 = port_list[2]
+        port4 = port_list[3]
+        dmac1 = '00:0a:0a:0a:00:01'
+        dmac2 = '00:0b:0b:0b:00:01'
+        mac=''
+        v4_enabled = 0
+        v6_enabled = 1
+
+        addr_family = SAI_IP_ADDR_FAMILY_IPV6
+        ip_addr1 = '2001:1000::1'
+        ip_addr2 = '2001:1111::1'
+        ip_addr1_subnet='2001:1000::0'
+        ip_mask1 = 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:0000'
+
+
+        ### create vlan
+        vlan_oid = sai_thrift_create_vlan(self.client, vlan_id)
+
+        ### create vlan membership with ports
+        vlan_member1 = sai_thrift_create_vlan_member(self.client, vlan_oid, port1, SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        vlan_member2 = sai_thrift_create_vlan_member(self.client, vlan_oid, port2, SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        vlan_member3 = sai_thrift_create_vlan_member(self.client, vlan_oid, port3, SAI_VLAN_TAGGING_MODE_UNTAGGED)
+
+        ### Assign PVLAN ID with ports
+        attr_value = sai_thrift_attribute_value_t(u16=vlan_id)
+        attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
+        self.client.sai_thrift_set_port_attribute(port1, attr)
+        self.client.sai_thrift_set_port_attribute(port2, attr)
+        self.client.sai_thrift_set_port_attribute(port3, attr)
+
+        ### create virtual router
+        vr_id = sai_thrift_create_virtual_router(self.client, v4_enabled, v6_enabled)
+
+        ### create router interfaces
+        rif_id1 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_VLAN, 0, vlan_oid, v4_enabled, v6_enabled, mac)
+        rif_id2 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_PORT, port4, 0, v4_enabled, v6_enabled, mac)
+
+        ### create neighbor and next hop
+        sai_thrift_create_neighbor(self.client, addr_family, rif_id1, ip_addr1, dmac1)
+
+        try:
+            # send the test packet(s)
+            pkt1 = simple_tcpv6_packet(eth_dst=dmac2,
+                                eth_src=dmac1,
+                                ipv6_dst='2001:1000::2',
+                                ipv6_src='2001:1000::1',
+                                ipv6_hlim=64)
+            exp_pkt1 = simple_tcpv6_packet(
+                                eth_src=dmac1,
+                                eth_dst=dmac2,
+                                ipv6_dst='2001:1000::2',
+                                ipv6_src='2001:1000::1',
+                                ipv6_hlim=64)
+
+            pkt2 = simple_tcpv6_packet(eth_dst=router_mac,
+                                eth_src=dmac1,
+                                ipv6_dst='2001:1000::1',
+                                ipv6_src='2001:1111::1',
+                                ipv6_hlim=64)
+
+            exp_pkt2 = simple_tcpv6_packet(
+                                eth_src=router_mac,
+                                eth_dst=dmac1,
+                                ipv6_dst='2001:1000::1',
+                                ipv6_src='2001:1111::1',
+                                ipv6_hlim=63)
+
+            ### Send test packet from port 1 with src_mac = MAC1 address.
+            send_packet(self, 0, str(pkt1))
+
+            ### Verifying the traffic @ Port2 and 3
+            verify_packets(self, exp_pkt1, [1, 2])
+
+            time.sleep(1)
+
+            ### Send IP packet from port4 with dst_mac= MAC1 and observe traffic forwarding to port1.
+            send_packet(self, 3, str(pkt2))
+
+            ### Verifying the traffic @ Port1
+            verify_packets(self, exp_pkt2, [0])
+
+            time.sleep(1)
+
+            ### Send IP packet from port 2 with src_mac = MAC1 and verify the FDB entry.
+            send_packet(self, 1, str(pkt1))
+
+            ### Verifying the traffic @ Port 1 and 3
+            verify_packets(self, exp_pkt1, [0, 2])
+
+            time.sleep(1)
+
+            ### Send again the IP  packet from port 4 with dst_mac = MAC1 address and verify it forward to port 2.
+            send_packet(self, 3, str(pkt2))
+
+            ### Verifying the traffic @ Port2
+            verify_packets(self, exp_pkt2, [1])
+
+        finally:
+            sai_thrift_flush_fdb_by_vlan(self.client, vlan_oid)
+
+            ### remove neighbor and next hop entries
+            sai_thrift_remove_neighbor(self.client, addr_family, rif_id1, ip_addr1, dmac1)
+            sai_thrift_remove_neighbor(self.client, addr_family, rif_id2, ip_addr2, dmac2)
+
+            ### remove router interface
+            self.client.sai_thrift_remove_router_interface(rif_id1)
+            self.client.sai_thrift_remove_router_interface(rif_id2)
+
+            ### remove viratual router
+            self.client.sai_thrift_remove_virtual_router(vr_id)
+
+            ### Set the ports to default VLAN
+            attr_value = sai_thrift_attribute_value_t(u16=1)
+            attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
+            self.client.sai_thrift_set_port_attribute(port1, attr)
+            self.client.sai_thrift_set_port_attribute(port2, attr)
+            self.client.sai_thrift_set_port_attribute(port3, attr)
+
+            self.client.sai_thrift_remove_vlan_member(vlan_member1)
+            self.client.sai_thrift_remove_vlan_member(vlan_member2)
+            self.client.sai_thrift_remove_vlan_member(vlan_member3)
+            self.client.sai_thrift_remove_vlan(vlan_oid)
+

--- a/test/saithrift/tests/sail3.py
+++ b/test/saithrift/tests/sail3.py
@@ -2146,10 +2146,11 @@ class L3IPv4NeighborMacTest(sai_base_test.ThriftInterfaceDataPlane):
         6. Create next hop, route to reach the neighbor (MAC1).
         7. Send test packet from port 1 with src_mac = MAC1 address and dst_mac = router MAC.
         8. Send traffic on port 2 and observe traffic forwarding to port 1.
-        9. Change the source MAC address (MAC3) and re-send the packet from port 1 and verify FDB entry.
-        10. Send IP packet from port 2 and verify the traffic forwarded to port 1 with new MAC address (MAC3) as destination MAC.
-        11. Remove the router interface and change the port attribute to default VLAN.
-        12. Remove the vlan members and VLAN 100,200 from the database.
+        9. Change the neighbor attribute to update with new MAC (MAC3)
+        10. Change the source MAC address (MAC3) and re-send the packet from port 1 and verify FDB entry.
+        11. Send IP packet from port 2 and verify the traffic forwarded to port 1 with new MAC address (MAC3) as destination MAC.
+        12. Remove the router interface and change the port attribute to default VLAN.
+        13. Remove the vlan members and VLAN 100,200 from the database.
         """
 
         print "Sending packet port 1 -> switch (for learning purpuse)"
@@ -2315,10 +2316,11 @@ class L3IPv6NeighborMacTest(sai_base_test.ThriftInterfaceDataPlane):
         6. Create next hop, route to reach the neighbor (MAC1).
         7. Send test packet from port 1 with src_mac = MAC1 address and dst_mac = router MAC.
         8. Send traffic on port 2 and observe traffic forwarding to port 1.
-        9. Change the source MAC address (MAC3) and re-send the packet from port 1 and verify FDB entry.
-        10. Send IPv6 packet from port 2 and verify the traffic forwarded to port 1 with new MAC address (MAC3) as destination MAC.
-        11. Remove the router interface and change the port attribute to default VLAN.
-        12. Remove the vlan members and VLAN 100,200 from the database.
+        9. Change the neighbor attribute to update with new MAC (MAC3)
+        10. Change the source MAC address (MAC3) and re-send the packet from port 1 and verify FDB entry.
+        11. Send IPv6 packet from port 2 and verify the traffic forwarded to port 1 with new MAC address (MAC3) as destination MAC.
+        12. Remove the router interface and change the port attribute to default VLAN.
+        13. Remove the vlan members and VLAN 100,200 from the database.
         """
         print
         print "Sending packet port 2 -> port 1 (2001:1111::1 -> 3001:1000::1) \n"
@@ -2368,7 +2370,7 @@ class L3IPv6NeighborMacTest(sai_base_test.ThriftInterfaceDataPlane):
                                  eth_src=dmac1,
                                  ipv6_dst='2001:1000::2',
                                  ipv6_src='2001:1000::1',
-                                 dl_vlan_enable=False,
+                                 dl_vlan_enable=True,
                                  vlan_vid=100,
                                  ipv6_hlim=64)
 

--- a/test/saithrift/tests/sail3.py
+++ b/test/saithrift/tests/sail3.py
@@ -2242,7 +2242,11 @@ class L3IPv4NeighborMacTest(sai_base_test.ThriftInterfaceDataPlane):
             # Change the neighbor attribute to update with new MAC
             sai_thrift_set_neighbor_attribute(self.client, addr_family, rif_vlan_id1, ip_addr1, mac_port3)
 
+            print "Expect no packet with Dst MAC1 after neighbor attribute set to MAC3"
+            send_packet(self, 1, str(L3_pkt))
+            verify_no_packet(self, exp_pkt, 0)
 
+            # learn mac MAC3
             arp_req_pkt2 = simple_arp_packet(eth_dst='ff:ff:ff:ff:ff:ff',
                                         eth_src=mac_port3,
                                         vlan_vid=vlan_id1,

--- a/test/saithrift/tests/sail3.py
+++ b/test/saithrift/tests/sail3.py
@@ -2025,3 +2025,276 @@ class L3SubPortAndVLANRifTest(sai_base_test.ThriftInterfaceDataPlane):
             attr_value = sai_thrift_attribute_value_t(u16=1)
             attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
             self.client.sai_thrift_set_port_attribute(port1, attr)
+
+@group('l3')
+@group('mtu')
+class L3MtuTest(sai_base_test.ThriftInterfaceDataPlane):
+    def runTest(self):
+        """
+        Description:
+        Send L3 destined packet with max interface MTU and verify forwarding. With L3
+        destined packet, verifying the forwarding behavior also ensures IP MTU value
+        configured for the router interface. Increase the packet size beyond the
+        configured MTU value and verify the behavior. Default action is to drop
+        packets exceeding configured MTU
+
+        Steps:
+        Part 1:
+           1. Create virtual router V1.
+           2. Create two  router interface R1 and R2.
+           3. Create next-hop and route.
+           4. Set IP mtu 1500 for router interface R1 and R2.
+           5. Send L3 IP packet of size 1500 bytes. (or packet size as per MTU size.) to port R2
+
+        Part 2:
+           6. Send Oversized packet (Packet size > MTU) to port R2.
+
+        """
+        switch_init(self.client)
+        port1 = port_list[0]
+        port2 = port_list[1]
+        v4_enabled = 1
+        v6_enabled = 1
+        mac = ''
+        port_mtu = 1500
+
+        vr_id = sai_thrift_create_virtual_router(self.client, v4_enabled, v6_enabled)
+
+        rif_id1 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_PORT, port1, 0, v4_enabled, v6_enabled, mac)
+        rif_id2 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_PORT, port2, 0, v4_enabled, v6_enabled, mac)
+
+        attr_mtu_value = sai_thrift_attribute_value_t(u32=port_mtu)
+        attr_mtu = sai_thrift_attribute_t(id=SAI_ROUTER_INTERFACE_ATTR_MTU, value=attr_mtu_value)
+        self.client.sai_thrift_set_router_interface_attribute(rif_id1, attr_mtu)
+        self.client.sai_thrift_set_router_interface_attribute(rif_id2, attr_mtu)
+
+        addr_family = SAI_IP_ADDR_FAMILY_IPV4
+        ip_addr1 = '10.10.10.1'
+        ip_addr1_subnet = '10.10.10.0'
+        ip_mask1 = '255.255.255.0'
+        dmac1 = '00:11:22:33:44:55'
+        sai_thrift_create_neighbor(self.client, addr_family, rif_id1, ip_addr1, dmac1)
+        nhop1 = sai_thrift_create_nhop(self.client, addr_family, ip_addr1, rif_id1)
+        sai_thrift_create_route(self.client, vr_id, addr_family, ip_addr1_subnet, ip_mask1, rif_id1)
+
+        # send the test packet(s)
+        pkt1 = simple_ip_packet(pktlen=1500,
+                                eth_dst=router_mac,
+                                eth_src='00:22:22:22:22:22',
+                                ip_dst='10.10.10.1',
+                                ip_src='192.168.0.1',
+                                ip_id=105,
+                                ip_ttl=64)
+
+        exp_pkt1 = simple_ip_packet(pktlen=1500,
+                                eth_dst='00:11:22:33:44:55',
+                                eth_src=router_mac,
+                                ip_dst='10.10.10.1',
+                                ip_src='192.168.0.1',
+                                ip_id=105,
+                                ip_ttl=63)
+
+        pkt2 = simple_ip_packet(pktlen=1600,
+                                eth_dst=router_mac,
+                                eth_src='00:22:22:22:22:22',
+                                ip_dst='10.10.10.1',
+                                ip_src='192.168.0.1',
+                                ip_id=105,
+                                ip_ttl=64)
+
+        exp_pkt2 = simple_ip_packet(pktlen=1600,
+                                eth_dst='00:11:22:33:44:55',
+                                eth_src=router_mac,
+                                ip_dst='10.10.10.1',
+                                ip_src='192.168.0.1',
+                                ip_id=105,
+                                ip_ttl=63)
+        try:
+            send_packet(self, 1, str(pkt1))
+            verify_packet(self, exp_pkt1, 0)
+            # send ip packet to interface 1 to interface 0 (Packet size > MTU)
+            send_packet(self, 1, str(pkt2))
+            verify_no_packet(self, exp_pkt2, 0)
+        finally:
+            sai_thrift_remove_route(self.client, vr_id, addr_family, ip_addr1_subnet, ip_mask1, rif_id1)
+            self.client.sai_thrift_remove_next_hop(nhop1)
+            sai_thrift_remove_neighbor(self.client, addr_family, rif_id1, ip_addr1, dmac1)
+
+            self.client.sai_thrift_remove_router_interface(rif_id1)
+            self.client.sai_thrift_remove_router_interface(rif_id2)
+
+            self.client.sai_thrift_remove_virtual_router(vr_id)
+
+
+@group('l3')
+class L3IPv4NeighborMacTest(sai_base_test.ThriftInterfaceDataPlane):
+    def runTest(self):
+        """
+        Description:
+        Create two VLAN router interfaces in the same VRF. Create nhop, route and
+        neighbor entry for destination. Send packet on one router interface and
+        verify packet received on the other router interface. Simulate a MAC address
+        change for the neighbor entry and verify traffic. The packet must now be
+        forwarded with the new MAC address as destination MAC
+
+        Steps:
+        1. Create VLAN 100, 200 in the database
+        2. Associate 2 tagged ports (port 1, 2) as the member port of VLAN 100 and 200 respectively.
+        3. Create Virtual router V1 and enable V4.
+        4. Create two virtual router interfaces and set the interface type as VLAN
+        5. Create IPv4 neighbor entry with MAC1 and asociate with ""RIF Id1"".
+        6. Create next hop, route to reach the neighbor (MAC1).
+        7. Send test packet from port 1 with src_mac = MAC1 address and dst_mac = router MAC.
+        8. Send traffic on port 2 and observe traffic forwarding to port 1.
+        9. Change the source MAC address (MAC3) and re-send the packet from port 1 and verify FDB entry.
+        10. Send IP packet from port 2 and verify the traffic forwarded to port 1 with new MAC address (MAC3) as destination MAC.
+        11. Remove the router interface and change the port attribute to default VLAN.
+        12. Remove the vlan members and VLAN 100,200 from the database.
+        """
+
+        print "Sending packet port 1 -> switch (for learning purpuse)"
+        print "and then sending packet from port 2 (11.11.11.1) -> port 1 (192.168.0.1 through the router)"
+
+        switch_init(self.client)
+        v4_enabled = 1
+        v6_enabled = 0
+        vlan_id1 = 100
+        vlan_id2 = 200
+        port1 = port_list[0]
+        port2 = port_list[1]
+        mac_action = SAI_PACKET_ACTION_FORWARD
+
+        addr_family = SAI_IP_ADDR_FAMILY_IPV4
+        ip_addr1 = '10.10.10.1'
+        ip_addr_subnet = '192.168.0.0'
+        ip_mask1 = '255.255.255.0'
+        mac_port1 = '00:0a:00:00:00:01'
+        mac_port2 = '00:0a:00:00:00:02'
+        mac_port3 = '00:0a:00:00:00:03'
+        mac1 = ''
+        mac2 = ''
+        mac3 = ''
+
+        vlan1 = sai_thrift_create_vlan(self.client, vlan_id1)
+        vlan2 = sai_thrift_create_vlan(self.client, vlan_id2)
+
+        vlan_member1 = sai_thrift_create_vlan_member(self.client, vlan1, port1, SAI_VLAN_TAGGING_MODE_TAGGED)
+        vlan_member2 = sai_thrift_create_vlan_member(self.client, vlan2, port2, SAI_VLAN_TAGGING_MODE_TAGGED)
+
+        attr_value1 = sai_thrift_attribute_value_t(u16=vlan_id1)
+        attr1 = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value1)
+        self.client.sai_thrift_set_port_attribute(port1, attr1)
+
+        attr_value2 = sai_thrift_attribute_value_t(u16=vlan_id2)
+        attr2 = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value2)
+        self.client.sai_thrift_set_port_attribute(port2, attr2)
+
+        vr_id = sai_thrift_create_virtual_router(self.client, v4_enabled, v6_enabled)
+
+        rif_vlan_id1 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_VLAN, 0, vlan1, v4_enabled, v6_enabled, mac1)
+        rif_vlan_id2 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_VLAN, 0, vlan2, v4_enabled, v6_enabled, mac2)
+
+        sai_thrift_create_neighbor(self.client, addr_family, rif_vlan_id1, ip_addr1, mac_port1)
+        nhop1 = sai_thrift_create_nhop(self.client, addr_family, ip_addr1, rif_vlan_id1)
+        sai_thrift_create_route(self.client, vr_id, addr_family, ip_addr_subnet, ip_mask1, nhop1)
+
+        arp_req_pkt = simple_arp_packet(eth_dst='ff:ff:ff:ff:ff:ff',
+                                        eth_src=mac_port1,
+                                        vlan_vid=100,
+                                        arp_op=1,     # ARP request
+                                        ip_snd='10.10.10.1',
+                                        ip_tgt='10.10.10.2',
+                                        hw_snd=mac_port1,
+                                        hw_tgt='00:00:00:00:00:00')
+
+
+        print "Send ARP request packet from port1 ..."
+        send_packet(self, 0, str(arp_req_pkt))
+
+        try:
+
+            #sending L3 packet from port 2 through router to port 1 that update the fdb with is MAC
+            L3_pkt = simple_tcp_packet(pktlen=144,
+                                       eth_dst=router_mac,
+                                       eth_src=mac_port2,
+                                       ip_src='11.11.11.1',
+                                       ip_dst='192.168.0.1',
+                                       dl_vlan_enable=True,
+                                       vlan_vid=vlan_id2,
+                                       ip_id=105,
+                                       ip_ttl=64)
+
+            exp_pkt = simple_tcp_packet(pktlen=144,
+                                       eth_dst=mac_port1,
+                                       eth_src=router_mac,
+                                       ip_dst='192.168.0.1',
+                                       ip_src='11.11.11.1',
+                                       dl_vlan_enable=True,
+                                       vlan_vid=vlan_id1,
+                                       ip_id=105,
+                                       ip_ttl=63)
+
+            send_packet(self, 1, str(L3_pkt))
+
+            verify_packets(self, exp_pkt, [0])
+
+            # Change the neighbor attribute to update with new MAC
+            sai_thrift_set_neighbor_attribute(self.client, addr_family, rif_vlan_id1, ip_addr1, mac_port3)
+
+
+            arp_req_pkt2 = simple_arp_packet(eth_dst='ff:ff:ff:ff:ff:ff',
+                                        eth_src=mac_port3,
+                                        vlan_vid=vlan_id1,
+                                        arp_op=1,     # ARP request
+                                        ip_snd='10.10.10.1',
+                                        ip_tgt='10.10.10.2',
+                                        hw_snd=mac_port3,
+                                        hw_tgt='00:00:00:00:00:00')
+
+            send_packet(self, 0, str(arp_req_pkt2))
+
+            L3_pkt1 = simple_tcp_packet(pktlen=104,
+                                       eth_dst=router_mac,
+                                       eth_src=mac_port2,
+                                       ip_dst='192.168.0.1',
+                                       ip_src='11.11.11.1',
+                                       dl_vlan_enable=True,
+                                       vlan_vid=vlan_id2,
+                                       ip_id=105,
+                                       ip_ttl=64)
+            exp_pkt1 = simple_tcp_packet(pktlen=104,
+                                       eth_dst=mac_port3,
+                                       eth_src=router_mac,
+                                       dl_vlan_enable=True,
+                                       vlan_vid=vlan_id1,
+                                       ip_dst='192.168.0.1',
+                                       ip_src='11.11.11.1',
+                                       ip_id=105,
+                                       ip_ttl=63)
+
+            send_packet(self, 1, str(L3_pkt1))
+            verify_packets(self, exp_pkt1, [0])
+
+        finally:
+            sai_thrift_flush_fdb_by_vlan(self.client, vlan1)
+            sai_thrift_flush_fdb_by_vlan(self.client, vlan2)
+
+            sai_thrift_remove_route(self.client, vr_id, addr_family, ip_addr_subnet, ip_mask1, nhop1)
+            self.client.sai_thrift_remove_next_hop(nhop1)
+            sai_thrift_remove_neighbor(self.client, addr_family, rif_vlan_id1, ip_addr1, mac_port3)
+
+            self.client.sai_thrift_remove_router_interface(rif_vlan_id1)
+            self.client.sai_thrift_remove_router_interface(rif_vlan_id2)
+
+            self.client.sai_thrift_remove_vlan_member(vlan_member1)
+            self.client.sai_thrift_remove_vlan_member(vlan_member2)
+
+            self.client.sai_thrift_remove_vlan(vlan1)
+            self.client.sai_thrift_remove_vlan(vlan2)
+
+            self.client.sai_thrift_remove_virtual_router(vr_id)
+
+            attr_value = sai_thrift_attribute_value_t(u16=1)
+            attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
+            self.client.sai_thrift_set_port_attribute(port1, attr)
+            self.client.sai_thrift_set_port_attribute(port2, attr)

--- a/test/saithrift/tests/sail3.py
+++ b/test/saithrift/tests/sail3.py
@@ -2298,3 +2298,156 @@ class L3IPv4NeighborMacTest(sai_base_test.ThriftInterfaceDataPlane):
             attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
             self.client.sai_thrift_set_port_attribute(port1, attr)
             self.client.sai_thrift_set_port_attribute(port2, attr)
+
+@group('l3')
+class L3IPv6NeighborMacTest(sai_base_test.ThriftInterfaceDataPlane):
+    def runTest(self):
+        """
+        Description:
+        Same as "L3IPv4NeighborMacTest" but for IPv6 neighbor
+
+        Steps:
+        1. Create VLAN 100, 200 in the database
+        2. Associate 2 tagged ports (port 1, 2) as the member port of VLAN 100 and 200 respectively.
+        3. Create Virtual router V1 and enable V6.
+        4. Create two virtual router interfaces and set the interface type as VLAN
+        5. Create IPv6 neighbor entry with MAC1 and asociate with ""RIF Id1"".
+        6. Create next hop, route to reach the neighbor (MAC1).
+        7. Send test packet from port 1 with src_mac = MAC1 address and dst_mac = router MAC.
+        8. Send traffic on port 2 and observe traffic forwarding to port 1.
+        9. Change the source MAC address (MAC3) and re-send the packet from port 1 and verify FDB entry.
+        10. Send IPv6 packet from port 2 and verify the traffic forwarded to port 1 with new MAC address (MAC3) as destination MAC.
+        11. Remove the router interface and change the port attribute to default VLAN.
+        12. Remove the vlan members and VLAN 100,200 from the database.
+        """
+        print
+        print "Sending packet port 2 -> port 1 (2001:1111::1 -> 3001:1000::1) \n"
+        switch_init(self.client)
+        port1 = port_list[0]
+        port2 = port_list[1]
+        port3 = port_list[2]
+        v4_enabled = 0
+        v6_enabled = 1
+        vlan1_id = 100
+        vlan2_id = 200
+
+        addr_family = SAI_IP_ADDR_FAMILY_IPV6
+        ip_addr1 = '2001:1000::1'
+        ip_addr_subnet = '3001:1000::0'
+        ip_mask1 = 'ffff:ffff:ffff:ffff:0000:0000:0000:0000'
+        dmac1 = '00:0a:00:00:00:01'
+        dmac2 = '00:0b:00:00:00:01'
+        mac1 = ''
+        dmac3 = '00:0c:00:00:00:01'
+
+        vlan1_oid = sai_thrift_create_vlan(self.client, vlan1_id)
+        vlan2_oid = sai_thrift_create_vlan(self.client, vlan2_id)
+
+        vlan_member1 = sai_thrift_create_vlan_member(self.client, vlan1_oid, port1, SAI_VLAN_TAGGING_MODE_TAGGED)
+        vlan_member2 = sai_thrift_create_vlan_member(self.client, vlan2_oid, port2, SAI_VLAN_TAGGING_MODE_TAGGED)
+
+        attr_value = sai_thrift_attribute_value_t(u16=vlan1_id)
+        attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
+        self.client.sai_thrift_set_port_attribute(port1, attr)
+
+        attr_value1 = sai_thrift_attribute_value_t(u16=vlan2_id)
+        attr1 = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value1)
+        self.client.sai_thrift_set_port_attribute(port2, attr1)
+
+        vr_id = sai_thrift_create_virtual_router(self.client, v4_enabled, v6_enabled)
+
+        rif_id1 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_VLAN, 0, vlan1_oid, v4_enabled, v6_enabled, mac1)
+        rif_id2 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_VLAN, 0, vlan2_oid, v4_enabled, v6_enabled, mac1)
+        sai_thrift_create_neighbor(self.client, addr_family, rif_id1, ip_addr1, dmac1)
+        nhop1 = sai_thrift_create_nhop(self.client, addr_family, ip_addr1, rif_id1)
+        sai_thrift_create_route(self.client, vr_id, addr_family, ip_addr_subnet, ip_mask1, nhop1)
+
+        try:
+
+            test_pkt = simple_tcpv6_packet(eth_dst='ff:ff:ff:ff:ff:ff',
+                                 eth_src=dmac1,
+                                 ipv6_dst='2001:1000::2',
+                                 ipv6_src='2001:1000::1',
+                                 dl_vlan_enable=False,
+                                 vlan_vid=100,
+                                 ipv6_hlim=64)
+
+            print "Send Broadcast packet from port1 to learn MAC1 using test packet..."
+            print "and then sending packet from port 2 -> port 1 (through the router) \n"
+            send_packet(self, 0, str(test_pkt))
+
+            time.sleep(1)
+
+            pkt = simple_tcpv6_packet(
+                                eth_dst=router_mac,
+                                eth_src=dmac2,
+                                ipv6_dst='3001:1000::1',
+                                ipv6_src='2001:1111::1',
+                                dl_vlan_enable=True,
+                                vlan_vid=vlan2_id,
+                                ipv6_hlim=64)
+
+            exp_pkt = simple_tcpv6_packet(
+                                eth_dst=dmac1,
+                                eth_src=router_mac,
+                                ipv6_dst='3001:1000::1',
+                                ipv6_src='2001:1111::1',
+                                dl_vlan_enable=True,
+                                vlan_vid=vlan1_id,
+                                ipv6_hlim=63)
+
+            send_packet(self, 1, str(pkt))
+            verify_packets(self, exp_pkt, [0])
+            # Update the neighbor MAC entry
+            sai_thrift_set_neighbor_attribute(self.client, addr_family, rif_id1, ip_addr1, dmac3)
+
+            # Construct test packet with new MAC
+            test_pkt = simple_tcpv6_packet(eth_dst='ff:ff:ff:ff:ff:ff',
+                                 eth_src=dmac3,
+                                 ipv6_dst='2001:1000::2',
+                                 ipv6_src='2001:1000::1',
+                                 dl_vlan_enable=True,
+                                 vlan_vid=100,
+                                 ipv6_hlim=64)
+
+            print "Send Broadcast packet from port1 to learn MAC3 using test packet..."
+            print "and then sending packet from port 2 -> port 1 (through the router) "
+
+            send_packet(self, 0, str(test_pkt))
+            time.sleep(1)
+            exp_pkt1 = simple_tcpv6_packet(
+                                eth_dst=dmac3,
+                                eth_src=router_mac,
+                                ipv6_dst='3001:1000::1',
+                                ipv6_src='2001:1111::1',
+                                dl_vlan_enable=True,
+                                vlan_vid=vlan1_id,
+                                ipv6_hlim=63)
+
+            send_packet(self, 1, str(pkt))
+            verify_packets(self, exp_pkt1, [0])
+
+        finally:
+            sai_thrift_flush_fdb_by_vlan(self.client, vlan1_oid)
+            sai_thrift_flush_fdb_by_vlan(self.client, vlan2_oid)
+
+            sai_thrift_remove_route(self.client, vr_id, addr_family, ip_addr_subnet, ip_mask1, nhop1)
+            self.client.sai_thrift_remove_next_hop(nhop1)
+            sai_thrift_remove_neighbor(self.client, addr_family, rif_id1, ip_addr1, dmac3)
+
+            self.client.sai_thrift_remove_router_interface(rif_id1)
+            self.client.sai_thrift_remove_router_interface(rif_id2)
+
+            self.client.sai_thrift_remove_vlan_member(vlan_member1)
+            self.client.sai_thrift_remove_vlan_member(vlan_member2)
+
+            self.client.sai_thrift_remove_vlan(vlan1_oid)
+            self.client.sai_thrift_remove_vlan(vlan2_oid)
+
+            self.client.sai_thrift_remove_virtual_router(vr_id)
+
+            attr_value = sai_thrift_attribute_value_t(u16=1)
+            attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
+            self.client.sai_thrift_set_port_attribute(port1, attr)
+            self.client.sai_thrift_set_port_attribute(port2, attr)
+

--- a/test/saithrift/tests/switch.py
+++ b/test/saithrift/tests/switch.py
@@ -477,6 +477,20 @@ def sai_thrift_remove_neighbor(client, addr_family, rif_id, ip_addr, dmac):
     neighbor_entry = sai_thrift_neighbor_entry_t(rif_id=rif_id, ip_address=ipaddr)
     client.sai_thrift_remove_neighbor_entry(neighbor_entry)
 
+def sai_thrift_set_neighbor_attribute(client, addr_family, rif_id, ip_addr, dmac):
+    if addr_family == SAI_IP_ADDR_FAMILY_IPV4:
+        addr = sai_thrift_ip_t(ip4=ip_addr)
+        ipaddr = sai_thrift_ip_address_t(addr_family=SAI_IP_ADDR_FAMILY_IPV4, addr=addr)
+    else:
+        addr = sai_thrift_ip_t(ip6=ip_addr)
+        ipaddr = sai_thrift_ip_address_t(addr_family=SAI_IP_ADDR_FAMILY_IPV6, addr=addr)
+    neighbor_attribute1_value = sai_thrift_attribute_value_t(mac=dmac)
+    neighbor_attribute1 = sai_thrift_attribute_t(id=SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS,
+                                                 value=neighbor_attribute1_value)
+    neighbor_attr_list = [neighbor_attribute1]
+    neighbor_entry = sai_thrift_neighbor_entry_t(rif_id=rif_id, ip_address=ipaddr)
+    return client.sai_thrift_set_neighbor_entry_attribute(neighbor_entry, neighbor_attr_list)
+
 def sai_thrift_create_next_hop_group(client):
     nhop_group_atr1_value = sai_thrift_attribute_value_t(s32=SAI_NEXT_HOP_GROUP_TYPE_ECMP)
     nhop_group_atr1 = sai_thrift_attribute_t(id=SAI_NEXT_HOP_GROUP_ATTR_TYPE,


### PR DESCRIPTION
Adding below tests into SAI PTF tests (https://github.com/opencomputeproject/SAI/blob/master/test/saithrift/tests/SAITest.md)

L2MtuTest
L3MtuTest
L2MacMoveTestI 
L2MacMoveTestII
L2MacMoveTestIII
L3IPv4NeighborMacTest
L3IPv6NeighborMacTest

Added sai_thrift_set_neighbor_attribute proc in switch.py
Test scripts  are validated with SAI version 1.3.3