### PR TITLE
add neighbor and tunnel term ip addr family for CRM

### DIFF
--- a/inc/saineighbor.h
+++ b/inc/saineighbor.h
@@ -153,6 +153,15 @@ typedef enum _sai_neighbor_entry_attr_t
      */
     SAI_NEIGHBOR_ENTRY_ATTR_IS_LOCAL,
 
+    /*
+     * @brief Neighbor entry IP address family
+     *
+     * @type sai_ip_addr_family_t
+     * @flags READ_ONLY
+     * @isresourcetype true
+     */
+    SAI_NEIGHBOR_ENTRY_ATTR_IP_ADDR_FAMILY,
+
     /**
      * @brief End of attributes
      */

--- a/inc/saineighbor.h
+++ b/inc/saineighbor.h
@@ -153,7 +153,9 @@ typedef enum _sai_neighbor_entry_attr_t
      */
     SAI_NEIGHBOR_ENTRY_ATTR_IS_LOCAL,
 
-    /*
+    /** READ-ONLY */
+
+    /**
      * @brief Neighbor entry IP address family
      *
      * @type sai_ip_addr_family_t

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -849,6 +849,8 @@ typedef enum _sai_tunnel_term_table_entry_attr_t
      */
     SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_ACTION_TUNNEL_ID,
 
+    /** READ-ONLY */
+
     /**
      * @brief Tunnel term table entry IP address family
      *

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -850,6 +850,15 @@ typedef enum _sai_tunnel_term_table_entry_attr_t
     SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_ACTION_TUNNEL_ID,
 
     /**
+     * @brief Tunnel term table entry IP address family
+     *
+     * @type sai_ip_addr_family_t
+     * @flags READ_ONLY
+     * @isresourcetype true
+     */
+    SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_IP_ADDR_FAMILY,
+
+    /**
      * @brief End of attributes
      */
     SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_END,


### PR DESCRIPTION
Generic resource monitoring, done by API sai_object_type_get_availability, introduced the ability to query avaialble resources per object type, and provide additional attributes as query params. This PR intoduces 2 such params - neighbor entry IP address family, to be able to query avaialble IPv4 and IPv6 neigbor entries, and tunnel termination table entry IP address family, to be able to query available IPv4 and IPv6 tunnel termination table entries.
Introduced attributes are read only, marked as resourcetype, and used only for this query

Signed-off-by: Itai Baz <itaib@mellanox.com>