### PR TITLE
renaming decrement ttl enum to disable decrement ttl enum

### DIFF
--- a/inc/sainexthop.h
+++ b/inc/sainexthop.h
@@ -227,7 +227,7 @@ typedef enum _sai_next_hop_attr_t
      * @flags CREATE_AND_SET
      * @default false
      */
-    SAI_NEXT_HOP_ATTR_DECREMENT_TTL,
+    SAI_NEXT_HOP_ATTR_DISABLE_DECREMENT_TTL,
 
     /**
      * @brief MPLS Outsegment type

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -1466,7 +1466,7 @@ typedef enum _sai_port_attr_t
      * @flags CREATE_AND_SET
      * @default false
      */
-    SAI_PORT_ATTR_DECREMENT_TTL,
+    SAI_PORT_ATTR_DISABLE_DECREMENT_TTL,
 
     /**
      * @brief Enable EXP -> TC MAP on port

--- a/inc/sairouterinterface.h
+++ b/inc/sairouterinterface.h
@@ -283,7 +283,7 @@ typedef enum _sai_router_interface_attr_t
      * @flags CREATE_AND_SET
      * @default false
      */
-    SAI_ROUTER_INTERFACE_ATTR_DECREMENT_TTL,
+    SAI_ROUTER_INTERFACE_ATTR_DISABLE_DECREMENT_TTL,
 
     /**
      * @brief End of attributes


### PR DESCRIPTION
In order to reflect the actual behavior, renaming SAI_NEXT_HOP_ATTR_DECREMENT_TTL to  SAI_NEXT_HOP_ATTR_DISABLE_DECREMENT_TTL.

SAI_*_ATTR_DISABLE_DECREMENT_TTL when set to true will disable decrementing ttl in the pipeline.