### PR TITLE
Fix linker error when compiling SAI RPC server.

### DIFF
--- a/meta/saiserialize.c
+++ b/meta/saiserialize.c
@@ -593,7 +593,7 @@ int sai_deserialize_macsec_salt(
         _In_ const char *buffer,
         _Out_ sai_macsec_salt_t salt)
 {
-    int arr[12];
+    int arr[32];
     int read;
 
     int n = sscanf(buffer, "%2X:%2X:%2X:%2X:%2X:%2X:%2X:%2X:%2X:%2X:%2X:%2X:%2X:%2X:%2X:%2X:\
@@ -607,9 +607,9 @@ int sai_deserialize_macsec_salt(
                    &arr[24], &arr[25], &arr[26], &arr[27],
                    &arr[28], &arr[29], &arr[30], &arr[31], &read);
 
-    if (n == 12 && read == (12*3-1))
+    if (n == 32 && read == (32*3-1))
     {
-        for (n = 0; n < 12; n++)
+        for (n = 0; n < 32; n++)
         {
             salt[n] = (uint8_t)arr[n];
         }

--- a/test/saithrift/src/saiserver.cpp
+++ b/test/saithrift/src/saiserver.cpp
@@ -37,6 +37,7 @@ sai_switch_api_t* sai_switch_api;
 std::map<std::string, std::string> gProfileMap;
 std::map<std::set<int>, std::string> gPortMap;
 
+extern std::vector<std::pair<sai_fdb_entry_t, sai_object_id_t>> gFdbMap;
 
 sai_object_id_t gSwitchId; ///< SAI switch global object ID.
 
@@ -69,7 +70,6 @@ void on_fdb_event(_In_ uint32_t count,
            
     sai_fdb_entry_t fdb_m;
     sai_object_id_t b_id;
-    extern std::vector<std::pair<sai_fdb_entry_t, sai_object_id_t>> gFdbMap;
       
     switch (event_type)
     {   

--- a/test/saithrift/src/saiserver.cpp
+++ b/test/saithrift/src/saiserver.cpp
@@ -37,7 +37,6 @@ sai_switch_api_t* sai_switch_api;
 std::map<std::string, std::string> gProfileMap;
 std::map<std::set<int>, std::string> gPortMap;
 
-std::vector<std::pair<sai_fdb_entry_t, sai_object_id_t>>gFdbMap;
 
 sai_object_id_t gSwitchId; ///< SAI switch global object ID.
 
@@ -70,6 +69,7 @@ void on_fdb_event(_In_ uint32_t count,
            
     sai_fdb_entry_t fdb_m;
     sai_object_id_t b_id;
+    extern std::vector<std::pair<sai_fdb_entry_t, sai_object_id_t>> gFdbMap;
       
     switch (event_type)
     {   

--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -82,6 +82,8 @@ extern sai_object_id_t gSwitchId;
 
 typedef std::vector<sai_thrift_attribute_t> std_sai_thrift_attr_vctr_t;
 
+std::vector<std::pair<sai_fdb_entry_t, sai_object_id_t>>gFdbMap;
+
 class switch_sai_rpcHandler : virtual public switch_sai_rpcIf {
 public:
     switch_sai_rpcHandler() noexcept
@@ -767,8 +769,6 @@ public:
       sai_object_id_t bport_id;
       sai_fdb_entry_t fdb_entry;  
              
-      extern std::vector<std::pair<sai_fdb_entry_t, sai_object_id_t>> gFdbMap;
- 
       thrift_attr_list.attr_count = gFdbMap.size();
       
       sai_fdb_entry_t fdb_m;


### PR DESCRIPTION
   The variable was not part of the librpcserver.a library. Moved the variable to the source file that's added in librpcserver.a.