### PR TITLE
Switch attributes for tunnel ECN mode

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -328,43 +328,46 @@ typedef enum _sai_switch_failover_config_mode_t
 /**
  * @brief Defines tunnel encap ECN mode
  */
-typedef enum _sai_switch_tunnel_encap_ecn_mode_t
+typedef enum _sai_tunnel_encap_ecn_mode_t
 {
     /**
      * @brief Normal mode behavior defined in RFC 6040
      * section 4.1 copy from inner
      */
-    SAI_SWITCH_TUNNEL_ENCAP_ECN_MODE_STANDARD,
+    SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD,
 
     /**
-     * @brief User defined behavior
+     * @brief User defined behavior.
+     *
+     * Need to provide #SAI_TUNNEL_MAP_TYPE_OECN_TO_UECN in #SAI_TUNNEL_ATTR_ENCAP_MAPPERS.
      */
-    SAI_SWITCH_TUNNEL_ENCAP_ECN_MODE_USER_DEFINED
+    SAI_TUNNEL_ENCAP_ECN_MODE_USER_DEFINED
 
-} sai_switch_tunnel_encap_ecn_mode_t;
+} sai_tunnel_encap_ecn_mode_t;
 
 /**
  * @brief Defines tunnel decap ECN mode
  */
-typedef enum _sai_switch_tunnel_decap_ecn_mode_t
+typedef enum _sai_tunnel_decap_ecn_mode_t
 {
     /**
-     * @brief Normal mode behavior defined in RFC 6040
-     * section 4.1 copy from inner
+     * @brief Behavior defined in RFC 6040 section 4.2
      */
-    SAI_SWITCH_TUNNEL_DECAP_ECN_MODE_STANDARD,
+    SAI_TUNNEL_DECAP_ECN_MODE_STANDARD,
 
     /**
      * @brief Copy from outer ECN
      */
-    SAI_SWITCH_TUNNEL_DECAP_ECN_MODE_COPY_FROM_OUTER,
+    SAI_TUNNEL_DECAP_ECN_MODE_COPY_FROM_OUTER,
 
     /**
      * @brief User defined behavior
+     *
+     * Need to provide #SAI_TUNNEL_MAP_TYPE_UECN_OECN_TO_OECN in #SAI_TUNNEL_ATTR_DECAP_MAPPERS
      */
-    SAI_SWITCH_TUNNEL_DECAP_ECN_MODE_USER_DEFINED
+    SAI_TUNNEL_DECAP_ECN_MODE_USER_DEFINED
 
-} sai_switch_tunnel_decap_ecn_mode_t;
+} sai_tunnel_decap_ecn_mode_t;
 
 /**
  * @brief Attribute Id in sai_set_switch_attribute() and
@@ -2310,9 +2313,9 @@ typedef enum _sai_switch_attr_t
     /**
      * @brief Tunnel encap ECN Mode load method
      *
-     * @type sai_switch_tunnel_encap_ecn_mode_t
+     * @type sai_tunnel_encap_ecn_mode_t
      * @flags CREATE_AND_SET
-     * @default SAI_SWITCH_TUNNEL_ENCAP_ECN_MODE_STANDARD
+     * @default SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD
      */
     SAI_SWITCH_ATTR_TUNNEL_ENCAP_ECN_MODE,
 
