### PR TITLE
[saiport.h]Support max accumulative headroom size[saiport] Add SAI_PORT_QOS_ATTR_MAXIMUM_HEADROOM_SIZE

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -369,7 +369,8 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_QOS_SCHEDULER_GROUP_LIST,
 
     /**
-     * @brief The maximum accumulative headroom size of a port in bytes
+     * @brief The sum of the headroom size of the ingress priority groups belonging to this port
+     *        should not exceed the SAI_PORT_ATTR_QOS_MAXIMUM_HEADROOM_SIZE value.
      *
      * This attribute is applicable only for per-port, per-PG headroom model
      * (which means SAI_BUFFER_POOL_ATTR_XOFF_SIZE is zero)

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -371,10 +371,13 @@ typedef enum _sai_port_attr_t
     /**
      * @brief The maximum accumulative headroom size of a port in bytes
      *
+     * This attribute is applicable only for per-port, per-PG headroom model
+     * (which means SAI_BUFFER_POOL_ATTR_XOFF_SIZE is zero)
+     *
      * @type sai_uint32_t
      * @flags READ_ONLY
      */
-    SAI_PORT_ATTR_QOS_MAXIMUM_ACCUMULATIVE_HEADROOM_SIZE,
+    SAI_PORT_ATTR_QOS_MAXIMUM_HEADROOM_SIZE,
 
     /**
      * @brief Query list of supported port speed(full-duplex) in Mbps

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -369,6 +369,14 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_QOS_SCHEDULER_GROUP_LIST,
 
     /**
+     * @brief The maximum accumulative headroom size of a port in bytes
+     *
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_PORT_ATTR_QOS_MAXIMUM_ACCUMULATIVE_HEADROOM_SIZE,
+
+    /**
      * @brief Query list of supported port speed(full-duplex) in Mbps
      *
      * @type sai_u32_list_t

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -375,6 +375,8 @@ typedef enum _sai_port_attr_t
      * This attribute is applicable only for per-port, per-PG headroom model
      * (which means SAI_BUFFER_POOL_ATTR_XOFF_SIZE is zero)
      *
+     * For the platforms which don't have this limitation, 0 should be returned.
+     *
      * @type sai_uint32_t
      * @flags READ_ONLY
      */


### PR DESCRIPTION
Support max accumulative headroom size, which is a read-only attribute.
For example, if a port has 2 PGs and headroom size of each is N bytes, the accumulative headroom size should be 2*N.
The motivation is that:
- We're going to have a port's headroom size automatically calculated according to its cable length and speed. If a user configured a very long cable length the headroom size can be very large as well, which will exceed the limit of switch chip and thus failing the SDK and then the orchagent.
- To prevent that case, we need to know the limit in hardware and prevent a limit-exceeding value from programming to switch chip by SAI.
- This attribute stands for that limit.