### PR TITLE
RO Attr (switch obj) to get a list of supported obj types

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -1762,6 +1762,17 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_TAM_EVENT_NOTIFY,
 
     /**
+     * @brief List of supported object types
+     *
+     * A list of object types (sai_oject_type_t) that the SAI adapter can
+     * support.
+     *
+     * @type sai_s32_list_t sai_object_type_t
+     * @flags READ_ONLY
+     */
+    SAI_SWITCH_ATTR_SUPPORTED_OBJECT_TYPE_LIST,
+
+    /**
      * @brief Instruct SAI to execute switch pre-shutdown
      *
      * Indicates controlled switch pre-shutdown as first step of warm shutdown.

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -1764,7 +1764,7 @@ typedef enum _sai_switch_attr_t
     /**
      * @brief List of supported object types
      *
-     * A list of object types (sai_oject_type_t) that the SAI adapter can
+     * A list of object types (sai_object_type_t) that the SAI adapter can
      * support.
      *
      * @type sai_s32_list_t sai_object_type_t


### PR DESCRIPTION
A new RO attribute to switch object that returns the list of supported object types that the underlying SAI adapter can support. This allows the clients of SAI to understand the abilities of the underlying silicon as well as the SAI adapter to support the SAI feature set.