### PR TITLE
Add support for INT type tail timestamping

### DIFF
--- a/inc/saitam.h
+++ b/inc/saitam.h
@@ -469,7 +469,12 @@ typedef enum _sai_tam_int_type_t
     /**
      * @brief Direct Export (aka postcard)
      */
-    SAI_TAM_INT_TYPE_DIRECT_EXPORT
+    SAI_TAM_INT_TYPE_DIRECT_EXPORT,
+
+    /**
+     * @brief Telemetry data at the end of the packet
+     */
+    SAI_TAM_INT_TYPE_TAIL_TIMESTAMP,
 
 } sai_tam_int_type_t;
 

--- a/inc/saitam.h
+++ b/inc/saitam.h
@@ -474,7 +474,7 @@ typedef enum _sai_tam_int_type_t
     /**
      * @brief Telemetry data at the end of the packet
      */
-    SAI_TAM_INT_TYPE_TAIL_TIMESTAMP,
+    SAI_TAM_INT_TYPE_IFA1_TAILSTAMP,
 
 } sai_tam_int_type_t;
 


### PR DESCRIPTION
Add support for an INT type where the metadata (ingress and egress timestamps) are inserted at the end of the packet before the Ethernet CRC.

The developer work flow is identical as described in the TAM documentation, and only a new INT type is being added.