### PR TITLE
Adding SAI PTF tests for 3AclTableTest_II and L3AclTableTest_III

### DIFF
--- a/test/saithrift/tests/saiacl.py
+++ b/test/saithrift/tests/saiacl.py
@@ -1634,3 +1634,273 @@ class L3AclTableGroupTestI(sai_base_test.ThriftInterfaceDataPlane):
             self.client.sai_thrift_remove_vlan_member(vlan_member1)
             self.client.sai_thrift_remove_vlan(vlan_oid)
 
+@group('acl')
+class L3AclTableTestII(sai_base_test.ThriftInterfaceDataPlane):
+    def runTest(self):
+        """
+        Description:
+        Same as "L3AclTableTest_I" for bind point type VLAN. Create ACL
+        entry for the traffic over VLAN in this case.
+
+        After "L3AclTableTest_II", bind the same ACL table to a port.
+        Test is to verify dynamically changing the bind point type of an ACL table from VLAN to a PORT.
+        Verify that the bind point can be changed, and the ACL action is only applied on the associated port but not the VLAN.
+        Remove all the table bindings and verify that traffic is now forwarded for the VLAN and PORT
+
+        Steps:
+           1. Create VLAN 100 and associate untagged port 2, 3 as the member port of VLAN 100.
+           2. Set port attribute value of "Port VLAN ID 100" for the port 2, 3.
+           3. Create Virtual router V1 and enable V4.
+           4. Create LAG "Id1"
+           5. Remove the port 1 from default VLAN and add the port 1 as member of LAG Id1.
+           6. Create two virtual router interfaces and set the interface type as "LAG" and "VLAN" for port 1 and (2,3) respectively.
+           7. Create IPv4 neighbor entry (10.10.10.1) with MAC1 and associate with "RIF Id1".
+           8. Create next hop to reach the neighbor entry.
+           9. Create route entry with /24 mask (i.e 12.12.12.0/24) through NHop1
+           10. Send IPv4 packet from port 2 (VLAN member) with destination IP 12.12.12.1
+
+        Part1:
+           11. Create ACL table and entry block the traffic based on Destination IP address (12.12.12.1)
+           12. Bind the ACL table with VLAN with attribute SAI_VLAN_ATTR_INGRESS_ACL
+           13. Send the IP packet again through port 2 and ensure the packet is dropped.
+        Part2:
+           14. Change the bind point from VLAN to the port 2
+           15. Send the IP packet again through port 2 and ensure the packet is dropped.
+           16. Send the IP packet again through port 3 and ensure the packet is received on port 1 (LAG)
+           17. Remove the ACL attribute and send the packet from port 2 and from port 3 (VLAN) and verify the packet is received on
+               port 1 (LAG)
+        Part3:
+           18. Remove the ACL table and entry.
+           19. Remove the route and the associated router interface, vlan members and the corresponding VLAN from the database.
+        """
+        switch_init(self.client)
+        port1 = port_list[0]
+        port2 = port_list[1]
+        port3 = port_list[2]
+        v4_enabled = 1
+        v6_enabled = 0
+        vlan_id = 100
+        mac_action = SAI_PACKET_ACTION_FORWARD
+        mac1 = ''
+
+        # Creating VLAN ID
+        vlan_oid = sai_thrift_create_vlan(self.client, vlan_id)
+        vlan_member1 = sai_thrift_create_vlan_member(self.client, vlan_oid, port2, SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        vlan_member2 = sai_thrift_create_vlan_member(self.client, vlan_oid, port3, SAI_VLAN_TAGGING_MODE_UNTAGGED)
+
+        attr_value = sai_thrift_attribute_value_t(u16=vlan_id)
+        attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_PORT_VLAN_ID, value=attr_value)
+        self.client.sai_thrift_set_port_attribute(port2, attr)
+        self.client.sai_thrift_set_port_attribute(port3, attr)
+
+        # Creating Virtual router
+        vr_id = sai_thrift_create_virtual_router(self.client, v4_enabled, v6_enabled)
+
+        lag_id1 = self.client.sai_thrift_create_lag([])
+        sai_thrift_vlan_remove_ports(self.client, switch.default_vlan.oid, [port1])
+        lag_member_id1 = sai_thrift_create_lag_member(self.client, lag_id1, port1)
+
+        # Creating RIF
+        rif_id1 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_PORT, lag_id1, 0, v4_enabled, v6_enabled, mac1)
+        rif_id2 = sai_thrift_create_router_interface(self.client, vr_id, SAI_ROUTER_INTERFACE_TYPE_VLAN, 0, vlan_oid, v4_enabled, v6_enabled, mac1)
+
+        addr_family = SAI_IP_ADDR_FAMILY_IPV4
+        ip_addr1 = '10.10.10.1'
+        ip_mask1 = '255.255.255.0'
+        dmac1 = '00:11:22:33:44:55'
+        ip_addr2 = '192.168.0.1'
+        ip_addr3_subnet = '12.12.12.0'
+        dmac2 = '00:11:22:33:44:56'
+
+        # Creating Neighbor, NHop and route
+        sai_thrift_create_neighbor(self.client, addr_family, rif_id1, ip_addr1, dmac1)
+        nhop1 = sai_thrift_create_nhop(self.client, addr_family, ip_addr1, rif_id1)
+        sai_thrift_create_route(self.client, vr_id, addr_family, ip_addr3_subnet, ip_mask1, nhop1)
+
+        # send the test packet(s)
+        pkt = simple_tcp_packet(pktlen=100,
+                                eth_dst=router_mac,
+                                eth_src=dmac2,
+                                ip_src=ip_addr2,
+                                ip_dst='12.12.12.1',
+                                ip_id=105,
+                                ip_ttl=64)
+        exp_pkt = simple_tcp_packet(
+                                pktlen=100,
+                                eth_dst=dmac1,
+                                eth_src=router_mac,
+                                ip_src=ip_addr2,
+                                ip_dst='12.12.12.1',
+                                ip_id=105,
+                                ip_ttl=63)
+
+        try:
+            print "Sending packet port 2 -> port 1 (192.168.0.1 -> 12.12.12.1 [id = 105])"
+            send_packet(self, 1, str(pkt))
+            print "Verifying packet"
+            verify_packets(self, exp_pkt, [0])
+            print "Expected packets received"
+
+            print "Sending packet port 3 -> port 1"
+            send_packet(self, 2, str(pkt))
+            print "Verifying packet at port 1"
+            verify_packets(self, exp_pkt, [0])
+
+            # setup ACL to block based on Destination IP
+            print "Setting up ACL"
+            table_stage = SAI_ACL_STAGE_INGRESS
+            table_bind_point_list = [SAI_ACL_BIND_POINT_TYPE_VLAN, SAI_ACL_BIND_POINT_TYPE_PORT]
+            entry_priority = SAI_SWITCH_ATTR_ACL_ENTRY_MINIMUM_PRIORITY
+            action = SAI_PACKET_ACTION_DROP
+            in_ports = None
+            mac_src = None
+            mac_dst = None
+            mac_src_mask = None
+            mac_dst_mask = None
+            ip_src = None
+            ip_src_mask = None
+            ip_dst = "12.12.12.1"
+            ip_dst_mask = "255.255.255.0"
+            ip_proto = None
+            in_port = None
+            out_port = None
+            out_ports = None
+            src_l4_port = None
+            dst_l4_port = None
+            ingress_mirror_id = None
+            egress_mirror_id = None
+
+
+            acl_table_id = sai_thrift_create_acl_table(
+                                                self.client,
+                                                table_stage,
+                                                table_bind_point_list,
+                                                addr_family,
+                                                mac_src,
+                                                mac_dst,
+                                                ip_src,
+                                                ip_dst,
+                                                ip_proto,
+                                                in_ports,
+                                                out_ports,
+                                                in_port,
+                                                out_port,
+                                                src_l4_port,
+                                                dst_l4_port)
+            acl_entry_id = sai_thrift_create_acl_entry(
+                                                self.client,
+                                                acl_table_id,
+                                                entry_priority,
+                                                action,
+                                                addr_family,
+                                                mac_src,
+                                                mac_src_mask,
+                                                mac_dst,
+                                                mac_dst_mask,
+                                                ip_src,
+                                                ip_src_mask,
+                                                ip_dst,
+                                                ip_dst_mask,
+                                                ip_proto,
+                                                in_ports,
+                                                out_ports,
+                                                in_port,
+                                                out_port,
+                                                src_l4_port,
+                                                dst_l4_port,
+                                                ingress_mirror_id,
+                                                egress_mirror_id)
+
+            # bind this ACL table to VLAN object id
+            print "Binding ACL to VLAN"
+            attr_value = sai_thrift_attribute_value_t(oid=acl_table_id)
+            attr = sai_thrift_attribute_t(id=SAI_VLAN_ATTR_INGRESS_ACL, value=attr_value)
+            self.client.sai_thrift_set_vlan_attribute(vlan_oid, attr)
+
+            print "Asserting ACL table entry"
+            assert acl_table_id > 0, 'acl_entry_id is <= 0'
+            assert acl_entry_id > 0, 'acl_entry_id is <= 0'
+            print '#### ACL \'DROP, src 12.12.12.1/255.255.255.0, in_ports[ptf_intf_1]\' Applied ####'
+            print '#### Sending      ', router_mac, '| 00:11:22:33:44:56 | 192.168.0.1 | 12.12.12.1 | @ ptf_intf 2'
+            # send the same packet
+            send_packet(self, 1, str(pkt))
+            # ensure packet is dropped
+            # check for absence of packet here!
+            print '#### NOT Expecting 00:11:22:33:44:55 |', router_mac, '| 12.12.12.1 | 192.168.0.1 | @ ptf_intf 1'
+            verify_no_packet(self, exp_pkt, 0)
+            print "ACL blocked packet as expected"
+
+            print "Sending packet port 3 -> port 1"
+            send_packet(self, 2, str(pkt))
+            print "Verifying packet at port 1"
+            verify_no_packet(self, exp_pkt, 0)
+
+
+            # ===== L3AclTableTest_III verification =======
+            print "\n\nChanging bind type from VLAN to Port"
+            attr_value = sai_thrift_attribute_value_t(oid=acl_table_id)
+            attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_INGRESS_ACL, value=attr_value)
+            self.client.sai_thrift_set_port_attribute(port2, attr)
+
+            print "Asserting ACL table entry"
+            assert acl_table_id > 0, 'acl_entry_id is <= 0'
+            assert acl_entry_id > 0, 'acl_entry_id is <= 0'
+            print '#### ACL \'DROP, src 12.12.12.1/255.255.255.0, in_ports[ptf_intf_2]\' Applied ####'
+
+            print "Sending packet from port 3 to port 1"
+            send_packet(self, 2, str(pkt))
+            print '#### Expecting 00:11:22:33:44:55 |', router_mac, '| 12.12.12.1 | 192.168.0.1 | @ ptf_intf 1'
+            verify_packets(self, exp_pkt, [0])
+
+            print "Sending packet from port 2 to port 1"
+            send_packet(self, 1, str(pkt))
+            print '#### NOT Expecting 00:11:22:33:44:55 |', router_mac, '| 12.12.12.1 | 192.168.0.1 | @ ptf_intf 1'
+            verify_no_packet(self, exp_pkt, 0)
+
+            print "Removing the ACL entry and table"
+            attr_value = sai_thrift_attribute_value_t(oid=SAI_NULL_OBJECT_ID)
+            attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_INGRESS_ACL, value=attr_value)
+            self.client.sai_thrift_set_port_attribute(port2, attr)
+
+            # unbind this ACL table from vlan object id
+            attr_value = sai_thrift_attribute_value_t(oid=SAI_NULL_OBJECT_ID)
+            attr = sai_thrift_attribute_t(id=SAI_VLAN_ATTR_INGRESS_ACL, value=attr_value)
+            self.client.sai_thrift_set_vlan_attribute(vlan_oid, attr)
+
+            print "Sending packet port 2 -> port 1 (192.168.0.1 -> 12.12.12.1 [id = 105])"
+            send_packet(self, 1, str(pkt))
+            print "Verifying packet"
+            verify_packets(self, exp_pkt, [0])
+
+            print "Sending packet port 3 -> port 1"
+            send_packet(self, 2, str(pkt))
+            print "Verifying packet at port 1"
+            verify_packets(self, exp_pkt, [0])
+
+        finally:
+            # unbind this ACL table from port and vlan object id
+            attr_value = sai_thrift_attribute_value_t(oid=SAI_NULL_OBJECT_ID)
+            attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_INGRESS_ACL, value=attr_value)
+            self.client.sai_thrift_set_port_attribute(port2, attr)
+
+            attr_value = sai_thrift_attribute_value_t(oid=SAI_NULL_OBJECT_ID)
+            attr = sai_thrift_attribute_t(id=SAI_VLAN_ATTR_INGRESS_ACL, value=attr_value)
+            self.client.sai_thrift_set_vlan_attribute(vlan_oid, attr)
+
+            sai_thrift_delete_fdb(self.client, vlan_oid, dmac2, port1)
+
+            # cleanup ACL
+            self.client.sai_thrift_remove_acl_entry(acl_entry_id)
+            self.client.sai_thrift_remove_acl_table(acl_table_id)
+            sai_thrift_remove_route(self.client, vr_id, addr_family, ip_addr3_subnet, ip_mask1, rif_id1)
+            self.client.sai_thrift_remove_next_hop(nhop1)
+            sai_thrift_remove_neighbor(self.client, addr_family, rif_id1, ip_addr1, dmac1)
+            sai_thrift_remove_lag_member(self.client, lag_member_id1)
+            self.client.sai_thrift_remove_lag(lag_id1)
+            self.client.sai_thrift_remove_router_interface(rif_id1)
+            self.client.sai_thrift_remove_router_interface(rif_id2)
+            self.client.sai_thrift_remove_virtual_router(vr_id)
+            self.client.sai_thrift_remove_vlan_member(vlan_member1)
+            self.client.sai_thrift_remove_vlan(vlan_oid)
+
+

