### PR TITLE
Defining new serdes attributes

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -1223,6 +1223,7 @@ typedef enum _sai_port_attr_t
      * @type sai_object_id_t
      * @flags READ_ONLY
      * @objects SAI_OBJECT_TYPE_PORT_SERDES
+     * @default internal
      */
     SAI_PORT_ATTR_PORT_SERDES_ID,
 
@@ -2147,7 +2148,7 @@ typedef enum _sai_port_serdes_attr_t
      * to be applied to each lane.
      *
      * @type sai_u32_list_t
-     * @flags CREATE_AND_SET
+     * @flags CREATE_ONLY
      * @default internal
      */
     SAI_PORT_SERDES_ATTR_PREEMPHASIS,
@@ -2160,7 +2161,7 @@ typedef enum _sai_port_serdes_attr_t
      * to be applied to each lane.
      *
      * @type sai_u32_list_t
-     * @flags CREATE_AND_SET
+     * @flags CREATE_ONLY
      * @default internal
      */
     SAI_PORT_SERDES_ATTR_IDRIVER,
@@ -2173,7 +2174,7 @@ typedef enum _sai_port_serdes_attr_t
      * to be applied to each lane.
      *
      * @type sai_u32_list_t
-     * @flags CREATE_AND_SET
+     * @flags CREATE_ONLY
      * @default internal
      */
     SAI_PORT_SERDES_ATTR_IPREDRIVER,
@@ -2186,7 +2187,7 @@ typedef enum _sai_port_serdes_attr_t
      * a port and the list specifies list of values to be applied to each lane.
      *
      * @type sai_u32_list_t
-     * @flags CREATE_AND_SET
+     * @flags CREATE_ONLY
      * @default internal
      */
     SAI_PORT_SERDES_ATTR_TX_FIR_PRE1,
@@ -2199,7 +2200,7 @@ typedef enum _sai_port_serdes_attr_t
      * a port and the list specifies list of values to be applied to each lane.
      *
      * @type sai_u32_list_t
-     * @flags CREATE_AND_SET
+     * @flags CREATE_ONLY
      * @default internal
      */
     SAI_PORT_SERDES_ATTR_TX_FIR_PRE2,
@@ -2212,7 +2213,7 @@ typedef enum _sai_port_serdes_attr_t
      * a port and the list specifies list of values to be applied to each lane.
      *
      * @type sai_u32_list_t
-     * @flags CREATE_AND_SET
+     * @flags CREATE_ONLY
      * @default internal
      */
     SAI_PORT_SERDES_ATTR_TX_FIR_PRE3,
@@ -2225,7 +2226,7 @@ typedef enum _sai_port_serdes_attr_t
      * a port and the list specifies list of values to be applied to each lane.
      *
      * @type sai_u32_list_t
-     * @flags CREATE_AND_SET
+     * @flags CREATE_ONLY
      * @default internal
      */
     SAI_PORT_SERDES_ATTR_TX_FIR_MAIN,
@@ -2238,7 +2239,7 @@ typedef enum _sai_port_serdes_attr_t
      * a port and the list specifies list of values to be applied to each lane.
      *
      * @type sai_u32_list_t
-     * @flags CREATE_AND_SET
+     * @flags CREATE_ONLY
      * @default internal
      */
     SAI_PORT_SERDES_ATTR_TX_FIR_POST1,
@@ -2251,7 +2252,7 @@ typedef enum _sai_port_serdes_attr_t
      * a port and the list specifies list of values to be applied to each lane.
      *
      * @type sai_u32_list_t
-     * @flags CREATE_AND_SET
+     * @flags CREATE_ONLY
      * @default internal
      */
     SAI_PORT_SERDES_ATTR_TX_FIR_POST2,
@@ -2264,7 +2265,7 @@ typedef enum _sai_port_serdes_attr_t
      * a port and the list specifies list of values to be applied to each lane.
      *
      * @type sai_u32_list_t
-     * @flags CREATE_AND_SET
+     * @flags CREATE_ONLY
      * @default internal
      */
     SAI_PORT_SERDES_ATTR_TX_FIR_POST3,
@@ -2277,7 +2278,7 @@ typedef enum _sai_port_serdes_attr_t
      * a port and the list specifies list of values to be applied to each lane.
      *
      * @type sai_u32_list_t
