### PR TITLE
Attribute for Link Training

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -1182,6 +1182,15 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_SERDES_IPREDRIVER,
 
     /**
+     * @brief Enable/Disable Port Link Training
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_PORT_ATTR_LINK_TRAINING_ENABLE,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_ATTR_END,


### PR DESCRIPTION
Adding an attribute for controlling Link Training on the ports, for improving interop among devices.