### PR TITLE
Change SerDes attributes from unsigned to signed list.

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -2745,11 +2745,11 @@ typedef enum _sai_port_serdes_attr_t
     /**
      * @brief Port serdes control pre-emphasis
      *
-     * List of port serdes pre-emphasis values. The values are of type sai_u32_list_t
+     * List of port serdes pre-emphasis values. The values are of type sai_s32_list_t
      * where the count is number lanes in a port and the list specifies list of values
      * to be applied to each lane.
      *
-     * @type sai_u32_list_t
+     * @type sai_s32_list_t
      * @flags CREATE_ONLY
      * @default internal
      */
@@ -2758,11 +2758,11 @@ typedef enum _sai_port_serdes_attr_t
     /**
      * @brief Port serdes control idriver
      *
-     * List of port serdes idriver values. The values are of type sai_u32_list_t
+     * List of port serdes idriver values. The values are of type sai_s32_list_t
      * where the count is number lanes in a port and the list specifies list of values
      * to be applied to each lane.
      *
-     * @type sai_u32_list_t
+     * @type sai_s32_list_t
      * @flags CREATE_ONLY
      * @default internal
      */
@@ -2771,11 +2771,11 @@ typedef enum _sai_port_serdes_attr_t
     /**
      * @brief Port serdes control pre-emphasis
      *
-     * List of port serdes ipredriver values. The values are of type sai_u32_list_t
+     * List of port serdes ipredriver values. The values are of type sai_s32_list_t
      * where the count is number lanes in a port and the list specifies list of values
      * to be applied to each lane.
      *
-     * @type sai_u32_list_t
+     * @type sai_s32_list_t
      * @flags CREATE_ONLY
      * @default internal
      */
@@ -2785,10 +2785,10 @@ typedef enum _sai_port_serdes_attr_t
      * @brief Port serdes control TX FIR PRE1 filter
      *
      * List of port serdes TX fir precursor1 tap-filter values.
-     * The values are of type sai_u32_list_t where the count is number lanes in
+     * The values are of type sai_s32_list_t where the count is number lanes in
      * a port and the list specifies list of values to be applied to each lane.
      *
-     * @type sai_u32_list_t
+     * @type sai_s32_list_t
      * @flags CREATE_ONLY
      * @default internal
      */
@@ -2798,10 +2798,10 @@ typedef enum _sai_port_serdes_attr_t
      * @brief Port serdes control TX FIR PRE2 filter
      *
      * List of port serdes TX fir precursor2 tap-filter values.
-     * The values are of type sai_u32_list_t where the count is number lanes in
+     * The values are of type sai_s32_list_t where the count is number lanes in
      * a port and the list specifies list of values to be applied to each lane.
      *
-     * @type sai_u32_list_t
+     * @type sai_s32_list_t
      * @flags CREATE_ONLY
      * @default internal
      */
@@ -2811,10 +2811,10 @@ typedef enum _sai_port_serdes_attr_t
      * @brief Port serdes control TX FIR PRE3 filter
      *
      * List of port serdes TX fir precursor3 tap-filter values.
-     * The values are of type sai_u32_list_t where the count is number lanes in
+     * The values are of type sai_s32_list_t where the count is number lanes in
      * a port and the list specifies list of values to be applied to each lane.
      *
-     * @type sai_u32_list_t
+     * @type sai_s32_list_t
      * @flags CREATE_ONLY
      * @default internal
      */
@@ -2824,10 +2824,10 @@ typedef enum _sai_port_serdes_attr_t
      * @brief Port serdes control TX FIR MAIN filter
      *
      * List of port serdes TX fir maincursor tap-filter values.
-     * The values are of type sai_u32_list_t where the count is number lanes in
+     * The values are of type sai_s32_list_t where the count is number lanes in
      * a port and the list specifies list of values to be applied to each lane.
      *
-     * @type sai_u32_list_t
+     * @type sai_s32_list_t
      * @flags CREATE_ONLY
      * @default internal
      */
@@ -2837,10 +2837,10 @@ typedef enum _sai_port_serdes_attr_t
      * @brief Port serdes control TX FIR POST1 filter
      *
      * List of port serdes TX fir postcursor1 tap-filter values.
-     * The values are of type sai_u32_list_t where the count is number lanes in
+     * The values are of type sai_s32_list_t where the count is number lanes in
      * a port and the list specifies list of values to be applied to each lane.
      *
-     * @type sai_u32_list_t
+     * @type sai_s32_list_t
      * @flags CREATE_ONLY
      * @default internal
      */
@@ -2850,10 +2850,10 @@ typedef enum _sai_port_serdes_attr_t
      * @brief Port serdes control TX FIR POST2 filter
      *
      * List of port serdes TX fir postcursor2 tap-filter values.
-     * The values are of type sai_u32_list_t where the count is number lanes in
+     * The values are of type sai_s32_list_t where the count is number lanes in
      * a port and the list specifies list of values to be applied to each lane.
      *
-     * @type sai_u32_list_t
+     * @type sai_s32_list_t
      * @flags CREATE_ONLY
      * @default internal
      */
@@ -2863,10 +2863,10 @@ typedef enum _sai_port_serdes_attr_t
      * @brief Port serdes control TX FIR POST3 filter
      *
      * List of port serdes TX fir postcursor3 tap-filter values.
-     * The values are of type sai_u32_list_t where the count is number lanes in
+     * The values are of type sai_s32_list_t where the count is number lanes in
      * a port and the list specifies list of values to be applied to each lane.
      *
-     * @type sai_u32_list_t
+     * @type sai_s32_list_t
      * @flags CREATE_ONLY
      * @default internal
      */
@@ -2876,10 +2876,10 @@ typedef enum _sai_port_serdes_attr_t
      * @brief Port serdes control TX FIR attenuation
      *
      * List of port serdes TX fir attn values.
-     * The values are of type sai_u32_list_t where the count is number lanes in
+     * The values are of type sai_s32_list_t where the count is number lanes in
      * a port and the list specifies list of values to be applied to each lane.
      *
-     * @type sai_u32_list_t
+     * @type sai_s32_list_t
      * @flags CREATE_ONLY
      * @default internal
      */


### PR DESCRIPTION
The SerDes attributes may be negative values, so change from
sai_u32_list_t to sai_s32_list_t.

There were several comments on https://github.com/opencomputeproject/SAI/pull/1002 relating to this which do not appear to have been resolved when the PR was merged.

Signed-off-by: Mike Beresford <mberes@google.com>