### PR TITLE
New attribute to start fw broadcast

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -2266,6 +2266,18 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_TUNNEL_LOOPBACK_PACKET_ACTION,
 
     /**
+     * @brief Start Firmware Broadcast
+     *
+     * Configure PHY to start Firmware Broadcast.
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     * @validonly SAI_SWITCH_ATTR_FIRMWARE_DOWNLOAD_BROADCAST == true
+     */
+    SAI_SWITCH_ATTR_FIRMWARE_BROADCAST_START,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,


### PR DESCRIPTION
A new attribute is added to start the FW broadcast. This is necessary to start FW broadcast on all PHY chips