### PR TITLE
Update sainat.h

### DIFF
--- a/inc/sainat.h
+++ b/inc/sainat.h
@@ -326,7 +326,7 @@ typedef struct _sai_nat_entry_t
      * @objects SAI_OBJECT_TYPE_VIRTUAL_ROUTER
      */
     sai_object_id_t vr_id;
-    
+
     /**
      * @brief NAT entry type
      */

--- a/inc/sainat.h
+++ b/inc/sainat.h
@@ -326,6 +326,11 @@ typedef struct _sai_nat_entry_t
      * @objects SAI_OBJECT_TYPE_VIRTUAL_ROUTER
      */
     sai_object_id_t vr_id;
+    
+    /**
+     * @brief NAT entry type
+     */
+    sai_nat_type_t nat_type;
 
     /**
      * @brief NAT entry data


### PR DESCRIPTION
This change adds nat type in sai_nat_entry_t to distinguish between dnat pool and dnat entry. Its possible that for dnat pool and dnat entry all the key/attributes are same and in this case ASIC redis DB rejects the update as duplicate. NAT type will help distinguish two of them