### PR TITLE
Additional Port Interface Types

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -249,11 +249,11 @@ typedef enum _sai_port_interface_type_t
     /** Interface type XLAUI */
     SAI_PORT_INTERFACE_TYPE_XLAUI,
 
-    /** Interface type CUSTOM BEGIN */
-    SAI_PORT_INTERFACE_TYPE_CUSTOM_BEGIN,
+    /** Custom range base value */
+    SAI_PORT_INTERFACE_TYPE_CUSTOM_RANGE_START = 0x10000000,
 
-    /** Interface type CUSTOM END */
-    SAI_PORT_INTERFACE_TYPE_CUSTOM_END = SAI_PORT_INTERFACE_TYPE_CUSTOM_BEGIN,
+    /** End of custom range base */
+    SAI_PORT_INTERFACE_TYPE_CUSTOM_RANGE_END = SAI_PORT_INTERFACE_TYPE_CUSTOM_RANGE_START,
 } sai_port_interface_type_t;
 
 /**

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -236,6 +236,19 @@ typedef enum _sai_port_interface_type_t
 
     /** Interface type KR4 */
     SAI_PORT_INTERFACE_TYPE_KR4,
+
+    /** Interface type CAUI */
+    SAI_PORT_INTERFACE_TYPE_CAUI,
+
+    /** Interface type GMII */
+    SAI_PORT_INTERFACE_TYPE_GMII,
+
+    /** Interface type SFI */
+    SAI_PORT_INTERFACE_TYPE_SFI,
+
+    /** Interface type XLAUI */
+    SAI_PORT_INTERFACE_TYPE_XLAUI,
+
 } sai_port_interface_type_t;
 
 /**
@@ -1348,8 +1361,6 @@ typedef enum _sai_port_attr_t
 
     /**
      * @brief Configure Interface type
-     *
-     * Valid when SAI_SWITCH_ATTR_TYPE == SAI_SWITCH_TYPE_PHY
      *
      * @type sai_port_interface_type_t
      * @flags CREATE_AND_SET

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -249,6 +249,11 @@ typedef enum _sai_port_interface_type_t
     /** Interface type XLAUI */
     SAI_PORT_INTERFACE_TYPE_XLAUI,
 
+    /** Interface type CUSTOM BEGIN */
+    SAI_PORT_INTERFACE_TYPE_CUSTOM_BEGIN,
+
+    /** Interface type CUSTOM END */
+    SAI_PORT_INTERFACE_TYPE_CUSTOM_END = SAI_PORT_INTERFACE_TYPE_CUSTOM_BEGIN,
 } sai_port_interface_type_t;
 
 /**

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -249,11 +249,9 @@ typedef enum _sai_port_interface_type_t
     /** Interface type XLAUI */
     SAI_PORT_INTERFACE_TYPE_XLAUI,
 
-    /** Custom range base value */
-    SAI_PORT_INTERFACE_TYPE_CUSTOM_RANGE_START = 0x10000000,
+    /** Interface type MAX */
+    SAI_PORT_INTERFACE_TYPE_MAX,
 
-    /** End of custom range base */
-    SAI_PORT_INTERFACE_TYPE_CUSTOM_RANGE_END = SAI_PORT_INTERFACE_TYPE_CUSTOM_RANGE_START,
 } sai_port_interface_type_t;
 
 /**

--- a/inc/saitam.h
+++ b/inc/saitam.h
@@ -653,6 +653,18 @@ typedef enum _sai_tam_int_attr_t
     SAI_TAM_INT_ATTR_METADATA_FRAGMENT_ENABLE,
 
     /**
+     * @brief Enable checksum
+     *
+     * Enable checksum for metadata stack
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     * @validonly SAI_TAM_INT_ATTR_TYPE == SAI_TAM_INT_TYPE_IFA2
+     */
+    SAI_TAM_INT_ATTR_METADATA_CHECKSUM_ENABLE,
+
+    /**
      * @brief TAM INT should report all packets without filtering
      *
      * @type bool
@@ -1237,6 +1249,16 @@ typedef enum _sai_tam_report_attr_t
     SAI_TAM_REPORT_ATTR_REPORT_INTERVAL,
 
     /**
+     * @brief Enterprise number
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     * @validonly SAI_TAM_REPORT_ATTR_TYPE == SAI_TAM_REPORT_TYPE_IPFIX
+     */
+    SAI_TAM_REPORT_ATTR_ENTERPRISE_NUMBER,
+
+    /**
      * @brief End of Attributes
      */
     SAI_TAM_REPORT_ATTR_END,
@@ -1468,6 +1490,10 @@ typedef enum _sai_tam_transport_type_t
      */
     SAI_TAM_TRANSPORT_TYPE_GRPC,
 
+    /**
+     * @brief Transport MIRROR session
+     */
+    SAI_TAM_TRANSPORT_TYPE_MIRROR,
 } sai_tam_transport_type_t;
 
 /**

--- a/meta/acronyms.txt
+++ b/meta/acronyms.txt
@@ -11,6 +11,7 @@ BFDV6 - Bidirectional Forwarding Detection for IPv6
 BGP - Border Gateway Protocol
 BOS - Bottom Of Stack
 CAM - Content Addressable Memory
+CAUI - 100 Gigabit Attachment Unit Interface
 CB - Callback
 CBS - Committed Burst Size
 CCITT - Comite Consultatif International de Telegraphique et Telephonique
@@ -38,6 +39,7 @@ FDB - Forwarding Data Base
 FEC - Forward Error Correction
 FPGA - Field Programmable Gate Array
 GCM - Galois Counter Mode
+GMII - Gigabit Media-Independent Interface
 GPB - Google Protocol Buffers
 GRE - Generic Routing Encapsulation
 GRPC - GRPC Remote Procedure Call
@@ -92,6 +94,7 @@ SAI - Switch Abstraction Interface
 SCI - Secure Channel Identifier
 SC - Secure Channel
 SDK - Software Development Kit
+SFI - SerDes Framer Interface
 SFLOW - Sampled Flow
 SG - (S,G) Source-specific multicast
 SNAT - Source Network Address Translation
@@ -122,6 +125,7 @@ WCMP - Weighted Cost Multipath
 WRED - Weighted Random Early Detection
 WWW - World Wide Web
 XG - (*,G) Any-source Multicast
+XLAUI - 40 Gbps Attachment Unit Interface
 XPN - Extended Packet Number
 XOFF - Transmitter Off
 XON - Transmitter On


### PR DESCRIPTION
Summary:

Providing more options for port interface types to allow more granular programmability of port settings. These interface types are part of  IEEE 802.3 standard

GMII - Gigabit
SFI - 10 Gigabit
XLAUI - 40 Gigabit
CAUI - 100 Gigabit

Each of these have different electrical characteristics and different from available port interface types.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: