### PR TITLE
[saiport.h] Add 'internal' FEC mode and ability to query operational mode

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -1709,7 +1709,7 @@ typedef enum _sai_port_attr_t
      * it was set explicitly or determined internally. Thus
      * it should never return SAI_PORT_FEC_MODE_INTERNAL.
      *
-     * @type sai_s32_list_t sai_port_fec_mode_t
+     * @type sai_port_fec_mode_t
      * @flags READ_ONLY
      */
     SAI_PORT_ATTR_OPER_FEC_MODE,

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -176,6 +176,10 @@ typedef enum _sai_port_fec_mode_t
 
     /** Enable FC-FEC - 10G, 25G, 40G, 50G ports */
     SAI_PORT_FEC_MODE_FC,
+
+    /** FEC mode is chosen by driver/firmware, e.g., via auto-negotiation */
+    SAI_PORT_FEC_MODE_INTERNAL,
+
 } sai_port_fec_mode_t;
 
 /**
@@ -1697,6 +1701,18 @@ typedef enum _sai_port_attr_t
      * @objects SAI_OBJECT_TYPE_SYSTEM_PORT
      */
     SAI_PORT_ATTR_SYSTEM_PORT,
+
+    /**
+     * @brief Query the current operational FEC mode for the port
+     *
+     * Returns the FEC mode currently configured for the port, whether
+     * it was set explicitly or determined internally. Thus
+     * it should never return SAI_PORT_FEC_MODE_INTERNAL.
+     *
+     * @type sai_s32_list_t sai_port_fec_mode_t
+     * @flags READ_ONLY
+     */
+    SAI_PORT_ATTR_OPER_FEC_MODE,
 
     /**
      * @brief End of attributes


### PR DESCRIPTION
Add new FEC mode, `SAI_PORT_FEC_MODE_INTERNAL`, which allows the port to be configured without an explicit FEC mode, rather allowing the driver/firmware to determine the FEC mode (e.g., via autonegotiation).

With the addition of the\is new FEC mode attribute, we also need a way to query the current operational FEC mode for a port. This is accomplished by the addition of a new attribute, `SAI_PORT_ATTR_OPER_FEC_MODE`. This is expected to return the current operational FEC mode (i.e., `SAI_PORT_FEC_MODE_NONE`, `SAI_PORT_FEC_MODE_RS`, or `SAI_PORT_FEC_MODE_FC`). It should never return `SAI_PORT_FEC_MODE_INTERNAL`.