### PR TITLE
Query statistics capability

### DIFF
--- a/inc/saiobject.h
+++ b/inc/saiobject.h
@@ -232,6 +232,20 @@ sai_status_t sai_query_attribute_enum_values_capability(
         _Inout_ sai_s32_list_t *enum_values_capability);
 
 /**
+ * @brief Query statistics capability
+ *
+ * @param[in] switch_id SAI Switch object id
+ * @param[in] object_type SAI object type
+ * @param[inout] stats_values_capability List of implemented enum values
+ *
+ * @return #SAI_STATUS_SUCCESS on success, #SAI_STATUS_BUFFER_OVERFLOW if list size insufficient, failure status code on error
+ */
+sai_status_t sai_query_stats_capability(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _Inout_ sai_s32_list_t *stats_values_capability);
+
+/**
  * @}
  */
 #endif /** __SAIOBJECT_H_ */


### PR DESCRIPTION
Add ability to query statistics values capability per object type - meaning which statistics enum values are implemented per object type
Currently, these is not exposed, and in order to check capabilities, the user has to retry each value, one by one