### PR TITLE
Warning: Fix for Unsigned long long usage in 32bit arch using ULL macro

### DIFF
--- a/meta/Makefile
+++ b/meta/Makefile
@@ -41,7 +41,6 @@ WARNINGS = \
 	-Winit-self \
 	-Winline \
 	-Winvalid-pch \
-	-Wlong-long \
 	-Wmissing-field-initializers \
 	-Wmissing-format-attribute \
 	-Wmissing-include-dirs \

--- a/meta/saiserialize.c
+++ b/meta/saiserialize.c
@@ -850,10 +850,12 @@ int sai_serialize_ip6_mask(
         _In_ const sai_ip6_t mask)
 {
     uint32_t n = 64;
-    uint64_t tmp = 0xFFFFFFFFFFFFFFFFUL;
+    uint64_t tmp = UINT64_C(0xFFFFFFFFFFFFFFFF);
 
-    uint64_t high = *((const uint64_t*)mask);
-    uint64_t low  = *((const uint64_t*)mask + 1);
+    uint64_t high;
+    uint64_t low;
+    memcpy(&high, (const uint8_t*)mask, sizeof(uint64_t));
+    memcpy(&low, ((const uint8_t*)mask + sizeof(uint64_t)), sizeof(uint64_t));
 
     high = __builtin_bswap64(high);
     low = __builtin_bswap64(low);
@@ -899,8 +901,9 @@ int sai_deserialize_ip6_mask(
         return SAI_SERIALIZE_ERROR;
     }
 
-    uint64_t high = 0xFFFFFFFFFFFFFFFFUL;
-    uint64_t low  = 0xFFFFFFFFFFFFFFFFUL;
+    uint64_t high = UINT64_C(0xFFFFFFFFFFFFFFFF);
+    uint64_t low  = UINT64_C(0xFFFFFFFFFFFFFFFF);
+    uint64_t tmp;
 
     if (value == 128)
     {
@@ -924,8 +927,10 @@ int sai_deserialize_ip6_mask(
         low = 0;
     }
 
-    *((uint64_t*)mask) = __builtin_bswap64(high);
-    *((uint64_t*)mask + 1) = __builtin_bswap64(low);
+    tmp = __builtin_bswap64(high);
+    memcpy((uint8_t*)mask, &tmp, sizeof(uint64_t));
+    tmp = __builtin_bswap64(low);
+    memcpy(((uint8_t*)mask + sizeof(uint64_t)), &tmp, sizeof(uint64_t));
 
     return res;
 }


### PR DESCRIPTION
Signed-off-by: Antony Rheneus <arheneus@marvell.com>