@@ -2329,9 +2332,9 @@ typedef enum _sai_switch_attr_t
     /**
      * @brief Tunnel decap ECN Mode load method
      *
-     * @type sai_switch_tunnel_decap_ecn_mode_t
+     * @type sai_tunnel_decap_ecn_mode_t
      * @flags CREATE_AND_SET
-     * @default SAI_SWITCH_TUNNEL_DECAP_ECN_MODE_STANDARD
+     * @default SAI_TUNNEL_DECAP_ECN_MODE_STANDARD
      */
     SAI_SWITCH_ATTR_TUNNEL_DECAP_ECN_MODE,
 

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -326,6 +326,29 @@ typedef enum _sai_switch_failover_config_mode_t
 } sai_switch_failover_config_mode_t;
 
 /**
+ * @brief Defines tunnel ECN mode
+ */
+typedef enum _sai_switch_tunnel_ecn_mode_t
+{
+    /**
+     * @brief Normal mode behavior defined in RFC 6040
+     * section 4.1 copy from inner
+     */
+    SAI_SWITCH_TUNNEL_ECN_MODE_STANDARD,
+
+    /**
+     * @brief Copy from outer ECN
+     */
+    SAI_SWITCH_TUNNEL_ECN_MODE_COPY_FROM_OUTER,
+
+    /**
+     * @brief User defined behavior
+     */
+    SAI_SWITCH_TUNNEL_ECN_MODE_USER_DEFINED
+
+} sai_switch_tunnel_ecn_mode_t;
+
+/**
  * @brief Attribute Id in sai_set_switch_attribute() and
  * sai_get_switch_attribute() calls
  */

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -328,46 +328,178 @@ typedef enum _sai_switch_failover_config_mode_t
 /**
  * @brief Defines tunnel encap ECN mode
  */
-typedef enum _sai_tunnel_encap_ecn_mode_t
+typedef enum _sai_tunnel_ipinip_encap_ecn_mode_t
 {
     /**
      * @brief Normal mode behavior defined in RFC 6040
      * section 4.1 copy from inner
      */
-    SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD,
+    SAI_TUNNEL_IPINIP_ENCAP_ECN_MODE_STANDARD,
 
     /**
      * @brief User defined behavior.
      *
      * Need to provide #SAI_TUNNEL_MAP_TYPE_OECN_TO_UECN in #SAI_TUNNEL_ATTR_ENCAP_MAPPERS.
      */
-    SAI_TUNNEL_ENCAP_ECN_MODE_USER_DEFINED
+    SAI_TUNNEL_IPINIP_ENCAP_ECN_MODE_USER_DEFINED
 
-} sai_tunnel_encap_ecn_mode_t;
+} sai_tunnel_ipinip_encap_ecn_mode_t;
+
+/**
+ * @brief Defines GRE tunnel encap ECN mode
+ */
+typedef enum _sai_tunnel_ipinip_gre_encap_ecn_mode_t
+{
+    /**
+     * @brief Normal mode behavior defined in RFC 6040
+     * section 4.1 copy from inner
+     */
+    SAI_TUNNEL_IPINIP_GRE_ENCAP_ECN_MODE_STANDARD,
+
+    /**
+     * @brief User defined behavior.
+     *
+     * Need to provide #SAI_TUNNEL_MAP_TYPE_OECN_TO_UECN in #SAI_TUNNEL_ATTR_ENCAP_MAPPERS.
+     */
+    SAI_TUNNEL_IPINIP_GRE_ENCAP_ECN_MODE_USER_DEFINED
+
+} sai_tunnel_ipinip_gre_encap_ecn_mode_t;
+
+/**
+ * @brief Defines VXLAN tunnel encap ECN mode
+ */
+typedef enum _sai_tunnel_vxlan_encap_ecn_mode_t
+{
+    /**
+     * @brief Normal mode behavior defined in RFC 6040
+     * section 4.1 copy from inner
+     */
+    SAI_TUNNEL_VXLAN_ENCAP_ECN_MODE_STANDARD,
+
+    /**
+     * @brief User defined behavior.
+     *
+     * Need to provide #SAI_TUNNEL_MAP_TYPE_OECN_TO_UECN in #SAI_TUNNEL_ATTR_ENCAP_MAPPERS.
+     */
+    SAI_TUNNEL_VXLAN_ENCAP_ECN_MODE_USER_DEFINED
+
+} sai_tunnel_vxlan_encap_ecn_mode_t;
+
+/**
+ * @brief Defines MPLS tunnel encap ECN mode
+ */
+typedef enum _sai_tunnel_mpls_encap_ecn_mode_t
+{
+    /**
+     * @brief Normal mode behavior defined in RFC 6040
+     * section 4.1 copy from inner
+     */
+    SAI_TUNNEL_MPLS_ENCAP_ECN_MODE_STANDARD,
+
+    /**
+     * @brief User defined behavior.
+     *
+     * Need to provide #SAI_TUNNEL_MAP_TYPE_OECN_TO_UECN in #SAI_TUNNEL_ATTR_ENCAP_MAPPERS.
+     */
+    SAI_TUNNEL_MPLS_ENCAP_ECN_MODE_USER_DEFINED
+
+} sai_tunnel_mpls_encap_ecn_mode_t;
 
 /**
  * @brief Defines tunnel decap ECN mode
  */
