### PR TITLE
Tunnel loopback packet action as resource

### DIFF
--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -649,6 +649,7 @@ typedef enum _sai_tunnel_attr_t
      * @type sai_packet_action_t
      * @flags CREATE_AND_SET
      * @default SAI_PACKET_ACTION_FORWARD
+     * @isresourcetype true
      */
     SAI_TUNNEL_ATTR_LOOPBACK_PACKET_ACTION,
 


### PR DESCRIPTION
SAI_TUNNEL_ATTR_LOOPBACK_PACKET_ACTION is marked as resource and can be queried using the sai_object_type_get_availability API.
Example
sai_attribute_t *attr;
sai_status_t status;
uint64_t count;
 
attr[0].id = SAI_TUNNEL_ATTR_TYPE;
attr[0].value.s32 = SAI_TUNNEL_TYPE_VXLAN;
 
attr[1].id = SAI_TUNNEL_ATTR_LOOPBACK_PACKET_ACTION;
attr[1].value.s32 = SAI_PACKET_ACTION_DROP;
 
status = sai_object_type_get_availability(g_switch_id, SAI_OBJECT_TYPE_TUNNEL, 2, &attr, &count);
 
This API will return number of vxlan tunnels which can further with packet action as drop.
SONiC when invokes this API with out any tunnels configured
SAI will return 4
SONiC will configure 1 tunnel with packet action as drop and call the query API.
SAI will return 3 and so forth