--- a/test/saithrift/tests/saiacl.py
+++ b/test/saithrift/tests/saiacl.py
@@ -1904,7 +1904,7 @@ class L3AclTableTestII(sai_base_test.ThriftInterfaceDataPlane):
             # cleanup ACL
             self.client.sai_thrift_remove_acl_entry(acl_entry_id)
             self.client.sai_thrift_remove_acl_table(acl_table_id)
-            sai_thrift_remove_route(self.client, vr_id, addr_family, ip_addr3_subnet, ip_mask1, rif_id1)
+            sai_thrift_remove_route(self.client, vr_id, addr_family, ip_addr3_subnet, ip_mask1, nhop1)
             sai_thrift_remove_route(self.client, vr_id, addr_family, ip_addr1_subnet, ip_mask, rif_id1)
             self.client.sai_thrift_remove_next_hop(nhop1)
             sai_thrift_remove_neighbor(self.client, addr_family, rif_id1, ip_addr1, dmac1)

--- a/test/saithrift/tests/saiacl.py
+++ b/test/saithrift/tests/saiacl.py
@@ -1707,6 +1707,8 @@ class L3AclTableTestII(sai_base_test.ThriftInterfaceDataPlane):
         addr_family = SAI_IP_ADDR_FAMILY_IPV4
         ip_addr1 = '10.10.10.1'
         ip_mask1 = '255.255.255.0'