-typedef enum _sai_tunnel_decap_ecn_mode_t
+typedef enum _sai_tunnel_ipinip_decap_ecn_mode_t
 {
     /**
      * @brief Behavior defined in RFC 6040 section 4.2
      */
-    SAI_TUNNEL_DECAP_ECN_MODE_STANDARD,
+    SAI_TUNNEL_IPINIP_DECAP_ECN_MODE_STANDARD,
 
     /**
      * @brief Copy from outer ECN
      */
-    SAI_TUNNEL_DECAP_ECN_MODE_COPY_FROM_OUTER,
+    SAI_TUNNEL_IPINIP_DECAP_ECN_MODE_COPY_FROM_OUTER,
 
     /**
      * @brief User defined behavior
      *
      * Need to provide #SAI_TUNNEL_MAP_TYPE_UECN_OECN_TO_OECN in #SAI_TUNNEL_ATTR_DECAP_MAPPERS
      */
-    SAI_TUNNEL_DECAP_ECN_MODE_USER_DEFINED
+    SAI_TUNNEL_IPINIP_DECAP_ECN_MODE_USER_DEFINED
 
-} sai_tunnel_decap_ecn_mode_t;
+} sai_tunnel_ipinip_decap_ecn_mode_t;
+
+/**
+ * @brief Defines GRE tunnel decap ECN mode
+ */
+typedef enum _sai_tunnel_ipinip_gre_decap_ecn_mode_t
+{
+    /**
+     * @brief Behavior defined in RFC 6040 section 4.2
+     */
+    SAI_TUNNEL_IPINIP_GRE_DECAP_ECN_MODE_STANDARD,
+
+    /**
+     * @brief Copy from outer ECN
+     */
+    SAI_TUNNEL_IPINIP_GRE_DECAP_ECN_MODE_COPY_FROM_OUTER,
+
+    /**
+     * @brief User defined behavior
+     *
+     * Need to provide #SAI_TUNNEL_MAP_TYPE_UECN_OECN_TO_OECN in #SAI_TUNNEL_ATTR_DECAP_MAPPERS
+     */
+    SAI_TUNNEL_IPINIP_GRE_DECAP_ECN_MODE_USER_DEFINED
+
+} sai_tunnel_ipinip_gre_decap_ecn_mode_t;
+
+/**
+ * @brief Defines VXLAN tunnel decap ECN mode
+ */
+typedef enum _sai_tunnel_vxlan_decap_ecn_mode_t
+{
+    /**
+     * @brief Behavior defined in RFC 6040 section 4.2
+     */
+    SAI_TUNNEL_VXLAN_DECAP_ECN_MODE_STANDARD,
+
+    /**
+     * @brief Copy from outer ECN
+     */
+    SAI_TUNNEL_VXLAN_DECAP_ECN_MODE_COPY_FROM_OUTER,
+
+    /**
+     * @brief User defined behavior
+     *
+     * Need to provide #SAI_TUNNEL_MAP_TYPE_UECN_OECN_TO_OECN in #SAI_TUNNEL_ATTR_DECAP_MAPPERS
+     */
+    SAI_TUNNEL_VXLAN_DECAP_ECN_MODE_USER_DEFINED
+
+} sai_tunnel_vxlan_decap_ecn_mode_t;
+
+/**
+ * @brief Defines MPLS tunnel decap ECN mode
+ */
+typedef enum _sai_tunnel_mpls_decap_ecn_mode_t
+{
+    /**
+     * @brief Behavior defined in RFC 6040 section 4.2
+     */
+    SAI_TUNNEL_MPLS_DECAP_ECN_MODE_STANDARD,
+
+    /**
+     * @brief Copy from outer ECN
+     */
+    SAI_TUNNEL_MPLS_DECAP_ECN_MODE_COPY_FROM_OUTER,
+
+    /**
+     * @brief User defined behavior
+     *
+     * Need to provide #SAI_TUNNEL_MAP_TYPE_UECN_OECN_TO_OECN in #SAI_TUNNEL_ATTR_DECAP_MAPPERS
+     */
+    SAI_TUNNEL_MPLS_DECAP_ECN_MODE_USER_DEFINED
+
+} sai_tunnel_mpls_decap_ecn_mode_t;
 
 /**
  * @brief Attribute Id in sai_set_switch_attribute() and
@@ -2308,16 +2440,37 @@ typedef enum _sai_switch_attr_t
      * @objects SAI_OBJECT_TYPE_TUNNEL_MAP
      * @default empty
      */
