### PR TITLE
Do not call sai_metadata_sai get APIs if they are not allocated

### DIFF
--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -2684,10 +2684,18 @@ sub ProcessGet
     }
     elsif (not defined $struct)
     {
+        WriteSource "if (!sai_metadata_sai_${api}_api || !sai_metadata_sai_${api}_api->get_${small}_attribute)";
+        WriteSource "{";
+        WriteSource "return SAI_STATUS_NOT_SUPPORTED;";
+        WriteSource "}";
         WriteSource "return sai_metadata_sai_${api}_api->get_${small}_attribute(meta_key->objectkey.key.object_id, attr_count, attr_list);";
     }
     else
     {
+        WriteSource "if (!sai_metadata_sai_${api}_api || !sai_metadata_sai_${api}_api->get_${small}_attribute)";
+        WriteSource "{";
+        WriteSource "return SAI_STATUS_NOT_SUPPORTED;";
+        WriteSource "}";
         WriteSource "return sai_metadata_sai_${api}_api->get_${small}_attribute(&meta_key->objectkey.key.$small, attr_count, attr_list);";
     }
 


### PR DESCRIPTION
New asic - fabric - doesn't have attributes like VLAN, HOSTIF... So Broadcom SAI will not allocate these APIs or function pointers of those API objects are not allocated. This causes  attempts that try to get/read these attributes to fail. So sai discovery for fabric will crash.

Solution: Modify `parse.pl` to verify sai_metadata_sai if they are allocated or not before trying to  attributes.

This PR will change only for getting attributes. Create, Set, Remove may also need to be changed, but this is out of the scope of this PR.

Signed-off-by: ngocdo <ngocdo@arista.com>