-     * @flags CREATE_AND_SET
+     * @flags CREATE_ONLY
      * @default internal
      */
     SAI_PORT_SERDES_ATTR_TX_FIR_ATTN,

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -1160,6 +1160,7 @@ typedef enum _sai_port_attr_t
     /**
      * @brief Port serdes control pre-emphasis
      *
+     * Deprecated. Use SAI_OBJECT_TYPE_PORT_SERDES
      * List of port serdes pre-emphasis values. The values are of type sai_u32_list_t
      * where the count is number lanes in a port and the list specifies list of values
      * to be applied to each lane.
@@ -1173,6 +1174,7 @@ typedef enum _sai_port_attr_t
     /**
      * @brief Port serdes control idriver
      *
+     * Deprecated. Use SAI_OBJECT_TYPE_PORT_SERDES
      * List of port serdes idriver values. The values are of type sai_u32_list_t
      * where the count is number lanes in a port and the list specifies list of values
      * to be applied to each lane.
@@ -1186,6 +1188,7 @@ typedef enum _sai_port_attr_t
     /**
      * @brief Port serdes control ipredriver
      *
+     * Deprecated. Use SAI_OBJECT_TYPE_PORT_SERDES
      * List of port serdes ipredriver values. The values are of type sai_u32_list_t
      * where the count is number lanes in a port and the list specifies list of values
      * to be applied to each lane.
@@ -1213,6 +1216,15 @@ typedef enum _sai_port_attr_t
      * @default SAI_PORT_PTP_MODE_NONE
      */
     SAI_PORT_ATTR_PTP_MODE,
