### PR TITLE
Query statistics capability

### DIFF
--- a/inc/saiobject.h
+++ b/inc/saiobject.h
@@ -237,13 +237,15 @@ sai_status_t sai_query_attribute_enum_values_capability(
  * @param[in] switch_id SAI Switch object id
  * @param[in] object_type SAI object type
  * @param[inout] stats_values_capability List of implemented enum values
+ * @param[inout] stats_modes_capability List of implemented sai_stats_mode_t values
  *
- * @return #SAI_STATUS_SUCCESS on success, #SAI_STATUS_BUFFER_OVERFLOW if list size insufficient, failure status code on error
+ * @return #SAI_STATUS_SUCCESS on success, #SAI_STATUS_BUFFER_OVERFLOW if lists size insufficient, failure status code on error
  */
 sai_status_t sai_query_stats_capability(
         _In_ sai_object_id_t switch_id,
         _In_ sai_object_type_t object_type,
-        _Inout_ sai_s32_list_t *stats_values_capability);
+        _Inout_ sai_s32_list_t *stats_values_capability,
+        _Inout_ sai_s32_list_t *stats_modes_capability);
 
 /**
  * @}

--- a/inc/saiobject.h
+++ b/inc/saiobject.h
@@ -236,16 +236,14 @@ sai_status_t sai_query_attribute_enum_values_capability(
  *
  * @param[in] switch_id SAI Switch object id
  * @param[in] object_type SAI object type
- * @param[inout] stats_values_capability List of implemented enum values
- * @param[inout] stats_modes_capability List of implemented sai_stats_mode_t values
+ * @param[inout] stats_capability List of implemented enum values, and the statistics modes (bit mask) supported per value
  *
  * @return #SAI_STATUS_SUCCESS on success, #SAI_STATUS_BUFFER_OVERFLOW if lists size insufficient, failure status code on error
  */
 sai_status_t sai_query_stats_capability(
         _In_ sai_object_id_t switch_id,
         _In_ sai_object_type_t object_type,
-        _Inout_ sai_s32_list_t *stats_values_capability,
-        _Inout_ sai_s32_list_t *stats_modes_capability);
+        _Inout_ sai_stat_capability_list_t *stats_capability);
 
 /**
  * @}

--- a/inc/saiobject.h
+++ b/inc/saiobject.h
@@ -232,6 +232,20 @@ sai_status_t sai_query_attribute_enum_values_capability(
         _Inout_ sai_s32_list_t *enum_values_capability);
 
 /**
+ * @brief Query statistics capability
+ *
+ * @param[in] switch_id SAI Switch object id
+ * @param[in] object_type SAI object type
+ * @param[inout] stats_values_capability List of implemented enum values
+ *
+ * @return #SAI_STATUS_SUCCESS on success, #SAI_STATUS_BUFFER_OVERFLOW if list size insufficient, failure status code on error
+ */
+sai_status_t sai_query_stats_capability(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _Inout_ sai_s32_list_t *stats_values_capability);
+
+/**
  * @}
  */
 #endif /** __SAIOBJECT_H_ */

--- a/inc/saiobject.h
+++ b/inc/saiobject.h
@@ -232,7 +232,7 @@ sai_status_t sai_query_attribute_enum_values_capability(
         _Inout_ sai_s32_list_t *enum_values_capability);
 
 /**
- * @brief Query statistics capability
+ * @brief Query statistics capability for statistics bound at object level
  *
  * @param[in] switch_id SAI Switch object id
  * @param[in] object_type SAI object type

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1355,18 +1355,46 @@ typedef sai_status_t (*sai_bulk_object_get_attribute_fn)(
         _In_ sai_bulk_op_error_mode_t mode,
         _Out_ sai_status_t *object_statuses);
 
+/**
+ * @brief SAI statistics modes
+ *
+ * Used in get statistics extended or query statistics capabilities
+ * Note enum values must be powers of 2 to be used as bit mask for query statistics capabilities
+ */
 typedef enum _sai_stats_mode_t
 {
     /**
      * @brief Read statistics
      */
-    SAI_STATS_MODE_READ,
+    SAI_STATS_MODE_READ = 1 << 0,
 
     /**
      * @brief Read and clear after reading
      */
-    SAI_STATS_MODE_READ_AND_CLEAR,
+    SAI_STATS_MODE_READ_AND_CLEAR = 1 << 1,
 } sai_stats_mode_t;