+        ip_addr_subnet = '10.10.0.0'
+        ip_mask = '255.255.0.0'
         dmac1 = '00:11:22:33:44:55'
         ip_addr2 = '192.168.0.1'
         ip_addr3_subnet = '12.12.12.0'
@@ -1716,6 +1718,7 @@ class L3AclTableTestII(sai_base_test.ThriftInterfaceDataPlane):
         sai_thrift_create_neighbor(self.client, addr_family, rif_id1, ip_addr1, dmac1)
         nhop1 = sai_thrift_create_nhop(self.client, addr_family, ip_addr1, rif_id1)
         sai_thrift_create_route(self.client, vr_id, addr_family, ip_addr3_subnet, ip_mask1, nhop1)
+        sai_thrift_create_route(self.client, vr_id, addr_family, ip_addr1_subnet, ip_mask, rif_id1)
 
         # send the test packet(s)
         pkt = simple_tcp_packet(pktlen=100,
@@ -1733,6 +1736,9 @@ class L3AclTableTestII(sai_base_test.ThriftInterfaceDataPlane):
                                 ip_dst='12.12.12.1',
                                 ip_id=105,
                                 ip_ttl=63)
+
+        acl_entry_id = SAI_NULL_OBJECT_ID
+        acl_table_id = SAI_NULL_OBJECT_ID
 
         try:
             print "Sending packet port 2 -> port 1 (192.168.0.1 -> 12.12.12.1 [id = 105])"
