### PR TITLE
Support max accumulative headroom size

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -369,6 +369,14 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_QOS_SCHEDULER_GROUP_LIST,
 
     /**
+     * @brief The maximum accumulative headroom size of a port
+     *
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_PORT_ATTR_QOS_MAXIMUM_ACCUMULATIVE_HEADROOM_SIZE,
+
+    /**
      * @brief Query list of supported port speed(full-duplex) in Mbps
      *
      * @type sai_u32_list_t

--- a/test/saithrift/src/saiserver.cpp
+++ b/test/saithrift/src/saiserver.cpp
@@ -37,7 +37,7 @@ sai_switch_api_t* sai_switch_api;
 std::map<std::string, std::string> gProfileMap;
 std::map<std::set<int>, std::string> gPortMap;
 
-std::vector<std::pair<sai_fdb_entry_t, sai_object_id_t>>gFdbMap;
+extern std::vector<std::pair<sai_fdb_entry_t, sai_object_id_t>> gFdbMap;
 
 sai_object_id_t gSwitchId; ///< SAI switch global object ID.
 

--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -82,6 +82,8 @@ extern sai_object_id_t gSwitchId;
 
 typedef std::vector<sai_thrift_attribute_t> std_sai_thrift_attr_vctr_t;
 
+std::vector<std::pair<sai_fdb_entry_t, sai_object_id_t>>gFdbMap;
+
 class switch_sai_rpcHandler : virtual public switch_sai_rpcIf {
 public:
     switch_sai_rpcHandler() noexcept
@@ -767,8 +769,6 @@ public:
       sai_object_id_t bport_id;
       sai_fdb_entry_t fdb_entry;  
              
-      extern std::vector<std::pair<sai_fdb_entry_t, sai_object_id_t>> gFdbMap;
- 
       thrift_attr_list.attr_count = gFdbMap.size();
       
       sai_fdb_entry_t fdb_m;


### PR DESCRIPTION
Support max accumulative headroom size, which is a read-only attribute.
For example, if a port has 2 PGs and headroom size of each is N bytes, the accumulative headroom size should be 2*N.
The motivation is that:
- We're going to have a port's headroom size automatically calculated according to its cable length and speed. If a user configured a very long cable length the headroom size can be very large as well, which will exceed the limit of switch chip and thus failing the SDK and then the orchagent.
- To prevent that case, we need to know the limit in hardware and prevent a limit-exceeding value from programming to switch chip by SAI.
- This attribute stands for that limit.