### PR TITLE
tunnel decap ttl/dscp valid also for vxlan, mpls

### DIFF
--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -622,7 +622,6 @@ typedef enum _sai_tunnel_attr_t
      * @type sai_tunnel_ttl_mode_t
      * @flags CREATE_AND_SET
      * @default SAI_TUNNEL_TTL_MODE_UNIFORM_MODEL
-     * @validonly SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_IPINIP or SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_IPINIP_GRE
      */
     SAI_TUNNEL_ATTR_DECAP_TTL_MODE,
 
@@ -632,7 +631,6 @@ typedef enum _sai_tunnel_attr_t
      * @type sai_tunnel_dscp_mode_t
      * @flags CREATE_AND_SET
      * @default SAI_TUNNEL_DSCP_MODE_UNIFORM_MODEL
-     * @validonly SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_IPINIP or SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_IPINIP_GRE
      */
     SAI_TUNNEL_ATTR_DECAP_DSCP_MODE,
 


### PR DESCRIPTION
recently several tunnel attributes were enabled for create and set, instead of create only, as part of PR https://github.com/opencomputeproject/SAI/pull/1086/files
before the change decap dscp/ttl were mandatory for ip in ip and ip in ip gre tunnel types, and it was also possible but not mandatory to set them on vxlan and mpls
after the change, the attributes were marked as valid only for ip in ip and ip in ip gre tunnels
but they are also relevant for vxlan and mpls
this commit enables usage for vxlan and mpls