@@ -1896,11 +1902,12 @@ class L3AclTableTestII(sai_base_test.ThriftInterfaceDataPlane):
             self.client.sai_thrift_remove_next_hop(nhop1)
             sai_thrift_remove_neighbor(self.client, addr_family, rif_id1, ip_addr1, dmac1)
             sai_thrift_remove_lag_member(self.client, lag_member_id1)
-            self.client.sai_thrift_remove_lag(lag_id1)
             self.client.sai_thrift_remove_router_interface(rif_id1)
             self.client.sai_thrift_remove_router_interface(rif_id2)
+            self.client.sai_thrift_remove_lag(lag_id1)
             self.client.sai_thrift_remove_virtual_router(vr_id)
             self.client.sai_thrift_remove_vlan_member(vlan_member1)
+            self.client.sai_thrift_remove_vlan_member(vlan_member2)
             self.client.sai_thrift_remove_vlan(vlan_oid)
 
 

--- a/test/saithrift/tests/saiacl.py
+++ b/test/saithrift/tests/saiacl.py
@@ -1707,7 +1707,7 @@ class L3AclTableTestII(sai_base_test.ThriftInterfaceDataPlane):
         addr_family = SAI_IP_ADDR_FAMILY_IPV4
         ip_addr1 = '10.10.10.1'
         ip_mask1 = '255.255.255.0'
