### PR TITLE
MPLS Host-If traps for packets with expiring TTL and Router Alert Label

### DIFF
--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -397,6 +397,18 @@ typedef enum _sai_hostif_trap_type_t
      */
     SAI_HOSTIF_TRAP_TYPE_PIPELINE_DISCARD_ROUTER = 0x00007002,
 
+    /**
+     * @brief MPLS packets with expiring TTL value of 1
+     * (default packet action is drop)
+     */
+    SAI_HOSTIF_TRAP_TYPE_MPLS_TTL_ERROR = 0x00007003,
+
+    /**
+     * @brief MPLS packet with router alert label
+     * (default packet action is forward)
+     */
+    SAI_HOSTIF_TRAP_TYPE_MPLS_ROUTER_ALERT_LABEL = 0x00007004,
+
     /** Exception traps custom range start */
     SAI_HOSTIF_TRAP_TYPE_CUSTOM_EXCEPTION_RANGE_BASE = 0x00008000,
 

--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -397,20 +397,20 @@ typedef enum _sai_hostif_trap_type_t
      */
     SAI_HOSTIF_TRAP_TYPE_PIPELINE_DISCARD_ROUTER = 0x00007002,
 
-    /** Exception traps custom range start */
-    SAI_HOSTIF_TRAP_TYPE_CUSTOM_EXCEPTION_RANGE_BASE = 0x00008000,
-
     /**
      * @brief MPLS packets with expiring TTL value of 1
      * (default packet action is drop)
      */
-    SAI_HOSTIF_TRAP_TYPE_MPLS_TTL_ERROR = 0x00009000,
+    SAI_HOSTIF_TRAP_TYPE_MPLS_TTL_ERROR = 0x00008000,
 
     /**
      * @brief MPLS packet with router alert label
      * (default packet action is forward)
      */
-    SAI_HOSTIF_TRAP_TYPE_MPLS_ROUTER_ALERT_LABEL = 0x00009001,
+    SAI_HOSTIF_TRAP_TYPE_MPLS_ROUTER_ALERT_LABEL = 0x00008001,
+
+    /** Exception traps custom range start */
+    SAI_HOSTIF_TRAP_TYPE_CUSTOM_EXCEPTION_RANGE_BASE = 0x00009000,
 
     /**
      * @brief End of trap types

--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -401,20 +401,13 @@ typedef enum _sai_hostif_trap_type_t
      * @brief MPLS packets with expiring TTL value of 1
      * (default packet action is drop)
      */
-    SAI_HOSTIF_TRAP_TYPE_MPLS_TTL_ERROR = 0x00007003,
+    SAI_HOSTIF_TRAP_TYPE_MPLS_TTL_ERROR = 0x00007500,
 
     /**
      * @brief MPLS packet with router alert label
      * (default packet action is forward)
      */
-    SAI_HOSTIF_TRAP_TYPE_MPLS_ROUTER_ALERT_LABEL = 0x00007004,
-
-    /**
-     * @brief MPLS packet with label trapped to CPU
-     * This is the MPLS packet with incoming label map entry
-     * programmed to trap it to CPU
-     */
-    SAI_HOSTIF_TRAP_TYPE_MPLS_INSEG_ENTRY_TO_CPU = 0x00007005,
+    SAI_HOSTIF_TRAP_TYPE_MPLS_ROUTER_ALERT_LABEL = 0x00007501,
 
     /** Exception traps custom range start */
     SAI_HOSTIF_TRAP_TYPE_CUSTOM_EXCEPTION_RANGE_BASE = 0x00008000,
@@ -605,6 +598,9 @@ typedef enum _sai_hostif_user_defined_trap_type_t
 
     /** FDB traps */
     SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_FDB,
+
+    /** In Segment Entry traps */
+    SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_INSEG_ENTRY,
 
     /** Custom range base */
     SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_CUSTOM_RANGE_BASE = 0x00001000,

--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -397,25 +397,25 @@ typedef enum _sai_hostif_trap_type_t
      */
     SAI_HOSTIF_TRAP_TYPE_PIPELINE_DISCARD_ROUTER = 0x00007002,
 
+    /** Exception traps custom range start */
+    SAI_HOSTIF_TRAP_TYPE_CUSTOM_EXCEPTION_RANGE_BASE = 0x00008000,
+
     /**
      * @brief MPLS packets with expiring TTL value of 1
      * (default packet action is drop)
      */
-    SAI_HOSTIF_TRAP_TYPE_MPLS_TTL_ERROR = 0x00007500,
+    SAI_HOSTIF_TRAP_TYPE_MPLS_TTL_ERROR = 0x00009000,
 
     /**
      * @brief MPLS packet with router alert label
      * (default packet action is forward)
      */
-    SAI_HOSTIF_TRAP_TYPE_MPLS_ROUTER_ALERT_LABEL = 0x00007501,
-
-    /** Exception traps custom range start */
-    SAI_HOSTIF_TRAP_TYPE_CUSTOM_EXCEPTION_RANGE_BASE = 0x00008000,
+    SAI_HOSTIF_TRAP_TYPE_MPLS_ROUTER_ALERT_LABEL = 0x00009001,
 
     /**
      * @brief End of trap types
      */
-    SAI_HOSTIF_TRAP_TYPE_END = 0x00009000
+    SAI_HOSTIF_TRAP_TYPE_END = 0x0000a000
 
 } sai_hostif_trap_type_t;
 

--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -409,6 +409,13 @@ typedef enum _sai_hostif_trap_type_t
      */
     SAI_HOSTIF_TRAP_TYPE_MPLS_ROUTER_ALERT_LABEL = 0x00007004,
 
+    /**
+     * @brief MPLS packet with label trapped to CPU
+     * This is the MPLS packet with incoming label map entry
+     * programmed to trap it to CPU
+     */
+    SAI_HOSTIF_TRAP_TYPE_MPLS_INSEG_ENTRY_TO_CPU = 0x00007005,
+
     /** Exception traps custom range start */
     SAI_HOSTIF_TRAP_TYPE_CUSTOM_EXCEPTION_RANGE_BASE = 0x00008000,
 


### PR DESCRIPTION
Summary: this commit fixes #1061

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: