### PR TITLE
Updates for Linux MACsec driver and 802.1AE-2018

### DIFF
--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -46,13 +46,13 @@ typedef enum _sai_macsec_direction_t
 /**
  * @brief MACsec Cipher Suites.
  */
-typedef enum _sai_macsec_direction_t
+typedef enum _sai_macsec_cipher_suite_t
 {
     SAI_MACSEC_CIPHER_SUITE_GCM_AES_128,
     SAI_MACSEC_CIPHER_SUITE_GCM_AES_256,
     SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_128,
     SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_256
-} sai_macsec_direction_t;
+} sai_macsec_cipher_suite_t;
 
 /**
  * @brief Attribute Id for sai_macsec

--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -773,6 +773,7 @@ typedef enum _sai_macsec_sa_attr_t
 
     /**
      * @brief SSCI value for this Secure Association
+     *
      * Valid when SAI_MACSEC_SC_ATTR_MACSEC_CIPHER_SUITE == SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_128 or SAI_MACSEC_SC_ATTR_MACSEC_CIPHER_SUITE == SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_256.
      *
      * @type sai_uint32_t

--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -734,7 +734,7 @@ typedef enum _sai_macsec_sa_attr_t
      * @brief MACsec Salt used for encryption/decryption.
      * Network Byte order.
      *
-     * Valid when SAI_MACSEC_SC_ATTR_CIPHER_SUITE == SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_128 or SAI_MACSEC_SC_ATTR_CIPHER_SUITE == SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_256.
+     * Valid when SAI_MACSEC_SC_ATTR_MACSEC_CIPHER_SUITE == SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_128 or SAI_MACSEC_SC_ATTR_MACSEC_CIPHER_SUITE == SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_256.
      *
      * @type sai_macsec_salt_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
@@ -773,7 +773,7 @@ typedef enum _sai_macsec_sa_attr_t
 
     /**
      * @brief SSCI value for this Secure Association
-     * Valid when SAI_MACSEC_SC_ATTR_CIPHER_SUITE == SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_128 or SAI_MACSEC_SC_ATTR_CIPHER_SUITE == SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_256.
+     * Valid when SAI_MACSEC_SC_ATTR_MACSEC_CIPHER_SUITE == SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_128 or SAI_MACSEC_SC_ATTR_MACSEC_CIPHER_SUITE == SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_256.
      *
      * @type sai_uint32_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY

--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -646,6 +646,23 @@ typedef enum _sai_macsec_sc_attr_t
     SAI_MACSEC_SC_ATTR_SA_LIST,
 
     /**
+     * @brief Cipher suite for this Secure Channel.
+     *
+     * @type sai_uint64_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     */
+    SAI_MACSEC_SC_ATTR_MACSEC_CIPHER_SUITE,
+
+    /**
+     * @brief True means encryption is enabled.  False means encryption is disabled.
+     *
+     * @type bool
+     * @flags CREATE_ONLY
+     * @default true
+     */
+    SAI_MACSEC_SC_ATTR_ENCRYPTION_ENABLE,
+
+    /**
      * @brief End of MACsec Secure Channel attributes
      */
     SAI_MACSEC_SC_ATTR_END,
@@ -777,6 +794,15 @@ typedef enum _sai_macsec_sa_attr_t
      * @validonly SAI_MACSEC_SA_ATTR_MACSEC_DIRECTION == SAI_MACSEC_DIRECTION_INGRESS
      */
     SAI_MACSEC_SA_ATTR_MINIMUM_XPN,
+
+    /**
+     * @brief SSCI value for this Secure Association
+     * Used only if SAI_MACSEC_SC_ATTR_MACSEC_XPN64_ENABLE == true.
+     *
+     * @type sai_uint32_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     */
+    SAI_MACSEC_SA_ATTR_MACSEC_SSCI,
 
     /**
      * @brief End of MACsec Secure Association attributes

--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -44,6 +44,17 @@ typedef enum _sai_macsec_direction_t
 } sai_macsec_direction_t;
 
 /**
+ * @brief MACsec Cipher Suites.
+ */
+typedef enum _sai_macsec_direction_t
+{
+    SAI_MACSEC_CIPHER_SUITE_GCM_AES_128,
+    SAI_MACSEC_CIPHER_SUITE_GCM_AES_256,
+    SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_128,
+    SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_256
+} sai_macsec_direction_t;
+
+/**
  * @brief Attribute Id for sai_macsec
  */
 typedef enum _sai_macsec_attr_t
@@ -571,23 +582,6 @@ typedef enum _sai_macsec_sc_attr_t
     SAI_MACSEC_SC_ATTR_MACSEC_SCI,
 
     /**
-     * @brief SSCI value for this Secure Channel
-     *
-     * @type sai_uint32_t
-     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
-     * @condition SAI_MACSEC_SC_ATTR_MACSEC_XPN64_ENABLE == true
-     */
-    SAI_MACSEC_SC_ATTR_MACSEC_SSCI,
-
-    /**
-     * @brief Enable 64-bit XPN (vs 32-bit PN) for this Secure Channel
-     *
-     * @type bool
-     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
-     */
-    SAI_MACSEC_SC_ATTR_MACSEC_XPN64_ENABLE,
-
-    /**
      * @brief Explicit SCI enable for this Secure Channel.
      *
      * @type bool
@@ -648,8 +642,8 @@ typedef enum _sai_macsec_sc_attr_t
     /**
      * @brief Cipher suite for this Secure Channel.
      *
-     * @type sai_uint64_t
-     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @type sai_macsec_cipher_suite_t
+     * @flags MANDATORY_ON_CREATE | CREATE_AND_SET
      */
     SAI_MACSEC_SC_ATTR_MACSEC_CIPHER_SUITE,
 