-        ip_addr_subnet = '10.10.0.0'
+        ip_addr1_subnet = '10.10.0.0'
         ip_mask = '255.255.0.0'
         dmac1 = '00:11:22:33:44:55'
         ip_addr2 = '192.168.0.1'
@@ -1844,6 +1844,12 @@ class L3AclTableTestII(sai_base_test.ThriftInterfaceDataPlane):
 
             # ===== L3AclTableTest_III verification =======
             print "\n\nChanging bind type from VLAN to Port"
+            # Unbinding from vlan
+            attr_value = sai_thrift_attribute_value_t(oid=SAI_NULL_OBJECT_ID)
+            attr = sai_thrift_attribute_t(id=SAI_VLAN_ATTR_INGRESS_ACL, value=attr_value)
+            self.client.sai_thrift_set_vlan_attribute(vlan_oid, attr)
+
+            #binding acl  to port
             attr_value = sai_thrift_attribute_value_t(oid=acl_table_id)
             attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_INGRESS_ACL, value=attr_value)
             self.client.sai_thrift_set_port_attribute(port2, attr)
@@ -1899,6 +1905,7 @@ class L3AclTableTestII(sai_base_test.ThriftInterfaceDataPlane):
             self.client.sai_thrift_remove_acl_entry(acl_entry_id)
             self.client.sai_thrift_remove_acl_table(acl_table_id)
             sai_thrift_remove_route(self.client, vr_id, addr_family, ip_addr3_subnet, ip_mask1, rif_id1)
+            sai_thrift_remove_route(self.client, vr_id, addr_family, ip_addr1_subnet, ip_mask, rif_id1)
             self.client.sai_thrift_remove_next_hop(nhop1)
             sai_thrift_remove_neighbor(self.client, addr_family, rif_id1, ip_addr1, dmac1)
             sai_thrift_remove_lag_member(self.client, lag_member_id1)


### PR DESCRIPTION
Adding SAI PTF tests for 3AclTableTest_II and L3AclTableTest_III
(https://github.com/opencomputeproject/SAI/blob/master/test/saithrift/tests/SAITest.md)

Note : This PR to b merged after  #975 
The changed required for vlan configurations in  inswitch_sai_rpc_server.cpp   and switch_sai.thrift are committed in #975 

