### PR TITLE
Modify GENETLINK multicast group attribute from id to name

### DIFF
--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -46,6 +46,11 @@
 #define SAI_HOSTIF_NAME_SIZE 16
 
 /**
+ * @brief Defines maximum length of generic netlink multicast group name
+ */
+#define SAI_HOSTIF_GENETLINK_MCGRP_NAME_SIZE 16
+
+/**
  * @brief Host interface trap group attributes
  */
 typedef enum _sai_hostif_trap_group_attr_t
@@ -801,14 +806,17 @@ typedef enum _sai_hostif_attr_t
     SAI_HOSTIF_ATTR_VLAN_TAG,
 
     /**
-     * @brief Set the Generic netlink (multicast) port id on which the packets/buffers
+     * @brief Name [char[SAI_HOSTIF_GENETLINK_MCGRP_NAME_SIZE]]
+     *
+     * The maximum number of characters for the name is SAI_HOSTIF_GENETLINK_MCGRP_NAME_SIZE - 1
+     * Set the Generic netlink multicast group name on which the packets/buffers
      * are received on this host interface
      *
-     * @type sai_uint32_t
+     * @type char
      * @flags CREATE_AND_SET
-     * @default 0
+     * @default ""
      */
-    SAI_HOSTIF_ATTR_GENETLINK_PORT_ID,
+    SAI_HOSTIF_ATTR_GENETLINK_MCGRP_NAME,
 
     /**
      * @brief End of attributes

--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -813,8 +813,8 @@ typedef enum _sai_hostif_attr_t
      * are received on this host interface
      *
      * @type char
-     * @flags CREATE_AND_SET
-     * @default ""
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_HOSTIF_ATTR_TYPE == SAI_HOSTIF_TYPE_GENETLINK
      */
     SAI_HOSTIF_ATTR_GENETLINK_MCGRP_NAME,
 


### PR DESCRIPTION
Since it is convenient to lookup the multicast group based on name rather than id (both from SAI driver and sflow daemon perspective), changing the genetlink multicast sampling group attribute to char. For e.g, if the psample driver is used, SAI_HOSTIF_ATTR_NAME="psample" and SAI_HOSTIF_ATTR_GENETLINK_MCGRP_NAME="packets" (https://github.com/torvalds/linux/blob/master/include/uapi/linux/psample.h#L32 )