### PR TITLE
Add DHCP L2 trap

### DIFF
--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -232,9 +232,15 @@ typedef enum _sai_hostif_trap_type_t
 
     /**
      * @brief DHCP traffic (UDP ports 67, 68)
-     * (default packet action is drop)
+     * (default packet action is forward)
      */
     SAI_HOSTIF_TRAP_TYPE_DHCP_L2 = 0x00000012,
+
+    /**
+     * @brief DHCPV6 traffic (UDP ports 546, 547)
+     * (default packet action is forward)
+     */
+    SAI_HOSTIF_TRAP_TYPE_DHCPV6_L2 = 0x00000013,
 
     /** Switch traps custom range start */
     SAI_HOSTIF_TRAP_TYPE_SWITCH_CUSTOM_RANGE_BASE = 0x00001000,

--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -230,6 +230,12 @@ typedef enum _sai_hostif_trap_type_t
      */
     SAI_HOSTIF_TRAP_TYPE_PTP_TX_EVENT = 0x00000011,
 
+    /**
+     * @brief DHCP traffic (UDP ports 67, 68) 
+     * (default packet action is drop)
+     */
+    SAI_HOSTIF_TRAP_TYPE_DHCP_L2 = 0x00000012,
+
     /** Switch traps custom range start */
     SAI_HOSTIF_TRAP_TYPE_SWITCH_CUSTOM_RANGE_BASE = 0x00001000,
 

--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -231,7 +231,7 @@ typedef enum _sai_hostif_trap_type_t
     SAI_HOSTIF_TRAP_TYPE_PTP_TX_EVENT = 0x00000011,
 
     /**
-     * @brief DHCP traffic (UDP ports 67, 68) 
+     * @brief DHCP traffic (UDP ports 67, 68)
      * (default packet action is drop)
      */
     SAI_HOSTIF_TRAP_TYPE_DHCP_L2 = 0x00000012,

--- a/meta/acronyms.txt
+++ b/meta/acronyms.txt
@@ -21,6 +21,7 @@ CIR - Committed Information Rate
 CPU - Central Processing Unit
 CRC - Cyclic Redundancy Code
 DHCP - Dynamic Host Configuration Protocol
+DHCPV6 - Dynamic Host Configuration Protocol for IPv6
 DLD - Dead Lock Detection
 DLDR - Dead Lock Detection and Recovery
 DLL - Dynamic Link Library


### PR DESCRIPTION
Currently SAI defines router DHCP trap :

     * @brief DHCP traffic (UDP ports 67, 68), either L3 broadcast or unicast
     * to local router IP address (default packet action is forward)
    SAI_HOSTIF_TRAP_TYPE_DHCP = 0x00002002,

There is a bootstrap problem with L3 trap in case of ZTP use case
To be able to receive an L3 trap, a RIF has to be set up (and that requires having IP address)
However, such IP address can only be obtained by receiving DHCP packets, which in turn is only possible currently when having a RIF set up

The proposed solution is introducing a L2 switch DHCP trap
Such trap can be received without a RIF
Therefor, DHCP OFFER and DHCP ACKNOWLEDGE can be received
