### PR TITLE
Fix IP protocol number for encapsulated IPv4

### DIFF
--- a/bm/sai_adapter/test/ptf_tests/ptf/src/ptf/testutils.py
+++ b/bm/sai_adapter/test/ptf_tests/ptf/src/ptf/testutils.py
@@ -1262,7 +1262,7 @@ def simple_ipv4ip_packet(pktlen=300,
     else:
         pkt = pkt / scapy.IP()
         pkt = pkt/("D" * (pktlen - len(pkt)))
-        pkt['IP'].proto = 41
+        pkt['IP'].proto = 4
 
     return pkt
 


### PR DESCRIPTION
Update p4lang/ptf submodule to latest master to acquire p4lang/ptf#113, and apply the
same patch to the copy in `bm/sai_adapter/test/ptf_tests/ptf`.