### PR TITLE
Add support for deep/large buffers in buffer objects

### DIFF
--- a/inc/saibuffer.h
+++ b/inc/saibuffer.h
@@ -275,7 +275,7 @@ typedef enum _sai_buffer_pool_attr_t
      * This is derived from subtracting all reversed buffers of queue/port
      * from the total pool size.
      *
-     * @type sai_uint32_t
+     * @type sai_uint64_t
      * @flags READ_ONLY
      */
     SAI_BUFFER_POOL_ATTR_SHARED_SIZE = SAI_BUFFER_POOL_ATTR_START,
@@ -291,7 +291,7 @@ typedef enum _sai_buffer_pool_attr_t
     /**
      * @brief Buffer pool size in bytes
      *
-     * @type sai_uint32_t
+     * @type sai_uint64_t
      * @flags MANDATORY_ON_CREATE | CREATE_AND_SET
      */
     SAI_BUFFER_POOL_ATTR_SIZE,
@@ -322,7 +322,7 @@ typedef enum _sai_buffer_pool_attr_t
      * If shared headroom pool size is not zero, its size is included in
      * the corresponding ingress buffer pool size SAI_BUFFER_POOL_ATTR_SIZE
      *
-     * @type sai_uint32_t
+     * @type sai_uint64_t
      * @flags CREATE_AND_SET
      * @default 0
      */
@@ -570,7 +570,7 @@ typedef enum _sai_buffer_profile_attr_t
     /**
      * @brief Reserved buffer size in bytes
      *
-     * @type sai_uint32_t
+     * @type sai_uint64_t
      * @flags MANDATORY_ON_CREATE | CREATE_AND_SET
      */
     SAI_BUFFER_PROFILE_ATTR_RESERVED_BUFFER_SIZE,
@@ -604,7 +604,7 @@ typedef enum _sai_buffer_profile_attr_t
      *
      * When set to zero there is no limit for the shared usage.
      *
-     * @type sai_uint32_t
+     * @type sai_uint64_t
      * @flags MANDATORY_ON_CREATE | CREATE_AND_SET
      * @condition SAI_BUFFER_PROFILE_ATTR_THRESHOLD_MODE == SAI_BUFFER_PROFILE_THRESHOLD_MODE_STATIC
      */
@@ -624,7 +624,7 @@ typedef enum _sai_buffer_profile_attr_t
      * and XOFF_TH specifies the maximum amount of headroom pool
      * buffer one PG can use.
      *
-     * @type sai_uint32_t
+     * @type sai_uint64_t
      * @flags CREATE_AND_SET
      * @default 0
      */
@@ -641,7 +641,7 @@ typedef enum _sai_buffer_profile_attr_t
      * The XON trigger condition is governed by:
      * total buffer usage <= max(XON_TH, total buffer limit - XON_OFFSET_TH)
      *
-     * @type sai_uint32_t
+     * @type sai_uint64_t
      * @flags CREATE_AND_SET
      * @default 0
      */
@@ -658,7 +658,7 @@ typedef enum _sai_buffer_profile_attr_t
      * The XON trigger condition is governed by:
      * total buffer usage <= max(XON_TH, total buffer limit - XON_OFFSET_TH)
      *
-     * @type sai_uint32_t
+     * @type sai_uint64_t
      * @flags CREATE_AND_SET
      * @default 0
      */

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -1762,17 +1762,6 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_TAM_EVENT_NOTIFY,
 
     /**
-     * @brief List of supported object types
-     *
-     * A list of object types (sai_oject_type_t) that the SAI adapter can
-     * support.
-     *
-     * @type sai_s32_list_t sai_object_type_t
-     * @flags READ_ONLY
-     */
-    SAI_SWITCH_ATTR_SUPPORTED_OBJECT_TYPE_LIST,
-
-    /**
      * @brief Instruct SAI to execute switch pre-shutdown
      *
      * Indicates controlled switch pre-shutdown as first step of warm shutdown.

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -679,7 +679,7 @@ typedef enum _sai_switch_attr_t
     /**
      * @brief Switch total buffer size in KB
      *
-     * @type sai_uint32_t
+     * @type sai_uint64_t
      * @flags READ_ONLY
      */
     SAI_SWITCH_ATTR_TOTAL_BUFFER_SIZE,
@@ -1760,6 +1760,17 @@ typedef enum _sai_switch_attr_t
      * @default NULL
      */
     SAI_SWITCH_ATTR_TAM_EVENT_NOTIFY,
+
+    /**
+     * @brief List of supported object types
+     *
+     * A list of object types (sai_oject_type_t) that the SAI adapter can
+     * support.
+     *
+     * @type sai_s32_list_t sai_object_type_t
+     * @flags READ_ONLY
+     */
+    SAI_SWITCH_ATTR_SUPPORTED_OBJECT_TYPE_LIST,
 
     /**
      * @brief Instruct SAI to execute switch pre-shutdown


### PR DESCRIPTION
The currently defined 32bit type can't hold large sizes for the buffers. Changed the buffer size data type to 64bits.