### PR TITLE
Add switch attributes for hash offset configuration.

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -1169,7 +1169,12 @@ typedef enum _sai_switch_attr_t
     /**
      * @brief SAI ECMP default hash offset
      *
-     * @type sai_uint32_t
+     * When set, the output of the ECMP hash calculation will be shifted or
+     * rotated by the specified number of bits. The direction and exact behavior
+     * (shift vs offset) as well as the maximum rotation supported may be
+     * ASIC-specific.
+     *
+     * @type sai_uint8_t
      * @flags CREATE_AND_SET
      * @default 0
      */
@@ -1243,7 +1248,12 @@ typedef enum _sai_switch_attr_t
     /**
      * @brief SAI LAG default hash offset
      *
-     * @type sai_uint32_t
+     * When set, the output of the LAG hash calculation will be shifted or
+     * rotated by the specified number of bits. The direction and exact behavior
+     * (shift vs offset) as well as the maximum rotation supported may be
+     * ASIC-specific.
+     *
+     * @type sai_uint8_t
      * @flags CREATE_AND_SET
      * @default 0
      */

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -1169,10 +1169,8 @@ typedef enum _sai_switch_attr_t
     /**
      * @brief SAI ECMP default hash offset
      *
-     * When set, the output of the ECMP hash calculation will be shifted or
-     * rotated by the specified number of bits. The direction and exact behavior
-     * (shift vs offset) as well as the maximum rotation supported may be
-     * ASIC-specific.
+     * When set, the output of the ECMP hash calculation will be rotated right
+     * by the specified number of bits.
      *
      * @type sai_uint8_t
      * @flags CREATE_AND_SET
@@ -1248,10 +1246,8 @@ typedef enum _sai_switch_attr_t
     /**
      * @brief SAI LAG default hash offset
      *
-     * When set, the output of the LAG hash calculation will be shifted or
-     * rotated by the specified number of bits. The direction and exact behavior
-     * (shift vs offset) as well as the maximum rotation supported may be
-     * ASIC-specific.
+     * When set, the output of the LAG hash calculation will be rotated right
+     * by the specified number of bits.
      *
      * @type sai_uint8_t
      * @flags CREATE_AND_SET

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -1167,6 +1167,15 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_SEED,
 
     /**
+     * @brief SAI ECMP default hash offset
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_OFFSET,
+
+    /**
      * @brief SAI ECMP default symmetric hash
      *
      * When set, the hash calculation will result in the same value as when the
@@ -1230,6 +1239,15 @@ typedef enum _sai_switch_attr_t
      * @default 0
      */
     SAI_SWITCH_ATTR_LAG_DEFAULT_HASH_SEED,
+
+    /**
+     * @brief SAI LAG default hash offset
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_SWITCH_ATTR_LAG_DEFAULT_HASH_OFFSET,
 
     /**
      * @brief SAI LAG default symmetric hash


### PR DESCRIPTION
Add ability to specify the hash offset (rotation) in addition to the
hash seed.

Signed-off-by: Mike Beresford <mberes@google.com>