### PR TITLE
Support for ACL extensions in metadata

### DIFF
--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -435,6 +435,11 @@ bool sai_metadata_is_acl_field_or_action(
         {
             return true;
         }
+
+        if (metadata->isextensionattr == true)
+        {
+            return true;
+        }
     }
 
     return false;
@@ -1856,9 +1861,10 @@ void check_attr_acl_fields(
         case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_ID:
         case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_LIST:
 
-            if (md->objecttype != SAI_OBJECT_TYPE_ACL_ENTRY ||
-                    md->attrid < SAI_ACL_ENTRY_ATTR_ACTION_START ||
-                    md->attrid > SAI_ACL_ENTRY_ATTR_ACTION_END)
+            if (md->objecttype != SAI_OBJECT_TYPE_ACL_ENTRY  ||
+                    ((md->isextensionattr == false) &&
+                    (md->attrid < SAI_ACL_ENTRY_ATTR_ACTION_START  ||
+                    md->attrid > SAI_ACL_ENTRY_ATTR_ACTION_END)))
             {
                 META_MD_ASSERT_FAIL(md, "acl action may only be set on acl action");
             }
@@ -4078,7 +4084,7 @@ void check_acl_entry_actions()
             break;
         }
 
-        if (meta->attrid > SAI_ACL_ENTRY_ATTR_ACTION_END)
+        if ((meta->isextensionattr == false) && (meta->attrid > SAI_ACL_ENTRY_ATTR_ACTION_END))
         {
             break;
         }

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -1861,10 +1861,10 @@ void check_attr_acl_fields(
         case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_ID:
         case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_LIST:
 
-			if (md->objecttype == SAI_OBJECT_TYPE_ACL_ENTRY && md->isextensionattr)
-			{
-				break;
-			}
+            if (md->objecttype == SAI_OBJECT_TYPE_ACL_ENTRY && md->isextensionattr)
+            {
+                break;
+            }
 
             if (md->objecttype != SAI_OBJECT_TYPE_ACL_ENTRY  ||
                     md->attrid < SAI_ACL_ENTRY_ATTR_ACTION_START  ||

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -1861,8 +1861,7 @@ void check_attr_acl_fields(
         case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_ID:
         case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_LIST:
 
-			if (md->objecttype == SAI_OBJECT_TYPE_ACL_ENTRY &&
-					md->isextensionattr) 
+			if (md->objecttype == SAI_OBJECT_TYPE_ACL_ENTRY && md->isextensionattr)
 			{
 				break;
 			}

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -436,7 +436,7 @@ bool sai_metadata_is_acl_field_or_action(
             return true;
         }
 
-        if (metadata->isextensionattr == true)
+        if (metadata->isextensionattr)
         {
             return true;
         }
@@ -1861,10 +1861,15 @@ void check_attr_acl_fields(
         case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_ID:
         case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_LIST:
 
+			if (md->objecttype == SAI_OBJECT_TYPE_ACL_ENTRY &&
+					md->isextensionattr) 
+			{
+				break;
+			}
+
             if (md->objecttype != SAI_OBJECT_TYPE_ACL_ENTRY  ||
-                    ((md->isextensionattr == false) &&
-                    (md->attrid < SAI_ACL_ENTRY_ATTR_ACTION_START  ||
-                    md->attrid > SAI_ACL_ENTRY_ATTR_ACTION_END)))
+                    md->attrid < SAI_ACL_ENTRY_ATTR_ACTION_START  ||
+                    md->attrid > SAI_ACL_ENTRY_ATTR_ACTION_END)
             {
                 META_MD_ASSERT_FAIL(md, "acl action may only be set on acl action");
             }


### PR DESCRIPTION
SAI sanitychecker doesn't expect any extensions to be developed for ACL attributes. This PR aims to add support by adding checks whether the 'under-check-attribute' is an extension attribute. The value range for an attribute between SAI_ACL_ENTRY_ATTR_ACTION_START and SAI_ACL_ENTRY_ATTR_ACTION_END is valid only for non-extensions. The extensions are to have attributes beyond SAI_ACL_ENTRY_ATTR_ACTION_END. This PR allows the range check to be conditional for extension attributes.

If there is a better way to enhance the metachecker, this PR can be changed accordingly.

Signed-off-by: bandaru.viswanath@broadcom.com