### PR TITLE
Added attribute to identify  vlan type.

### DIFF
--- a/inc/saivlan.h
+++ b/inc/saivlan.h
@@ -134,7 +134,8 @@ typedef enum _sai_vlan_attr_t
      * @brief Vlan Type
      *
      * @type sai_vlan_type_t
-     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @flags CREATE_ONLY
+     * @default SAI_VLAN_TYPE_DATA
      */
     SAI_VLAN_ATTR_VLAN_TYPE,
 

--- a/inc/saivlan.h
+++ b/inc/saivlan.h
@@ -134,8 +134,7 @@ typedef enum _sai_vlan_attr_t
      * @brief Vlan Type
      *
      * @type sai_vlan_type_t
-     * @flags MANDATORY_ON_CREATE | CREATE_ONLY | KEY
-     * @default SAI_VLAN_TYPE_DATA
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
      */
     SAI_VLAN_ATTR_VLAN_TYPE,
 

--- a/inc/saivlan.h
+++ b/inc/saivlan.h
@@ -98,6 +98,19 @@ typedef enum _sai_vlan_flood_control_type_t
 } sai_vlan_flood_control_type_t;
 
 /**
+ * @brief Attribute data for vlan type parameter
+ */
+typedef enum _sai_vlan_type_t
+{
+    SAI_VLAN_TYPE_DATA,
+
+    SAI_VLAN_TYPE_MANAGEMENT,
+
+    SAI_VLAN_TYPE_CONTROL
+
+} sai_vlan_type_t;
+
+/**
  * @brief Attribute Id in sai_set_vlan_attribute() and
  * sai_get_vlan_attribute() calls
  */
@@ -116,6 +129,15 @@ typedef enum _sai_vlan_attr_t
      * @isvlan true
      */
     SAI_VLAN_ATTR_VLAN_ID = SAI_VLAN_ATTR_START,
+
+    /**
+     * @brief Vlan Type
+     *
+     * @type sai_vlan_type_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY | KEY
+     * @default SAI_VLAN_TYPE_DATA
+     */
+    SAI_VLAN_ATTR_VLAN_TYPE,
 
     /**
      * @brief List of vlan members in a VLAN


### PR DESCRIPTION
Added attribute to identify  vlan type, which can be one of,
SAI_VLAN_TYPE_DATA : VLAN configured to carry user generated data traffic.
SAI_VLAN_TYPE_MANAGEMENT : VLAN configured to access management capabilities of the node.
SAI_VLAN_TYPE_CONTROL : VLAN configured to carry traffic between the devices on same node or between the nodes.

Default : SAI_VLAN_TYPE_DATA

Signed-off-by: Rajkumar Pennadam Ramamoorthy <rpennadamram@marvell.com>