### PR TITLE
Introduce buffer pool type SAI_BUFFER_POOL_TYPE_BOTH

### DIFF
--- a/inc/saibuffer.h
+++ b/inc/saibuffer.h
@@ -244,6 +244,9 @@ typedef enum _sai_buffer_pool_type_t
     /** Egress buffer pool */
     SAI_BUFFER_POOL_TYPE_EGRESS,
 
+    /** Buffer pool used by both ingress and egress */
+    SAI_BUFFER_POOL_TYPE_BOTH
+
 } sai_buffer_pool_type_t;
 
 /**


### PR DESCRIPTION
SAI_BUFFER_POOL_TYPE_BOTH indicates the buffer pool specification encompasses both ingress characterization and egress characterization. Some of the fields may apply only to ingress, e.g., SAI_BUFFER_POOL_ATTR_XOFF_SIZE, while others can apply globally to both ingress and egress.

Specifically, SAI_BUFFER_POOL_ATTR_XOFF_SIZE is the partition for headroom pool, which applies only to ingress, while SAI_BUFFER_POOL_ATTR_SIZE is the shared pool size from the ingress viewpoint, as well as the shared pool size from the egress (VOQ) viewpoint.

Signed-off-by: Wenda Ni <wenni@microsoft.com>