-    SAI_SWITCH_ATTR_TUNNEL_ENCAP_ECN_MAPPERS,
+    SAI_SWITCH_ATTR_TUNNEL_IPINIP_ENCAP_ECN_MAPPERS,
 
     /**
-     * @brief Tunnel encap ECN Mode load method
+     * @brief VXLAN Tunnel mappers for encap
      *
-     * @type sai_tunnel_encap_ecn_mode_t
+     * @type sai_object_list_t
      * @flags CREATE_AND_SET
-     * @default SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD
+     * @objects SAI_OBJECT_TYPE_TUNNEL_MAP
+     * @default empty
      */
-    SAI_SWITCH_ATTR_TUNNEL_ENCAP_ECN_MODE,
+    SAI_SWITCH_ATTR_TUNNEL_VXLAN_ENCAP_ECN_MAPPERS,
+
+    /**
+     * @brief GRE Tunnel mappers for encap
+     *
+     * @type sai_object_list_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_TUNNEL_MAP
+     * @default empty
+     */
+    SAI_SWITCH_ATTR_TUNNEL_IPINIP_GRE_ENCAP_ECN_MAPPERS,
+
+    /**
+     * @brief MPLS Tunnel mappers for encap
+     *
+     * @type sai_object_list_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_TUNNEL_MAP
+     * @default empty
+     */
+    SAI_SWITCH_ATTR_TUNNEL_MPLS_ENCAP_ECN_MAPPERS,
 
     /**
      * @brief Tunnel mappers for decap
@@ -2327,16 +2480,109 @@ typedef enum _sai_switch_attr_t
      * @objects SAI_OBJECT_TYPE_TUNNEL_MAP
      * @default empty
      */