@@ -657,7 +651,7 @@ typedef enum _sai_macsec_sc_attr_t
      * @brief True means encryption is enabled.  False means encryption is disabled.
      *
      * @type bool
-     * @flags CREATE_ONLY
+     * @flags CREATE_AND_SET
      * @default true
      */
     SAI_MACSEC_SC_ATTR_ENCRYPTION_ENABLE,
@@ -728,24 +722,6 @@ typedef enum _sai_macsec_sa_attr_t
     SAI_MACSEC_SA_ATTR_AN,
 
     /**
-     * @brief True means encryption is enabled.  False means encryption is disabled.
-     *
-     * @type bool
-     * @flags CREATE_ONLY
-     * @default true
-     */
-    SAI_MACSEC_SA_ATTR_ENCRYPTION_ENABLE,
-
-    /**
-     * @brief True means 256-bit SAK (encryption key).  False means 128-bit key.
-     *
-     * @type bool
-     * @flags CREATE_ONLY
-     * @default true
-     */
-    SAI_MACSEC_SA_ATTR_SAK_256_BITS,
-
-    /**
      * @brief MACsec SAK (Secure Association Key) used for encryption/decryption.
      * Network Byte order. 128-bit SAK uses only Bytes 16..31.
      *
@@ -758,7 +734,7 @@ typedef enum _sai_macsec_sa_attr_t
      * @brief MACsec Salt used for encryption/decryption.
      * Network Byte order.
      *
-     * Valid when SAI_MACSEC_SC_ATTR_MACSEC_XPN64_ENABLE == true.
+     * Valid when SAI_MACSEC_SC_ATTR_CIPHER_SUITE == SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_128 or SAI_MACSEC_SC_ATTR_CIPHER_SUITE == SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_256.
      *
      * @type sai_macsec_salt_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
@@ -797,7 +773,7 @@ typedef enum _sai_macsec_sa_attr_t
 
     /**
      * @brief SSCI value for this Secure Association
-     * Used only if SAI_MACSEC_SC_ATTR_MACSEC_XPN64_ENABLE == true.
+     * Valid when SAI_MACSEC_SC_ATTR_CIPHER_SUITE == SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_128 or SAI_MACSEC_SC_ATTR_CIPHER_SUITE == SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_256.
      *
      * @type sai_uint32_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY


### PR DESCRIPTION
===================================================================================
This commit contains following non-backward compatible changes

1.            Replace attribute SAI_MACSEC_SC_ATTR_MACSEC_SSCI with SAI_MACSEC_SA_ATTR_MACSEC_SSCI.
Reason:
IEEE standards 802.1AE-2018 and 802.1X-2020 both state that SSCI is a property of the SA not the SC.  SSCI can only be assigned once the full Live Peer List has been exchanged via EAPOL between peers, which will occur after the KaY has already created the transmit SC for the actor.

    /**
     * @brief SSCI value for this Secure Association
     *
     * Valid when SAI_MACSEC_SC_ATTR_MACSEC_CIPHER_SUITE == SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_128 or SAI_MACSEC_SC_ATTR_MACSEC_CIPHER_SUITE == SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_256.
     *
     * @type sai_uint32_t
     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
     */
    SAI_MACSEC_SA_ATTR_MACSEC_SSCI,

2.            Replace attribute SAI_MACSEC_SA_ATTR_ENCRYPTION_ENABLE with SAI_MACSEC_SC_ATTR_ENCRYPTION_ENABLE
Reason:
As seen from both the open source KaY (wpa-supplicant) and SecY (Linux MACsec driver), the encryption attribute is typically an attribute of the SC, not the SA.  This alignment can be retained by shifting the SAI MACsec definition of the encryption attribute from the SA to the SC.  This should allow for a cleaner, more direct translation between the SAI MACsec layer and the underlying platform driver.

    /**
     * @brief True means encryption is enabled.  False means encryption is disabled.
     *
     * @type bool
     * @flags CREATE_AND_SET
     * @default true
     */
    SAI_MACSEC_SC_ATTR_ENCRYPTION_ENABLE,

3.            Replace attribute SAI_MACSEC_SC_ATTR_MACSEC_XPN64_ENABLE and SAI_MACSEC_SA_ATTR_SAK_256_BITS with SAI_MACSEC_SC_ATTR_MACSEC_CIPHER_SUITE
Reason:
As seen from both the open source KaY (wpa-supplicant) and SecY (Linux MACsec driver), the MACsec cipher suite is typically a single attribute of the SC.  This alignment can be retained by combining the two properties of the MACsec cipher suite (SAK length and XPN enable) of the SAI MACsec definition into a single attribute of the SC.  This should allow for a cleaner, more direct translation between the SAI MACsec layer and the underlying platform driver. 

    /**
     * @brief Cipher suite for this Secure Channel.
     *
     * @type sai_macsec_cipher_suite_t
     * @flags MANDATORY_ON_CREATE | CREATE_AND_SET
     */
    SAI_MACSEC_SC_ATTR_MACSEC_CIPHER_SUITE,
===================================================================================
