### PR TITLE
Add support for Aggregate reporting for TAM Events

### DIFF
--- a/inc/saitam.h
+++ b/inc/saitam.h
@@ -1159,8 +1159,8 @@ typedef enum _sai_tam_report_mode_t
     /** Report all events */
     SAI_TAM_REPORT_MODE_ALL = 0,
 
-    /** Report in an aggregate mode */
-    SAI_TAM_REPORT_MODE_AGGREGATE,
+    /** Report in a bulk mode */
+    SAI_TAM_REPORT_MODE_BULK,
 
 } sai_tam_report_mode_t;
 
@@ -1232,10 +1232,10 @@ typedef enum _sai_tam_report_attr_t
     /**
      * @brief Report Interval in micro seconds
      *
-     * Note: valid only if SAI_TAM_REPORT_ATTR_REPORT_MODE == SAI_TAM_REPORT_MODE_AGGREGATE
+     * Note: valid only if SAI_TAM_REPORT_ATTR_REPORT_MODE == SAI_TAM_REPORT_MODE_BULK
      *
      * @type sai_uint32_t
-     * @flags CREATE_ONLY
+     * @flags CREATE_AND_SET
      * @default 1000
      */
     SAI_TAM_REPORT_ATTR_REPORT_INTERVAL,

--- a/inc/saitam.h
+++ b/inc/saitam.h
@@ -1151,6 +1151,20 @@ typedef enum _sai_tam_report_type_t
 } sai_tam_report_type_t;
 
 /**
+ * @brief Enum defining reporting modes.
+ */
+typedef enum _sai_tam_report_mode_t
+{
+
+    /** Report all events */
+    SAI_TAM_REPORT_MODE_ALL = 0,
+
+    /** Report in an aggregate mode */
+    SAI_TAM_REPORT_MODE_AGGREGATE,
+
+} sai_tam_report_mode_t;
+
+/**
  * @brief Attributes for TAM report
  */
 typedef enum _sai_tam_report_attr_t
@@ -1206,6 +1220,25 @@ typedef enum _sai_tam_report_attr_t
      * @default 0
      */
     SAI_TAM_REPORT_ATTR_QUOTA,
+
+    /**
+     * @brief Report Mode
+     * @type sai_tam_report_mode_t
+     * @flags CREATE_ONLY
+     * @default SAI_TAM_REPORT_MODE_ALL
+     */
+    SAI_TAM_REPORT_ATTR_REPORT_MODE,
+
+    /**
+     * @brief Report Interval in micro seconds
+     *
+     * Note: valid only if SAI_TAM_REPORT_ATTR_REPORT_MODE == SAI_TAM_REPORT_MODE_AGGREGATE
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_ONLY
+     * @default 1000
+     */
+    SAI_TAM_REPORT_ATTR_REPORT_INTERVAL,
 
     /**
      * @brief End of Attributes

--- a/inc/saitam.h
+++ b/inc/saitam.h
@@ -1232,11 +1232,10 @@ typedef enum _sai_tam_report_attr_t
     /**
      * @brief Report Interval in micro seconds
      *
-     * Note: valid only if SAI_TAM_REPORT_ATTR_REPORT_MODE == SAI_TAM_REPORT_MODE_BULK
-     *
      * @type sai_uint32_t
      * @flags CREATE_AND_SET
      * @default 1000
+     * @validonly SAI_TAM_REPORT_ATTR_REPORT_MODE == SAI_TAM_REPORT_MODE_BULK
      */
     SAI_TAM_REPORT_ATTR_REPORT_INTERVAL,
 


### PR DESCRIPTION
Add an optional attribute to tam/report object to add support for Aggregate reporting for TAM Events. Since it is an optional attribute, the current functionality of reporting every event is unaffected. User can select 'aggregate' mode for the report mode attribute and specify an interval. When chosen, aggregate-reports are sent at the chosen interval.