### PR TITLE
Add drop counter for mpls lookup miss

### DIFF
--- a/inc/saidebugcounter.h
+++ b/inc/saidebugcounter.h
@@ -243,9 +243,6 @@ typedef enum _sai_in_drop_reason_t
     /** IPv6 Routing table (LPM) unicast miss */
     SAI_IN_DROP_REASON_LPM6_MISS,
 
-    /** MPLS Routing table lookup miss */
-    SAI_IN_DROP_REASON_MPLS_MISS,
-
     /** Black hole route (discard by route entry) */
     SAI_IN_DROP_REASON_BLACKHOLE_ROUTE,
 
@@ -310,6 +307,9 @@ typedef enum _sai_in_drop_reason_t
 
     /** Packet is dropped due to FDB action discards or route discards (black hole route) */
     SAI_IN_DROP_REASON_FDB_AND_BLACKHOLE_DISCARDS,
+
+    /** MPLS Routing table lookup miss */
+    SAI_IN_DROP_REASON_MPLS_MISS,
 
     /** End of in drop reasons */
     SAI_IN_DROP_REASON_END,

--- a/inc/saidebugcounter.h
+++ b/inc/saidebugcounter.h
@@ -243,6 +243,9 @@ typedef enum _sai_in_drop_reason_t
     /** IPv6 Routing table (LPM) unicast miss */
     SAI_IN_DROP_REASON_LPM6_MISS,
 
+    /** MPLS Routing table lookup miss */
+    SAI_IN_DROP_REASON_MPLS_MISS,
+
     /** Black hole route (discard by route entry) */
     SAI_IN_DROP_REASON_BLACKHOLE_ROUTE,
 


### PR DESCRIPTION
Signed-off-by: Midhun Somasundaran <msomasundaran@fb.com>

Adding a drop counter for MPLS lookup miss similar to existing counters for IPv4 and Ipv6