### PR TITLE
enable/disable decrement ttl support for port, rif and nexthop

### DIFF
--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -1948,9 +1948,9 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER,
 
     /**
-     * @brief Decrement TTL (enable/disable) (parameter is not needed)
+     * @brief Decrement TTL (enable/disable)
      *
-     * @type sai_acl_action_data_t sai_int32_t
+     * @type sai_acl_action_data_t bool
      * @flags CREATE_AND_SET
      * @default disabled
      */

--- a/inc/sainexthop.h
+++ b/inc/sainexthop.h
@@ -221,6 +221,15 @@ typedef enum _sai_next_hop_attr_t
     SAI_NEXT_HOP_ATTR_COUNTER_ID,
 
     /**
+     * @brief To enable/disable Decrement TTL
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_NEXT_HOP_ATTR_DECREMENT_TTL,
+
+    /**
      * @brief End of attributes
      */
     SAI_NEXT_HOP_ATTR_END,

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -1443,6 +1443,15 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_AUTO_NEG_STATUS,
 
     /**
+     * @brief To enable/disable Decrement TTL
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_PORT_ATTR_DECREMENT_TTL,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_ATTR_END,

--- a/inc/sairouterinterface.h
+++ b/inc/sairouterinterface.h
@@ -277,6 +277,15 @@ typedef enum _sai_router_interface_attr_t
     SAI_ROUTER_INTERFACE_ATTR_NAT_ZONE_ID,
 
     /**
+     * @brief To enable/disable Decrement TTL
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_ROUTER_INTERFACE_ATTR_DECREMENT_TTL,
+
+    /**
      * @brief End of attributes
      */
     SAI_ROUTER_INTERFACE_ATTR_END,


### PR DESCRIPTION
### **Single chip dataplane testing:**

We utilize the port loopback modes to verify the dataplane functionality without using any external devices like IXIA, hosts or any other traffic generators.

For instance, we use the following sequence to test load balancer functionality

- Set the ports in loopback mode (PHY or MAC).
- Create N wide ECMP group
- Create a ::/0 route pointing to the above ECMP group
- Send packets from CPU with destination mac as router mac and varying source, destination {IP, L4 port}. Packets will go through normal L3 processing. This includes going through the hashing engines (functionality we desire to test) and then egressing out of a port.
- Check port counters and assert for traffic being evenly balanced. 

**What is the need to disable Decrement TTL in dataplane testing:**
To test certain functionalities like queue congestion or port schedulers, line rate traffic is needed and CPU cannot generate line rate. By setting the port in loopback mode and setting the nexthop mac as router mac, the packets will only loop till max ttl set in the packet and then will be dropped by the asic. This will not hit the line rate and hence will not cause any congestion. 

By disabling the ttl decrement for routed packets, the packets loopback on the port, gets routed again since the dmac matches the router mac but will be egressed out without the ttl being decremented and will be looping forever causing congestion.

**Example:**
Let us say we would like to test the queue scheduling by providing different weights to the queues, creating line rate traffic and check the queue counters for the traffic.

_Queue Config:_

- Queue 1 , WRR, Weight 80
- Queue 2, WRR, Weight 20

_Qos Map Config:_ 

- DSCP 1 maps to queue 1
- DSCP 2 maps to queue 2

_Other Configs:_

- Create port 1 with a vlan and a l3 interface.
- Create nexthop with the l3 interface and nexthop mac as the router mac.
- Add route 0/0 with the above nexthop.
- Disable decrementing TTL for that nexthop.

_Testing Sequence:_

- Send a few packets for every DSCP based on the Qos Map config from the CPU.
- Since the port is in loopback mode and ttl decrement is disabled, this would cause the packet to loop in the asic and cause congestion.
- Based on the queue config, the weights will be honored. Queue 1 will receive 80% traffic and queue will receive 20% traffic and this can be verified through the queue traffic counters.

As we discussed in the SAI community meetup, this proposal is to add attributes to port, RIF, nexthop and to ACL to support enabling and disabling ttl decrement to provide more granularity. 