+
+    /**
+     * @brief Serdes object ID for the port
+     *
+     * @type sai_object_id_t
+     * @flags READ_ONLY
+     * @objects SAI_OBJECT_TYPE_PORT_SERDES
+     */
+    SAI_PORT_ATTR_PORT_SERDES_ID,
 
     /**
      * @brief End of attributes
@@ -2109,6 +2121,233 @@ typedef sai_status_t (*sai_clear_port_pool_stats_fn)(
         _In_ const sai_stat_id_t *counter_ids);
 
 /**
+ * @brief List of Port Serdes attributes
+ */
+typedef enum _sai_port_serdes_attr_t
+{
+    /**
+     * @brief Start of attributes
+     */
+    SAI_PORT_SERDES_ATTR_START,
+
+    /**
+     * @brief Port ID
+     *
+     * @type sai_object_id_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @objects SAI_OBJECT_TYPE_PORT
+     */
+    SAI_PORT_SERDES_ATTR_PORT_ID = SAI_PORT_SERDES_ATTR_START,
+
+    /**
+     * @brief Port serdes control pre-emphasis
+     *
+     * List of port serdes pre-emphasis values. The values are of type sai_u32_list_t
+     * where the count is number lanes in a port and the list specifies list of values
+     * to be applied to each lane.
+     *
+     * @type sai_u32_list_t
+     * @flags CREATE_AND_SET
+     * @default internal
+     */
+    SAI_PORT_SERDES_ATTR_PREEMPHASIS,
+
+    /**
+     * @brief Port serdes control idriver
+     *
+     * List of port serdes idriver values. The values are of type sai_u32_list_t
+     * where the count is number lanes in a port and the list specifies list of values
+     * to be applied to each lane.
+     *
+     * @type sai_u32_list_t
+     * @flags CREATE_AND_SET
+     * @default internal
+     */
+    SAI_PORT_SERDES_ATTR_IDRIVER,
+
+    /**
+     * @brief Port serdes control pre-emphasis
+     *
+     * List of port serdes ipredriver values. The values are of type sai_u32_list_t
+     * where the count is number lanes in a port and the list specifies list of values
+     * to be applied to each lane.
+     *
+     * @type sai_u32_list_t
+     * @flags CREATE_AND_SET
+     * @default internal
+     */
+    SAI_PORT_SERDES_ATTR_IPREDRIVER,
+
+    /**
+     * @brief Port serdes control TX FIR PRE1 filter
+     *
+     * List of port serdes TX fir precursor1 tap-filter values.
+     * The values are of type sai_u32_list_t where the count is number lanes in
+     * a port and the list specifies list of values to be applied to each lane.
+     *
+     * @type sai_u32_list_t
+     * @flags CREATE_AND_SET
+     * @default internal
+     */
+    SAI_PORT_SERDES_ATTR_TX_FIR_PRE1,
+
+    /**
+     * @brief Port serdes control TX FIR PRE2 filter
+     *
+     * List of port serdes TX fir precursor2 tap-filter values.
+     * The values are of type sai_u32_list_t where the count is number lanes in
+     * a port and the list specifies list of values to be applied to each lane.
+     *
+     * @type sai_u32_list_t
+     * @flags CREATE_AND_SET
+     * @default internal
+     */
+    SAI_PORT_SERDES_ATTR_TX_FIR_PRE2,
+
+    /**
+     * @brief Port serdes control TX FIR PRE3 filter
+     *
+     * List of port serdes TX fir precursor3 tap-filter values.
+     * The values are of type sai_u32_list_t where the count is number lanes in
+     * a port and the list specifies list of values to be applied to each lane.
+     *
+     * @type sai_u32_list_t
+     * @flags CREATE_AND_SET
+     * @default internal
+     */
+    SAI_PORT_SERDES_ATTR_TX_FIR_PRE3,
+
+    /**
+     * @brief Port serdes control TX FIR MAIN filter
+     *
+     * List of port serdes TX fir maincursor tap-filter values.
+     * The values are of type sai_u32_list_t where the count is number lanes in
+     * a port and the list specifies list of values to be applied to each lane.
+     *
+     * @type sai_u32_list_t
+     * @flags CREATE_AND_SET
+     * @default internal
+     */
+    SAI_PORT_SERDES_ATTR_TX_FIR_MAIN,
+
+    /**
+     * @brief Port serdes control TX FIR POST1 filter
+     *
+     * List of port serdes TX fir postcursor1 tap-filter values.
+     * The values are of type sai_u32_list_t where the count is number lanes in
+     * a port and the list specifies list of values to be applied to each lane.
+     *
+     * @type sai_u32_list_t
+     * @flags CREATE_AND_SET
+     * @default internal
+     */
+    SAI_PORT_SERDES_ATTR_TX_FIR_POST1,
+
+    /**
+     * @brief Port serdes control TX FIR POST2 filter
+     *
+     * List of port serdes TX fir postcursor2 tap-filter values.
+     * The values are of type sai_u32_list_t where the count is number lanes in
+     * a port and the list specifies list of values to be applied to each lane.
+     *
+     * @type sai_u32_list_t
+     * @flags CREATE_AND_SET
+     * @default internal
+     */
+    SAI_PORT_SERDES_ATTR_TX_FIR_POST2,
+
+    /**
+     * @brief Port serdes control TX FIR POST3 filter
+     *
+     * List of port serdes TX fir postcursor3 tap-filter values.
+     * The values are of type sai_u32_list_t where the count is number lanes in
+     * a port and the list specifies list of values to be applied to each lane.
+     *
+     * @type sai_u32_list_t
+     * @flags CREATE_AND_SET
+     * @default internal
+     */
+    SAI_PORT_SERDES_ATTR_TX_FIR_POST3,
+
+    /**
+     * @brief Port serdes control TX FIR attenuation
+     *
+     * List of port serdes TX fir attn values.
+     * The values are of type sai_u32_list_t where the count is number lanes in
+     * a port and the list specifies list of values to be applied to each lane.
+     *
+     * @type sai_u32_list_t
+     * @flags CREATE_AND_SET
+     * @default internal
+     */
+    SAI_PORT_SERDES_ATTR_TX_FIR_ATTN,
+
+    /**
+     * @brief End of attributes
+     */
+    SAI_PORT_SERDES_ATTR_END,
+
+    /** Custom range base value */
+    SAI_PORT_SERDES_ATTR_CUSTOM_RANGE_START = 0x10000000,
+
+    /** End of custom range base */
+    SAI_PORT_SERDES_ATTR_CUSTOM_RANGE_END
+
+} sai_port_serdes_attr_t;
+
+/**
+ * @brief Create port serdes
+ *
+ * @param[out] port_serdes_id Port serdes id
+ * @param[in] switch_id Switch id
+ * @param[in] attr_count Number of attributes
+ * @param[in] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_create_port_serdes_fn)(
+        _Out_ sai_object_id_t *port_serdes_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list);
+
+/**
+ * @brief Remove port serdes
+ *
+ * @param[in] port_serdes_id Port serdes id
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_remove_port_serdes_fn)(
+        _In_ sai_object_id_t port_serdes_id);
+
+/**
+ * @brief Set Port serdes attribute value.
+ *
+ * @param[in] port_serdes_id Port serdes id
+ * @param[in] attr Attribute
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_set_port_serdes_attribute_fn)(
+        _In_ sai_object_id_t port_serdes_id,
+        _In_ const sai_attribute_t *attr);
+
+/**
+ * @brief Get Port serdes attribute value.
+ *
+ * @param[in] port_serdes_id Port serdes id
+ * @param[in] attr_count Number of attributes
+ * @param[inout] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_port_serdes_attribute_fn)(
+        _In_ sai_object_id_t port_serdes_id,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list);
+
+/**
  * @brief Port methods table retrieved with sai_api_query()
  */
 typedef struct _sai_port_api_t
