### PR TITLE
Packet loopback action for tunnels

### DIFF
--- a/inc/saidebugcounter.h
+++ b/inc/saidebugcounter.h
@@ -347,6 +347,13 @@ typedef enum _sai_out_drop_reason_t
      */
     SAI_OUT_DROP_REASON_L3_EGRESS_LINK_DOWN,
 
+    /* Tunnel reasons */
+
+    /**
+     * @brief Tunnel packets dropped if going back to the incoming tunnel
+     */
+    SAI_OUT_DROP_REASON_TUNNEL_LOOPBACK_PACKET_DROP,
+
     /** End of out drop reasons */
     SAI_OUT_DROP_REASON_END,
 

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -2257,6 +2257,15 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_SUPPORTED_FAILOVER_MODE,
 
     /**
+     * @brief Packet action when a packet ingress and gets routed back to same tunnel
+     *
+     * @type sai_packet_action_t
+     * @flags CREATE_AND_SET
+     * @default SAI_PACKET_ACTION_FORWARD
+     */
+    SAI_SWITCH_ATTR_TUNNEL_LOOPBACK_PACKET_ACTION,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -644,6 +644,15 @@ typedef enum _sai_tunnel_attr_t
     SAI_TUNNEL_ATTR_TERM_TABLE_ENTRY_LIST,
 
     /**
+     * @brief Packet action when a packet ingress and gets routed back to same tunnel
+     *
+     * @type sai_packet_action_t
+     * @flags CREATE_AND_SET
+     * @default SAI_PACKET_ACTION_FORWARD
+     */
+    SAI_TUNNEL_ATTR_LOOPBACK_PACKET_ACTION,
+
+    /**
      * @brief End of attributes
      */
     SAI_TUNNEL_ATTR_END,


### PR DESCRIPTION
Added loopback action as switch attribute: This will apply to all the tunnels configured
Added loopback action as tunnel attribute: This will apply as a tunnel specific action.