### PR TITLE
Add label attribute for LAG and virtual router

### DIFF
--- a/inc/sailag.h
+++ b/inc/sailag.h
@@ -168,13 +168,13 @@ typedef enum _sai_lag_attr_t
     SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID,
 
     /**
-     * @brief Anchor attribute used to unique identify empty LAG.
+     * @brief Label attribute used to unique identify empty LAG.
      *
      * @type char
      * @flags CREATE_AND_SET
      * @default ""
      */
-    SAI_LAG_ATTR_ANCHOR,
+    SAI_LAG_ATTR_LABEL,
 
     /**
      * @brief End of attributes

--- a/inc/sailag.h
+++ b/inc/sailag.h
@@ -170,9 +170,9 @@ typedef enum _sai_lag_attr_t
     /**
      * @brief Anchor attribute used to unique identify empty LAG.
      *
-     * @type sai_uint64_t
-     * @flags CREATE_ONLY
-     * @default 0
+     * @type char
+     * @flags CREATE_AND_SET
+     * @default ""
      */
     SAI_LAG_ATTR_ANCHOR,
 

--- a/inc/sailag.h
+++ b/inc/sailag.h
@@ -168,6 +168,15 @@ typedef enum _sai_lag_attr_t
     SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID,
 
     /**
+     * @brief Anchor attribute used to unique identify empty LAG.
+     *
+     * @type sai_uint64_t
+     * @flags CREATE_ONLY
+     * @default 0
+     */
+    SAI_LAG_ATTR_ANCHOR,
+
+    /**
      * @brief End of attributes
      */
     SAI_LAG_ATTR_END,

--- a/inc/saivirtualrouter.h
+++ b/inc/saivirtualrouter.h
@@ -107,13 +107,13 @@ typedef enum _sai_virtual_router_attr_t
     SAI_VIRTUAL_ROUTER_ATTR_UNKNOWN_L3_MULTICAST_PACKET_ACTION,
 
     /**
-     * @brief Anchor attribute used to unique identify empty VR.
+     * @brief Label attribute used to unique identify empty VR.
      *
      * @type char
      * @flags CREATE_AND_SET
      * @default ""
      */
-    SAI_VIRTUAL_ROUTER_ATTR_ANCHOR,
+    SAI_VIRTUAL_ROUTER_ATTR_LABEL,
 
     /**
      * @brief End of attributes

--- a/inc/saivirtualrouter.h
+++ b/inc/saivirtualrouter.h
@@ -109,9 +109,9 @@ typedef enum _sai_virtual_router_attr_t
     /**
      * @brief Anchor attribute used to unique identify empty VR.
      *
-     * @type sai_uint64_t
-     * @flags CREATE_ONLY
-     * @default 0
+     * @type char
+     * @flags CREATE_AND_SET
+     * @default ""
      */
     SAI_VIRTUAL_ROUTER_ATTR_ANCHOR,
 

--- a/inc/saivirtualrouter.h
+++ b/inc/saivirtualrouter.h
@@ -107,6 +107,15 @@ typedef enum _sai_virtual_router_attr_t
     SAI_VIRTUAL_ROUTER_ATTR_UNKNOWN_L3_MULTICAST_PACKET_ACTION,
 
     /**
+     * @brief Anchor attribute used to unique identify empty VR.
+     *
+     * @type sai_uint64_t
+     * @flags CREATE_ONLY
+     * @default 0
+     */
+    SAI_VIRTUAL_ROUTER_ATTR_ANCHOR,
+
+    /**
      * @brief End of attributes
      */
     SAI_VIRTUAL_ROUTER_ATTR_END,


### PR DESCRIPTION
Since LAG and virtual router can be created without any unique mandatory attributes, anchor attribute can be used to uniquely identify specified objects. This will be very useful in SONiC warm boot scenario, for example to identify 2 empty LAGs which are present on the device after reboot.

This attribute doesn't correspond to any internal SAI vendor device resources, and at this point it don't need to be implemented by any vendor, it implementation at create function internals **CAN** be skipped without posting error. This attribute is considered as user data attached to specific object.  
If vendor wants to support this attribute it should also be persistent over warm boot scenario

**Cons**: extra attribute, that has no actual resource meaning and it would need to be added to objects that need to be uniquely identified on user side

**Pros**: convenient for SONiC, since metadata for all attributes is auto generated, and it will make very easy to to use existing attribute, instead of making convoluted way to pass extra information from sairedis/syncd path (this is because of current SONiC architecture design in sairedis/syncd model)

Related to: 
https://github.com/opencomputeproject/SAI/pull/1080
https://github.com/opencomputeproject/SAI/pull/1132