### PR TITLE
Separate XPN configuration attribute from read-only attribute

### DIFF
--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -751,14 +751,14 @@ typedef enum _sai_macsec_sa_attr_t
     SAI_MACSEC_SA_ATTR_AUTH_KEY,
 
     /**
-     * @brief MACsec egress packet number (PN/XPN).  At most 1 less than the next PN/XPN.
+     * @brief Configured value of next MACsec egress packet number (PN/XPN).
      *
      * @type sai_uint64_t
      * @flags CREATE_AND_SET
      * @default 0
      * @validonly SAI_MACSEC_SA_ATTR_MACSEC_DIRECTION == SAI_MACSEC_DIRECTION_EGRESS
      */
-    SAI_MACSEC_SA_ATTR_INITIAL_EGRESS_XPN,
+    SAI_MACSEC_SA_ATTR_CONFIGURED_EGRESS_XPN,
 
     /**
      * @brief MACsec current packet number (PN/XPN). For ingress, largest

--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -118,12 +118,36 @@ typedef enum _sai_macsec_attr_t
     SAI_MACSEC_ATTR_SCI_IN_INGRESS_MACSEC_ACL,
 
     /**
-     * @brief List of supported cipher-suites
+     * @brief Indicates if 32-bit Packer Number (PN) is supported.
      *
-     * @type sai_s32_list_t sai_macsec_cipher_suite_t
+     * @type bool
      * @flags READ_ONLY
      */
-    SAI_MACSEC_ATTR_SUPPORTED_CIPHER_SUITE_LIST,
+    SAI_MACSEC_ATTR_PN_32BIT_SUPPORTED,
+
+    /**
+     * @brief Indicates if 64-bit Extended Packer Number (PN) is supported.
+     *
+     * @type bool
+     * @flags READ_ONLY
+     */
+    SAI_MACSEC_ATTR_XPN_64BIT_SUPPORTED,
+
+    /**
+     * @brief Indicates if GCM-AES128 cipher-suite is supported.
+     *
+     * @type bool
+     * @flags READ_ONLY
+     */
+    SAI_MACSEC_ATTR_GCM_AES128_SUPPORTED,
+
+    /**
+     * @brief Indicates if GCM-AES256 cipher-suite is supported.
+     *
+     * @type bool
+     * @flags READ_ONLY
+     */
+    SAI_MACSEC_ATTR_GCM_AES256_SUPPORTED,
 
     /**
      * @brief List of supported SecTAG offset values for both ingress parsing
@@ -737,16 +761,16 @@ typedef enum _sai_macsec_sa_attr_t
     SAI_MACSEC_SA_ATTR_INITIAL_EGRESS_XPN,
 
     /**
-     * @brief MACsec packet number (PN/XPN). For ingress, largest received
-     * packet number. For egress, 1 less than the next packet number.
+     * @brief MACsec current packet number (PN/XPN). For ingress, largest
+     * received packet number. For egress, 1 less than the next packet number.
      *
      * @type sai_uint64_t
      * @flags READ_ONLY
      */
-    SAI_MACSEC_SA_ATTR_XPN,
+    SAI_MACSEC_SA_ATTR_CURRENT_XPN,
 
     /**
-     * @brief Minimum value of ingress MACsec packet number (PN/XPN).
+     * @brief Configured minimum acceptable ingress MACsec packet number (PN/XPN).
      * Updated by value from MACsec peer by Key Agreement protocol.
      *
      * @type sai_uint64_t
@@ -754,7 +778,7 @@ typedef enum _sai_macsec_sa_attr_t
      * @default 1
      * @validonly SAI_MACSEC_SA_ATTR_MACSEC_DIRECTION == SAI_MACSEC_DIRECTION_INGRESS
      */
-    SAI_MACSEC_SA_ATTR_MINIMUM_XPN,
+    SAI_MACSEC_SA_ATTR_MINIMUM_INGRESS_XPN,
 
     /**
      * @brief SSCI value for this Secure Association

--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -769,6 +769,9 @@ typedef enum _sai_macsec_sa_attr_t
      */
     SAI_MACSEC_SA_ATTR_CURRENT_XPN,
 
+    /** @ignore - for backward compatibility */
+    SAI_MACSEC_SA_ATTR_XPN = SAI_MACSEC_SA_ATTR_CURRENT_XPN,
+
     /**
      * @brief Configured minimum acceptable ingress MACsec packet number (PN/XPN).
      * Updated by value from MACsec peer by Key Agreement protocol.
@@ -779,6 +782,9 @@ typedef enum _sai_macsec_sa_attr_t
      * @validonly SAI_MACSEC_SA_ATTR_MACSEC_DIRECTION == SAI_MACSEC_DIRECTION_INGRESS
      */
     SAI_MACSEC_SA_ATTR_MINIMUM_INGRESS_XPN,
+
+    /** @ignore - for backward compatibility */
+    SAI_MACSEC_SA_ATTR_MINIMUM_XPN = SAI_MACSEC_SA_ATTR_MINIMUM_INGRESS_XPN,
 
     /**
      * @brief SSCI value for this Secure Association

--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -118,36 +118,12 @@ typedef enum _sai_macsec_attr_t
     SAI_MACSEC_ATTR_SCI_IN_INGRESS_MACSEC_ACL,
 
     /**
-     * @brief Indicates if 32-bit Packer Number (PN) is supported.
+     * @brief List of supported cipher-suites
      *
-     * @type bool
+     * @type sai_s32_list_t sai_macsec_cipher_suite_t
      * @flags READ_ONLY
      */
-    SAI_MACSEC_ATTR_PN_32BIT_SUPPORTED,
-
-    /**
-     * @brief Indicates if 64-bit Extended Packer Number (PN) is supported.
-     *
-     * @type bool
-     * @flags READ_ONLY
-     */
-    SAI_MACSEC_ATTR_XPN_64BIT_SUPPORTED,
-
-    /**
-     * @brief Indicates if GCM-AES128 cipher-suite is supported.
-     *
-     * @type bool
-     * @flags READ_ONLY
-     */
-    SAI_MACSEC_ATTR_GCM_AES128_SUPPORTED,
-
-    /**
-     * @brief Indicates if GCM-AES256 cipher-suite is supported.
-     *
-     * @type bool
-     * @flags READ_ONLY
-     */
-    SAI_MACSEC_ATTR_GCM_AES256_SUPPORTED,
+    SAI_MACSEC_ATTR_SUPPORTED_CIPHER_SUITE_LIST,
 
     /**
      * @brief List of supported SecTAG offset values for both ingress parsing
@@ -757,6 +733,15 @@ typedef enum _sai_macsec_sa_attr_t
      * @flags CREATE_AND_SET
      * @default 0
      * @validonly SAI_MACSEC_SA_ATTR_MACSEC_DIRECTION == SAI_MACSEC_DIRECTION_EGRESS
+     */
+    SAI_MACSEC_SA_ATTR_INITIAL_EGRESS_XPN,
+
+    /**
+     * @brief MACsec packet number (PN/XPN). For ingress, largest received
+     * packet number. For egress, 1 less than the next packet number.
+     *
+     * @type sai_uint64_t
+     * @flags READ_ONLY
      */
     SAI_MACSEC_SA_ATTR_XPN,
 


### PR DESCRIPTION
Added a new read-only current XPN (available for both ingress and egress) and separate from the egress attribute for setting initial XPN value.
Renamed ingress set-and-clear attribute MINIMUM_XPN to MINIMUM_INGRESS_XPN.