@@ -2128,6 +2367,10 @@ typedef struct _sai_port_api_t
     sai_get_port_pool_stats_fn        get_port_pool_stats;
     sai_get_port_pool_stats_ext_fn    get_port_pool_stats_ext;
     sai_clear_port_pool_stats_fn      clear_port_pool_stats;
+    sai_create_port_serdes_fn         create_port_serdes;
+    sai_remove_port_serdes_fn         remove_port_serdes;
+    sai_set_port_serdes_attribute_fn  set_port_serdes_attribute;
+    sai_get_port_serdes_attribute_fn  get_port_serdes_attribute;
 
 } sai_port_api_t;
 

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -262,7 +262,8 @@ typedef enum _sai_object_type_t
     SAI_OBJECT_TYPE_TAM_INT                  = 83,
     SAI_OBJECT_TYPE_COUNTER                  = 84,
     SAI_OBJECT_TYPE_DEBUG_COUNTER            = 85,
-    SAI_OBJECT_TYPE_MAX                      = 86,
+    SAI_OBJECT_TYPE_PORT_SERDES              = 86,
+    SAI_OBJECT_TYPE_MAX                      = 87,
 } sai_object_type_t;
 
 typedef struct _sai_u8_list_t

--- a/meta/aspell.en.pws
+++ b/meta/aspell.en.pws
@@ -138,3 +138,6 @@ pre
 serdes
 idriver
 ipredriver
+precursor
+postcursor
+maincursor

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -764,7 +764,7 @@ void check_attr_default_required(
                 }
             }
 
-            if (md->objecttype == SAI_OBJECT_TYPE_PORT)
+            if ((md->objecttype == SAI_OBJECT_TYPE_PORT) || (md->objecttype == SAI_OBJECT_TYPE_PORT_SERDES))
             {
                 /*
                  * Allow PORT non object list attributes to be set to internal switch values.
@@ -879,7 +879,8 @@ void check_attr_default_required(
         case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
 
-            if (md->objecttype == SAI_OBJECT_TYPE_PORT && md->defaultvaluetype == SAI_DEFAULT_VALUE_TYPE_SWITCH_INTERNAL)
+            if (((md->objecttype == SAI_OBJECT_TYPE_PORT) || (md->objecttype == SAI_OBJECT_TYPE_PORT_SERDES))
+                 && md->defaultvaluetype == SAI_DEFAULT_VALUE_TYPE_SWITCH_INTERNAL)
             {
                 /*
                  * Allow non object lists on PORT to be set to internal default value.
@@ -1094,7 +1095,7 @@ void check_attr_default_value_type(
 
         case SAI_DEFAULT_VALUE_TYPE_SWITCH_INTERNAL:
 
-            if (md->objecttype == SAI_OBJECT_TYPE_PORT)
+            if ((md->objecttype == SAI_OBJECT_TYPE_PORT) || (md->objecttype == SAI_OBJECT_TYPE_PORT_SERDES))
             {
                 /*
                  * Allow PORT attribute list's to be set to internal.


### PR DESCRIPTION
Defined new Serdes attributes. The new serdes range is reserved so that in future the attributes can be extended to include new settings in the future.