### PR TITLE
Add a RO attr to trap object for Packet Count

### DIFF
--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -455,6 +455,14 @@ typedef enum _sai_hostif_trap_attr_t
     SAI_HOSTIF_TRAP_ATTR_MIRROR_SESSION,
 
     /**
+     * @brief Number of packets received for the trap
+     *
+     * @type sai_uint64_t
+     * @flags READ_ONLY
+     */
+    SAI_HOSTIF_TRAP_ATTR_RX_PKTS,
+
+    /**
      * @brief End of attributes
      */
     SAI_HOSTIF_TRAP_ATTR_END,


### PR DESCRIPTION
Add a RO attribute to the trap object to get Trap Packet Count : SAI_HOSTIF_TRAP_ATTR_RX_PKTS
