### PR TITLE
Add queue index to hostif packet attribute

### DIFF
--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -1173,6 +1173,17 @@ typedef enum _sai_hostif_packet_attr_t
     SAI_HOSTIF_PACKET_ATTR_TIMESTAMP,
 
     /**
+     * @brief Egress queue index
+     *
+     * The egress queue id for egress port or LAG.
+     *
+     * @type sai_uint8_t
+     * @flags CREATE_ONLY
+     * @default 0
+     */
+    SAI_HOSTIF_PACKET_ATTR_EGRESS_QUEUE_INDEX,
+
+    /**
      * @brief End of attributes
      */
     SAI_HOSTIF_PACKET_ATTR_END,


### PR DESCRIPTION
**Hostif Modes:**

Based on SAI Spec, there are several modes to transmit and receive packets to and from the application: Netdev, FD, Callback and Netlink

Except for callback, an hostif object has to be created for all other modes.

**Problem:**
Hostif has a queue attribute (SAI_HOSTIF_ATTR_QUEUE) that can be set per port. Any packet on this hostif will egress out on the queue specified. 

But there are two problems here:

- Callback mode can never set this queue attribute in TX bypass mode since hostif will never be created in this mode.
- Need for per packet override of queue attribute for cpu bound packets and this is applicable for all hostif modes.

For instance, for protocols like LACP and STP which needs faster convergence, we do the following:

- TX Port is known by the application
- Bypass pipeline and send the packet out of port.
- Send the packet to the highest priority (network control) queue of the port so that it is served ahead of other traffic. This ensures that network control packets can get through in face of port congestion. 

This proposal is to add an attribute to sai_hostif_packet_attr_t to set the egress queue index for callbacks and when the tx mode is set to TX_BYPASS.