### PR TITLE
add next hop group member counter

### DIFF
--- a/inc/sainexthopgroup.h
+++ b/inc/sainexthopgroup.h
@@ -286,6 +286,19 @@ typedef enum _sai_next_hop_group_member_attr_t
     SAI_NEXT_HOP_GROUP_MEMBER_ATTR_SEQUENCE_ID,
 
     /**
+     * @brief Attach a counter
+     *
+     * When it is empty, then packet hits won't be counted
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_COUNTER
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_NEXT_HOP_GROUP_MEMBER_ATTR_COUNTER_ID,
+
+    /**
      * @brief End of attributes
      */
     SAI_NEXT_HOP_GROUP_MEMBER_ATTR_END,


### PR DESCRIPTION
Add ability to attach a SAI counter to next hop group member, to count traffic routed to it

Signed-off-by: Itai Baz <itaib@mellanox.com>