### PR TITLE
Update saistatus.h

### DIFF
--- a/inc/saistatus.h
+++ b/inc/saistatus.h
@@ -259,27 +259,27 @@
 /**
  * @brief Is invalid attribute helper
  */
-#define SAI_STATUS_IS_INVALID_ATTRIBUTE(x)      (((x) & (~0xFFFF)) == SAI_STATUS_INVALID_ATTRIBUTE_0)
+#define SAI_STATUS_IS_INVALID_ATTRIBUTE(x)      (((abs(x)) & (~0xFFFF)) == (abs(SAI_STATUS_INVALID_ATTRIBUTE_0)))
 
 /**
  * @brief Is invalid attribute value helper
  */
-#define SAI_STATUS_IS_INVALID_ATTR_VALUE(x)     (((x) & (~0xFFFF)) == SAI_STATUS_INVALID_ATTR_VALUE_0)
+#define SAI_STATUS_IS_INVALID_ATTR_VALUE(x)     (((abs(x)) & (~0xFFFF)) == (abs(SAI_STATUS_INVALID_ATTR_VALUE_0)))
 
 /**
  * @brief Is attribute not implemented helper
  */
-#define SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(x)   (((x) & (~0xFFFF)) == SAI_STATUS_ATTR_NOT_IMPLEMENTED_0)
+#define SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(x)   (((abs(x)) & (~0xFFFF)) == (abs(SAI_STATUS_ATTR_NOT_IMPLEMENTED_0)))
 
 /**
  * @brief Is unknown attribute helper
  */
-#define SAI_STATUS_IS_UNKNOWN_ATTRIBUTE(x)      (((x) & (~0xFFFF)) == SAI_STATUS_INVALID_ATTRIBUTE_0)
+#define SAI_STATUS_IS_UNKNOWN_ATTRIBUTE(x)      (((abs(x)) & (~0xFFFF)) == (abs(SAI_STATUS_INVALID_ATTRIBUTE_0)))
 
 /**
  * @brief Is attribute not supported helper
  */
-#define SAI_STATUS_IS_ATTR_NOT_SUPPORTED(x)     (((x) & (~0xFFFF)) == SAI_STATUS_ATTR_NOT_SUPPORTED_0)
+#define SAI_STATUS_IS_ATTR_NOT_SUPPORTED(x)     (((abs(x)) & (~0xFFFF)) == (abs(SAI_STATUS_ATTR_NOT_SUPPORTED_0)))
 
 /**
  * @}


### PR DESCRIPTION
These helper Macro's logic are not correct when _WIN32 is not #defined as is the case for all of our Sonic/BRCM based platforms.  Therefore all SAI_STATUS_XXX error codes are negative due to "#define SAI_STATUS_CODE(_S_)    (-(_S_))" operation.  This result in incorrect helper error range checking.  For example, SAI_STATUS_ATTR_NOT_IMPLEMENTED_0 is defined as value of -0x00030000L and SAI_STATUS_ATTR_NOT_IMPLEMENTED_MAX as -0x0003FFFFL.  Assume the SAI returns error code of SAI_STATUS_ATTR_NOT_IMPLEMENTED_1 which is -0x00030001L (where SAI code should return SAI_STATUS_ATTR_NOT_IMPLEMENTED_0 + SAI_STATUS_CODE(1)).  The old SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(-0x00030001L) macro would result in -0x00040000L == SAI_STATUS_ATTR_NOT_IMPLEMENTED_0 which is not true where SAI_STATUS_ATTR_NOT_IMPLEMENTED_0 is defined as -0x00030000L.  The new helper macro will correct this logic.  The new logic would work regardless #ifdef _WIN32 is defined or not.