-    SAI_SWITCH_ATTR_TUNNEL_DECAP_ECN_MAPPERS,
+    SAI_SWITCH_ATTR_TUNNEL_IPINIP_DECAP_ECN_MAPPERS,
+
+    /**
+     * @brief VXLAN Tunnel mappers for decap
+     *
+     * @type sai_object_list_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_TUNNEL_MAP
+     * @default empty
+     */
+    SAI_SWITCH_ATTR_TUNNEL_VXLAN_DECAP_ECN_MAPPERS,
+
+    /**
+     * @brief GRE Tunnel mappers for decap
+     *
+     * @type sai_object_list_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_TUNNEL_MAP
+     * @default empty
+     */
+    SAI_SWITCH_ATTR_TUNNEL_IPINIP_GRE_DECAP_ECN_MAPPERS,
+
+    /**
+     * @brief MPLS Tunnel mappers for decap
+     *
+     * @type sai_object_list_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_TUNNEL_MAP
+     * @default empty
+     */
+    SAI_SWITCH_ATTR_TUNNEL_MPLS_DECAP_ECN_MAPPERS,
+
+    /**
+     * @brief Tunnel encap ECN Mode load method
+     *
+     * @type sai_tunnel_ipinip_encap_ecn_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_TUNNEL_IPINIP_ENCAP_ECN_MODE_STANDARD
+     */
+    SAI_SWITCH_ATTR_TUNNEL_IPINIP_ENCAP_ECN_MODE,
+
+    /**
+     * @brief GRE Tunnel encap ECN Mode load method
+     *
+     * @type sai_tunnel_ipinip_gre_encap_ecn_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_TUNNEL_IPINIP_GRE_ENCAP_ECN_MODE_STANDARD
+     */
+    SAI_SWITCH_ATTR_TUNNEL_IPINIP_GRE_ENCAP_ECN_MODE,
+
+    /**
+     * @brief VXLAN Tunnel encap ECN Mode load method
+     *
+     * @type sai_tunnel_vxlan_encap_ecn_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_TUNNEL_VXLAN_ENCAP_ECN_MODE_STANDARD
+     */
+    SAI_SWITCH_ATTR_TUNNEL_VXLAN_ENCAP_ECN_MODE,
+
+    /**
+     * @brief MPLS Tunnel encap ECN Mode load method
+     *
+     * @type sai_tunnel_mpls_encap_ecn_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_TUNNEL_MPLS_ENCAP_ECN_MODE_STANDARD
+     */
+    SAI_SWITCH_ATTR_TUNNEL_MPLS_ENCAP_ECN_MODE,
 
     /**
      * @brief Tunnel decap ECN Mode load method
      *
-     * @type sai_tunnel_decap_ecn_mode_t
+     * @type sai_tunnel_ipinip_decap_ecn_mode_t
      * @flags CREATE_AND_SET
-     * @default SAI_TUNNEL_DECAP_ECN_MODE_STANDARD
+     * @default SAI_TUNNEL_IPINIP_DECAP_ECN_MODE_STANDARD
      */
-    SAI_SWITCH_ATTR_TUNNEL_DECAP_ECN_MODE,
+    SAI_SWITCH_ATTR_TUNNEL_IPINIP_DECAP_ECN_MODE,
+
+    /**
+     * @brief GRE Tunnel decap ECN Mode load method
+     *
+     * @type sai_tunnel_ipinip_gre_decap_ecn_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_TUNNEL_IPINIP_GRE_DECAP_ECN_MODE_STANDARD
+     */
+    SAI_SWITCH_ATTR_TUNNEL_IPINIP_GRE_DECAP_ECN_MODE,
+
+    /**
+     * @brief VXLAN Tunnel decap ECN Mode load method
+     *
+     * @type sai_tunnel_vxlan_decap_ecn_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_TUNNEL_VXLAN_DECAP_ECN_MODE_STANDARD
+     */
+    SAI_SWITCH_ATTR_TUNNEL_VXLAN_DECAP_ECN_MODE,
+
+    /**
+     * @brief MPLS Tunnel decap ECN Mode load method
+     *
+     * @type sai_tunnel_mpls_decap_ecn_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_TUNNEL_MPLS_DECAP_ECN_MODE_STANDARD
+     */
+    SAI_SWITCH_ATTR_TUNNEL_MPLS_DECAP_ECN_MODE,
 
     /**
      * @brief End of attributes

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -326,27 +326,45 @@ typedef enum _sai_switch_failover_config_mode_t
 } sai_switch_failover_config_mode_t;
 
 /**
- * @brief Defines tunnel ECN mode
+ * @brief Defines tunnel encap ECN mode
  */
