### PR TITLE
New flood vector combined type

### DIFF
--- a/inc/saibridge.h
+++ b/inc/saibridge.h
@@ -412,7 +412,8 @@ typedef enum _sai_bridge_type_t
 typedef enum _sai_bridge_flood_control_type_t
 {
     /**
-     * Flood on all sub-ports
+     * @brief Flood on all sub-ports
+     *
      * When setting sub-ports to broadcast or unknown multicast flood, it also
      * includes flooding to the router. When setting sub-ports to unknown
      * unicast flood, it does not include flooding to the router
@@ -426,6 +427,8 @@ typedef enum _sai_bridge_flood_control_type_t
     SAI_BRIDGE_FLOOD_CONTROL_TYPE_L2MC_GROUP,
 
     /**
+     * @brief Flood on all sub-ports and L2MC group
+     *
      * Flood on all sub-ports, without the router
      * In addition, flood on the supplied L2MC group
      */
@@ -537,7 +540,7 @@ typedef enum _sai_bridge_attr_t
      * @default SAI_NULL_OBJECT_ID
      * @validonly SAI_BRIDGE_ATTR_UNKNOWN_MULTICAST_FLOOD_CONTROL_TYPE ==
      * SAI_BRIDGE_FLOOD_CONTROL_TYPE_L2MC_GROUP or
-     * SAI_BRIDGE_ATTR_UNKNOWN_UNICAST_FLOOD_CONTROL_TYPE ==
+     * SAI_BRIDGE_ATTR_UNKNOWN_MULTICAST_FLOOD_CONTROL_TYPE ==
      * SAI_BRIDGE_FLOOD_CONTROL_TYPE_COMBINED
      */
     SAI_BRIDGE_ATTR_UNKNOWN_MULTICAST_FLOOD_GROUP,
@@ -567,8 +570,8 @@ typedef enum _sai_bridge_attr_t
      * @allownull true
      * @default SAI_NULL_OBJECT_ID
      * @validonly SAI_BRIDGE_ATTR_BROADCAST_FLOOD_CONTROL_TYPE ==
-     * SAI_BRIDGE_FLOOD_CONTROL_TYPE_L2MC_GROUP
-     * SAI_BRIDGE_ATTR_UNKNOWN_UNICAST_FLOOD_CONTROL_TYPE ==
+     * SAI_BRIDGE_FLOOD_CONTROL_TYPE_L2MC_GROUP or
+     * SAI_BRIDGE_ATTR_BROADCAST_FLOOD_CONTROL_TYPE ==
      * SAI_BRIDGE_FLOOD_CONTROL_TYPE_COMBINED
      */
     SAI_BRIDGE_ATTR_BROADCAST_FLOOD_GROUP,

--- a/inc/saibridge.h
+++ b/inc/saibridge.h
@@ -411,7 +411,12 @@ typedef enum _sai_bridge_type_t
  */
 typedef enum _sai_bridge_flood_control_type_t
 {
-    /** Flood on all sub-ports */
+    /**
+     * Flood on all sub-ports
+     * When setting sub-ports to broadcast or unknown multicast flood, it also
+     * includes flooding to the router. When setting sub-ports to unknown
+     * unicast flood, it does not include flooding to the router
+     */
     SAI_BRIDGE_FLOOD_CONTROL_TYPE_SUB_PORTS,
 
     /** Disable flooding */
@@ -419,6 +424,12 @@ typedef enum _sai_bridge_flood_control_type_t
 
     /** Flood on the L2MC group */
     SAI_BRIDGE_FLOOD_CONTROL_TYPE_L2MC_GROUP,
+
+    /**
+     * Flood on all sub-ports, without the router
+     * In addition, flood on the supplied L2MC group
+     */
+    SAI_BRIDGE_FLOOD_CONTROL_TYPE_COMBINED
 
 } sai_bridge_flood_control_type_t;
 
@@ -494,7 +505,9 @@ typedef enum _sai_bridge_attr_t
      * @allownull true
      * @default SAI_NULL_OBJECT_ID
      * @validonly SAI_BRIDGE_ATTR_UNKNOWN_UNICAST_FLOOD_CONTROL_TYPE ==
-     * SAI_BRIDGE_FLOOD_CONTROL_TYPE_L2MC_GROUP and SAI_BRIDGE_ATTR_TYPE == SAI_BRIDGE_TYPE_1D
+     * SAI_BRIDGE_FLOOD_CONTROL_TYPE_L2MC_GROUP or
+     * SAI_BRIDGE_ATTR_UNKNOWN_UNICAST_FLOOD_CONTROL_TYPE ==
+     * SAI_BRIDGE_FLOOD_CONTROL_TYPE_COMBINED
      */
     SAI_BRIDGE_ATTR_UNKNOWN_UNICAST_FLOOD_GROUP,
 
@@ -523,7 +536,9 @@ typedef enum _sai_bridge_attr_t
      * @allownull true
      * @default SAI_NULL_OBJECT_ID
      * @validonly SAI_BRIDGE_ATTR_UNKNOWN_MULTICAST_FLOOD_CONTROL_TYPE ==
-     * SAI_BRIDGE_FLOOD_CONTROL_TYPE_L2MC_GROUP and SAI_BRIDGE_ATTR_TYPE == SAI_BRIDGE_TYPE_1D
+     * SAI_BRIDGE_FLOOD_CONTROL_TYPE_L2MC_GROUP or
+     * SAI_BRIDGE_ATTR_UNKNOWN_UNICAST_FLOOD_CONTROL_TYPE ==
+     * SAI_BRIDGE_FLOOD_CONTROL_TYPE_COMBINED
      */
     SAI_BRIDGE_ATTR_UNKNOWN_MULTICAST_FLOOD_GROUP,
 
@@ -552,7 +567,9 @@ typedef enum _sai_bridge_attr_t
      * @allownull true
      * @default SAI_NULL_OBJECT_ID
      * @validonly SAI_BRIDGE_ATTR_BROADCAST_FLOOD_CONTROL_TYPE ==
-     * SAI_BRIDGE_FLOOD_CONTROL_TYPE_L2MC_GROUP and SAI_BRIDGE_ATTR_TYPE == SAI_BRIDGE_TYPE_1D
+     * SAI_BRIDGE_FLOOD_CONTROL_TYPE_L2MC_GROUP
+     * SAI_BRIDGE_ATTR_UNKNOWN_UNICAST_FLOOD_CONTROL_TYPE ==
+     * SAI_BRIDGE_FLOOD_CONTROL_TYPE_COMBINED
      */
     SAI_BRIDGE_ATTR_BROADCAST_FLOOD_GROUP,
 

--- a/inc/saivlan.h
+++ b/inc/saivlan.h
@@ -73,7 +73,8 @@ typedef enum _sai_vlan_mcast_lookup_key_type_t
 typedef enum _sai_vlan_flood_control_type_t
 {
     /**
-     * Flood on all vlan members
+     * @brief Flood on all vlan members
+     *
      * When setting all to broadcast or unknown multicast flood, it also includes
      * flooding to the router. When setting all to unknown unicast flood, it does
      * not include flooding to the router
@@ -87,6 +88,8 @@ typedef enum _sai_vlan_flood_control_type_t
     SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP,
 
     /**
+     * @brief Flood on all vlan members and L2MC group
+     *
      * Flood on all vlan members, without the router
      * In addition, flood on the supplied L2MC group
      */
@@ -348,7 +351,7 @@ typedef enum _sai_vlan_attr_t
      * @default SAI_NULL_OBJECT_ID
      * @validonly SAI_VLAN_ATTR_UNKNOWN_MULTICAST_FLOOD_CONTROL_TYPE ==
      * SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP or
-     * SAI_VLAN_ATTR_UNKNOWN_UNICAST_FLOOD_CONTROL_TYPE ==
+     * SAI_VLAN_ATTR_UNKNOWN_MULTICAST_FLOOD_CONTROL_TYPE ==
      * SAI_VLAN_FLOOD_CONTROL_TYPE_COMBINED
      */
     SAI_VLAN_ATTR_UNKNOWN_MULTICAST_FLOOD_GROUP,
@@ -378,7 +381,7 @@ typedef enum _sai_vlan_attr_t
      * @default SAI_NULL_OBJECT_ID
      * @validonly SAI_VLAN_ATTR_BROADCAST_FLOOD_CONTROL_TYPE ==
      * SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP or
-     * SAI_VLAN_ATTR_UNKNOWN_UNICAST_FLOOD_CONTROL_TYPE ==
+     * SAI_VLAN_ATTR_BROADCAST_FLOOD_CONTROL_TYPE ==
      * SAI_VLAN_FLOOD_CONTROL_TYPE_COMBINED
      */
     SAI_VLAN_ATTR_BROADCAST_FLOOD_GROUP,

--- a/inc/saivlan.h
+++ b/inc/saivlan.h
@@ -72,7 +72,12 @@ typedef enum _sai_vlan_mcast_lookup_key_type_t
  */
 typedef enum _sai_vlan_flood_control_type_t
 {
-    /** Flood on all vlan members */
+    /**
+     * Flood on all vlan members
+     * When setting all to broadcast or unknown multicast flood, it also includes
+     * flooding to the router. When setting all to unknown unicast flood, it does
+     * not include flooding to the router
+     */
     SAI_VLAN_FLOOD_CONTROL_TYPE_ALL,
 
     /** Disable flooding */
@@ -80,6 +85,12 @@ typedef enum _sai_vlan_flood_control_type_t
 
     /** Flood on the L2MC group */
     SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP,
+
+    /**
+     * Flood on all vlan members, without the router
+     * In addition, flood on the supplied L2MC group
+     */
+    SAI_VLAN_FLOOD_CONTROL_TYPE_COMBINED
 
 } sai_vlan_flood_control_type_t;
 
@@ -306,7 +317,9 @@ typedef enum _sai_vlan_attr_t
      * @allownull true
      * @default SAI_NULL_OBJECT_ID
      * @validonly SAI_VLAN_ATTR_UNKNOWN_UNICAST_FLOOD_CONTROL_TYPE ==
-     * SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP
+     * SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP or
+     * SAI_VLAN_ATTR_UNKNOWN_UNICAST_FLOOD_CONTROL_TYPE ==
+     * SAI_VLAN_FLOOD_CONTROL_TYPE_COMBINED
      */
     SAI_VLAN_ATTR_UNKNOWN_UNICAST_FLOOD_GROUP,
 
@@ -334,7 +347,9 @@ typedef enum _sai_vlan_attr_t
      * @allownull true
      * @default SAI_NULL_OBJECT_ID
      * @validonly SAI_VLAN_ATTR_UNKNOWN_MULTICAST_FLOOD_CONTROL_TYPE ==
-     * SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP
+     * SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP or
+     * SAI_VLAN_ATTR_UNKNOWN_UNICAST_FLOOD_CONTROL_TYPE ==
+     * SAI_VLAN_FLOOD_CONTROL_TYPE_COMBINED
      */
     SAI_VLAN_ATTR_UNKNOWN_MULTICAST_FLOOD_GROUP,
 
@@ -362,7 +377,9 @@ typedef enum _sai_vlan_attr_t
      * @allownull true
      * @default SAI_NULL_OBJECT_ID
      * @validonly SAI_VLAN_ATTR_BROADCAST_FLOOD_CONTROL_TYPE ==
-     * SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP
+     * SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP or
+     * SAI_VLAN_ATTR_UNKNOWN_UNICAST_FLOOD_CONTROL_TYPE ==
+     * SAI_VLAN_FLOOD_CONTROL_TYPE_COMBINED
      */
     SAI_VLAN_ATTR_BROADCAST_FLOOD_GROUP,
 


### PR DESCRIPTION
Adding clarification to the meaning of all flood vector - includes the router for broadcast and multicast, doesn't include the router for unknown unicast.
Add a new type, combined, to easily add L2MC group on top of the existing all definition