+
+typedef struct _sai_stat_capability_t
+{
+    /** stat enum value */
+    int32_t stat_enum;
+
+    /**
+     * @brief bit mask of supported statistics modes (sai_stats_mode_t)
+     *
+     * For example, if read and read_and_clear are supported, value is
+     * SAI_STATS_MODE_READ | SAI_STATS_MODE_READ_AND_CLEAR
+     */
+    uint64_t stat_modes;
+
+} sai_stat_capability_t;
+
+typedef struct _sai_stat_capability_list_t
+{
+    uint32_t count;
+    sai_stat_capability_t *list;
+
+} sai_stat_capability_list_t;
 
 /**
  * @}

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1387,7 +1387,7 @@ typedef struct _sai_stat_capability_t
      * For example, if read and read_and_clear are supported, value is
      * SAI_STATS_MODE_READ | SAI_STATS_MODE_READ_AND_CLEAR
      */
-    uint64_t stat_modes;
+    uint32_t stat_modes;
 
 } sai_stat_capability_t;
 

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1360,14 +1360,11 @@ typedef sai_status_t (*sai_bulk_object_get_attribute_fn)(
  *
  * Used in get statistics extended or query statistics capabilities
  * Note enum values must be powers of 2 to be used as bit mask for query statistics capabilities
+ *
+ * @flags Contains flags
  */
 typedef enum _sai_stats_mode_t
 {
-    /**
-     * @brief Start of modes
-     */
-    SAI_STATS_MODE_START,
-
     /**
      * @brief Read statistics
      */

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1376,11 +1376,11 @@ typedef enum _sai_stats_mode_t
 
 typedef struct _sai_stat_capability_t
 {
-    /** stat enum value */
+    /** Stat enum value */
     int32_t stat_enum;
 
     /**
-     * @brief bit mask of supported statistics modes (sai_stats_mode_t)
+     * @brief Bit mask of supported statistics modes (sai_stats_mode_t)
      *
      * For example, if read and read_and_clear are supported, value is
      * SAI_STATS_MODE_READ | SAI_STATS_MODE_READ_AND_CLEAR

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1364,6 +1364,11 @@ typedef sai_status_t (*sai_bulk_object_get_attribute_fn)(
 typedef enum _sai_stats_mode_t
 {
     /**
+     * @brief Start of modes
+     */
+    SAI_STATS_MODE_START,
+
+    /**
      * @brief Read statistics
      */
     SAI_STATS_MODE_READ = 1 << 0,

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1379,7 +1379,7 @@ typedef enum _sai_stats_mode_t
 typedef struct _sai_stat_capability_t
 {
     /** Stat enum value */
-    int32_t stat_enum;
+    sai_stat_id_t stat_enum;
 
     /**
      * @brief Bit mask of supported statistics modes (sai_stats_mode_t)

--- a/meta/serialize.pm
+++ b/meta/serialize.pm
@@ -252,7 +252,7 @@ sub GetTypeInfoForSerialize
     {
         $TypeInfo{suffix} = "uint32";
         $TypeInfo{deamp} = "&";
-    }	
+    }
     elsif ($type =~ /^sai_(cos|queue_index)_t$/)
     {
         $TypeInfo{suffix} = "uint8";

--- a/meta/serialize.pm
+++ b/meta/serialize.pm
@@ -248,6 +248,11 @@ sub GetTypeInfoForSerialize
         $TypeInfo{suffix} = "uint32";
         $TypeInfo{deamp} = "&";
     }
+    elsif ($type =~ /^sai_(stat_id)_t$/)
+    {
+        $TypeInfo{suffix} = "uint32";
+        $TypeInfo{deamp} = "&";
+    }	
     elsif ($type =~ /^sai_(cos|queue_index)_t$/)
     {
         $TypeInfo{suffix} = "uint8";


### PR DESCRIPTION
Add ability to query statistics values capability per object type - meaning which statistics enum values are implemented per object type
Currently, these is not exposed, and in order to check capabilities, the user has to retry each value, one by one

Signed-off-by: Itai Baz <itaib@mellanox.com>