-typedef enum _sai_switch_tunnel_ecn_mode_t
+typedef enum _sai_switch_tunnel_encap_ecn_mode_t
 {
     /**
      * @brief Normal mode behavior defined in RFC 6040
      * section 4.1 copy from inner
      */
-    SAI_SWITCH_TUNNEL_ECN_MODE_STANDARD,
-
-    /**
-     * @brief Copy from outer ECN
-     */
-    SAI_SWITCH_TUNNEL_ECN_MODE_COPY_FROM_OUTER,
+    SAI_SWITCH_TUNNEL_ENCAP_ECN_MODE_STANDARD,
 
     /**
      * @brief User defined behavior
      */
-    SAI_SWITCH_TUNNEL_ECN_MODE_USER_DEFINED
+    SAI_SWITCH_TUNNEL_ENCAP_ECN_MODE_USER_DEFINED
 
-} sai_switch_tunnel_ecn_mode_t;
+} sai_switch_tunnel_encap_ecn_mode_t;
+
+/**
+ * @brief Defines tunnel decap ECN mode
+ */
+typedef enum _sai_switch_tunnel_decap_ecn_mode_t
+{
+    /**
+     * @brief Normal mode behavior defined in RFC 6040
+     * section 4.1 copy from inner
+     */
+    SAI_SWITCH_TUNNEL_DECAP_ECN_MODE_STANDARD,
+
+    /**
+     * @brief Copy from outer ECN
+     */
+    SAI_SWITCH_TUNNEL_DECAP_ECN_MODE_COPY_FROM_OUTER,
+
+    /**
+     * @brief User defined behavior
+     */
+    SAI_SWITCH_TUNNEL_DECAP_ECN_MODE_USER_DEFINED
+
+} sai_switch_tunnel_decap_ecn_mode_t;
 
 /**
  * @brief Attribute Id in sai_set_switch_attribute() and
@@ -2280,23 +2298,42 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_SUPPORTED_FAILOVER_MODE,
 
     /**
-     * @brief Tunnel mappers
+     * @brief Tunnel mappers for encap
      *
      * @type sai_object_list_t
      * @flags CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_TUNNEL_MAP
      * @default empty
      */
-    SAI_SWITCH_ATTR_TUNNEL_MAPPERS,
+    SAI_SWITCH_ATTR_TUNNEL_ENCAP_ECN_MAPPERS,
 
     /**
-     * @brief Tunnel ECN Mode load method
+     * @brief Tunnel encap ECN Mode load method
      *
-     * @type sai_switch_tunnel_ecn_mode_t
+     * @type sai_switch_tunnel_encap_ecn_mode_t
      * @flags CREATE_AND_SET
-     * @default SAI_SWITCH_TUNNEL_ECN_MODE_STANDARD
+     * @default SAI_SWITCH_TUNNEL_ENCAP_ECN_MODE_STANDARD
      */
