### PR TITLE
Fix error when compiling Broadcom SAI with v1.8.0

### DIFF
--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -373,8 +373,8 @@ void check_attr_by_object_type()
 
             META_ASSERT_TRUE(current == i, "object type must be equal on object type list");
             /* For Switch Attribute we have crossed > 200 with Vendor extention for SAIv1.8.0
-              so commenting it for now to avoid error when doing make */
-            /* META_ASSERT_TRUE(index < 200, "object defines > 200 attributes, metadata bug?"); */
+               so increasing threshold  */
+            META_ASSERT_TRUE(index < 300, "object defines > 300 attributes, metadata bug?");
             META_ASSERT_TRUE(current > SAI_OBJECT_TYPE_NULL, "object type must be > NULL");
             META_ASSERT_TRUE(current < SAI_OBJECT_TYPE_EXTENSIONS_MAX, "object type must be < MAX");
 

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -372,8 +372,8 @@ void check_attr_by_object_type()
             sai_object_type_t current = ot[index]->objecttype;
 
             META_ASSERT_TRUE(current == i, "object type must be equal on object type list");
-            // For Switch Attribute we have crossed > 200 with Vendor extention for SAIv1.8.0
-            // so commenting it for now to avoid error when doing make
+            /* For Switch Attribute we have crossed > 200 with Vendor extention for SAIv1.8.0
+              so commenting it for now to avoid error when doing make */
             /* META_ASSERT_TRUE(index < 200, "object defines > 200 attributes, metadata bug?"); */
             META_ASSERT_TRUE(current > SAI_OBJECT_TYPE_NULL, "object type must be > NULL");
             META_ASSERT_TRUE(current < SAI_OBJECT_TYPE_EXTENSIONS_MAX, "object type must be < MAX");

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -372,7 +372,9 @@ void check_attr_by_object_type()
             sai_object_type_t current = ot[index]->objecttype;
 
             META_ASSERT_TRUE(current == i, "object type must be equal on object type list");
-            META_ASSERT_TRUE(index < 200, "object defines > 200 attributes, metadata bug?");
+            // For Switch Attribute we have crossed > 200 with Vendor extention for SAIv1.8.0
+            // so commenting it for now to avoid error when doing make
+            /* META_ASSERT_TRUE(index < 200, "object defines > 200 attributes, metadata bug?"); */
             META_ASSERT_TRUE(current > SAI_OBJECT_TYPE_NULL, "object type must be > NULL");
             META_ASSERT_TRUE(current < SAI_OBJECT_TYPE_EXTENSIONS_MAX, "object type must be < MAX");
 


### PR DESCRIPTION
What I did:

With SAI v1.8.0 sanity check for having max attribute for any object to be < 200 is not valid for switch attribute.
Commenting out check as of  now.

Why I did:

Fix Broadcom build with SAI v1.8.0

How I verify:
After fix `make` is fine.