### PR TITLE
Add attribute to query available packet DMA pool size

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -2447,6 +2447,16 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_TUNNEL_OBJECTS_LIST,
 
     /**
+     * @brief The size of the available packet DMA pool memory in bytes
+     * This can be used in conjunction with total packet DMA pool
+     * size to account/debug % of memory available.
+     *
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_SWITCH_ATTR_PACKET_AVAILABLE_DMA_MEMORY_POOL_SIZE,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,


### PR DESCRIPTION
Summary:
Add more attribute for querying available packet DMA
pool size. This can be used for accounting for and
debugging allocations from packet DMA pool.

Test Plan: make in meta dir

Reviewers:

Subscribers:

Tasks:

Tags:
Signed-off-by: Jasmeet Bagga <jasmeetbagga@fb.com>