-    SAI_SWITCH_ATTR_TUNNEL_ECN_MODE,
+    SAI_SWITCH_ATTR_TUNNEL_ENCAP_ECN_MODE,
+
+    /**
+     * @brief Tunnel mappers for decap
+     *
+     * @type sai_object_list_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_TUNNEL_MAP
+     * @default empty
+     */
+    SAI_SWITCH_ATTR_TUNNEL_DECAP_ECN_MAPPERS,
+
+    /**
+     * @brief Tunnel decap ECN Mode load method
+     *
+     * @type sai_switch_tunnel_decap_ecn_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_SWITCH_TUNNEL_DECAP_ECN_MODE_STANDARD
+     */
+    SAI_SWITCH_ATTR_TUNNEL_DECAP_ECN_MODE,
 
     /**
      * @brief End of attributes

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -2280,6 +2280,25 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_SUPPORTED_FAILOVER_MODE,
 
     /**
+     * @brief Tunnel mappers
+     *
+     * @type sai_object_list_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_TUNNEL_MAP
+     * @default empty
+     */
+    SAI_SWITCH_ATTR_TUNNEL_MAPPERS,
+
+    /**
+     * @brief Tunnel ECN Mode load method
+     *
+     * @type sai_switch_tunnel_ecn_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_SWITCH_TUNNEL_ECN_MODE_STANDARD
+     */
+    SAI_SWITCH_ATTR_TUNNEL_ECN_MODE,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -386,50 +386,6 @@ typedef enum _sai_tunnel_dscp_mode_t
 } sai_tunnel_dscp_mode_t;
 
 /**
- * @brief Defines tunnel encap ECN mode
- */
-typedef enum _sai_tunnel_encap_ecn_mode_t
-{
-    /**
-     * @brief Normal mode behavior defined in RFC 6040
-     * section 4.1 copy from inner
-     */
-    SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD,
-
-    /**
-     * @brief User defined behavior.
-     *
-     * Need to provide #SAI_TUNNEL_MAP_TYPE_OECN_TO_UECN in #SAI_TUNNEL_ATTR_ENCAP_MAPPERS.
-     */
-    SAI_TUNNEL_ENCAP_ECN_MODE_USER_DEFINED
-
-} sai_tunnel_encap_ecn_mode_t;
-
-/**
- * @brief Defines tunnel decap ECN mode
- */
-typedef enum _sai_tunnel_decap_ecn_mode_t
-{
-    /**
-     * @brief Behavior defined in RFC 6040 section 4.2
-     */
-    SAI_TUNNEL_DECAP_ECN_MODE_STANDARD,
-
-    /**
-     * @brief Copy from outer ECN
-     */
-    SAI_TUNNEL_DECAP_ECN_MODE_COPY_FROM_OUTER,
-
-    /**
-     * @brief User defined behavior
-     *
-     * Need to provide #SAI_TUNNEL_MAP_TYPE_UECN_OECN_TO_OECN in #SAI_TUNNEL_ATTR_DECAP_MAPPERS
-     */
-    SAI_TUNNEL_DECAP_ECN_MODE_USER_DEFINED
-
-} sai_tunnel_decap_ecn_mode_t;
-
-/**
  * @brief Defines tunnel peer mode
  */
 typedef enum _sai_tunnel_peer_mode_t

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -386,6 +386,50 @@ typedef enum _sai_tunnel_dscp_mode_t
 } sai_tunnel_dscp_mode_t;
 
 /**
+ * @brief Defines tunnel encap ECN mode
+ */
+typedef enum _sai_tunnel_encap_ecn_mode_t
+{
+    /**
+     * @brief Normal mode behavior defined in RFC 6040
+     * section 4.1 copy from inner
+     */
+    SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD,
+
+    /**
+     * @brief User defined behavior.
+     *
+     * Need to provide #SAI_TUNNEL_MAP_TYPE_OECN_TO_UECN in #SAI_TUNNEL_ATTR_ENCAP_MAPPERS.
+     */
+    SAI_TUNNEL_ENCAP_ECN_MODE_USER_DEFINED
+
+} sai_tunnel_encap_ecn_mode_t;
+
+/**
+ * @brief Defines tunnel decap ECN mode
+ */
+typedef enum _sai_tunnel_decap_ecn_mode_t
+{
+    /**
+     * @brief Behavior defined in RFC 6040 section 4.2
+     */
+    SAI_TUNNEL_DECAP_ECN_MODE_STANDARD,
+
+    /**
+     * @brief Copy from outer ECN
+     */
+    SAI_TUNNEL_DECAP_ECN_MODE_COPY_FROM_OUTER,
+
+    /**
+     * @brief User defined behavior
+     *
+     * Need to provide #SAI_TUNNEL_MAP_TYPE_UECN_OECN_TO_OECN in #SAI_TUNNEL_ATTR_DECAP_MAPPERS
+     */
+    SAI_TUNNEL_DECAP_ECN_MODE_USER_DEFINED
+
+} sai_tunnel_decap_ecn_mode_t;
+
+/**
  * @brief Defines tunnel peer mode
  */
 typedef enum _sai_tunnel_peer_mode_t

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -372,7 +372,7 @@ void check_attr_by_object_type()
             sai_object_type_t current = ot[index]->objecttype;
 
             META_ASSERT_TRUE(current == i, "object type must be equal on object type list");
-            META_ASSERT_TRUE(index < 200, "object defines > 200 attributes, metadata bug?");
+            META_ASSERT_TRUE(index < 300, "object defines > 300 attributes, metadata bug?");
             META_ASSERT_TRUE(current > SAI_OBJECT_TYPE_NULL, "object type must be > NULL");
             META_ASSERT_TRUE(current < SAI_OBJECT_TYPE_EXTENSIONS_MAX, "object type must be < MAX");
 


### PR DESCRIPTION
Add switch attributes for switch level configuration of tunnel ECN modes.
Encap and Decap ecn modes can be configured individually with separately assigned ECN mappers for user defined ECN mode.