### PR TITLE
saineighbor.h: Updated SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX and deprecated SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX

### DIFF
--- a/inc/saineighbor.h
+++ b/inc/saineighbor.h
@@ -123,12 +123,12 @@ typedef enum _sai_neighbor_entry_attr_t
      *
      * @type sai_uint32_t
      * @flags CREATE_AND_SET
-     * @default 0
+     * @default internal
      */
     SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX,
 
     /**
-     * @brief Encapsulation index is imposed
+     * @brief Encapsulation index is imposed. This is deprecated
      *
      * This is a flag which states that the encap index was imposed. On create and set
      * the SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX must be present.
@@ -136,6 +136,7 @@ typedef enum _sai_neighbor_entry_attr_t
      * @type bool
      * @flags CREATE_AND_SET
      * @default false
+     * @deprecated true
      */
     SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX,
 

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -1175,10 +1175,12 @@ void check_attr_default_value_type(
 
         case SAI_DEFAULT_VALUE_TYPE_SWITCH_INTERNAL:
 
-            if ((md->objecttype == SAI_OBJECT_TYPE_PORT) || (md->objecttype == SAI_OBJECT_TYPE_PORT_SERDES))
+            if ((md->objecttype == SAI_OBJECT_TYPE_PORT) ||
+                (md->objecttype == SAI_OBJECT_TYPE_PORT_SERDES) ||
+                (md->objecttype == SAI_OBJECT_TYPE_NEIGHBOR_ENTRY))
             {
                 /*
-                 * Allow PORT attribute list's to be set to internal.
+                 * Allow PORT, NEIGHBOR attribute list's to be set to internal.
                  */
                 break;
             }


### PR DESCRIPTION

Fixes https://github.com/opencomputeproject/SAI/issues/1165

Signed-off-by: SarathBug <sarath.gadagottu@broadcom.com>