### PR TITLE
Add support for programming My MAC table separately from RIF

### DIFF
--- a/inc/sai.h
+++ b/inc/sai.h
@@ -72,6 +72,7 @@
 #include "sainat.h"
 #include "saiisolationgroup.h"
 #include "saidebugcounter.h"
+#include "saimymac.h"
 
 /**
  * @defgroup SAI SAI - Entry point specific API definitions.
@@ -133,7 +134,8 @@ typedef enum _sai_api_t
     SAI_API_DEBUG_COUNTER    = 42, /**< sai_debug_counter_api_t */
     SAI_API_MACSEC           = 43, /**< sai_macsec_api_t */
     SAI_API_SYSTEM_PORT      = 44, /**< sai_system_port_api_t */
-    SAI_API_MAX              = 45, /**< total number of APIs */
+    SAI_API_MY_MAC           = 45, /**< sai_my_mac_api_t */
+    SAI_API_MAX              = 46, /**< total number of APIs */
 } sai_api_t;
 
 /**

--- a/inc/saimymac.h
+++ b/inc/saimymac.h
@@ -1,0 +1,347 @@
+/**
+ * Copyright (c) 2014 Microsoft Open Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ *    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ *    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ *
+ *    See the Apache Version 2.0 License for specific language governing
+ *    permissions and limitations under the License.
+ *
+ *    Microsoft would like to thank the following companies for their review and
+ *    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+ *    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+ *
+ * @file    saimymac.h
+ *
+ * @brief   This module defines SAI My MAC
+ */
+
+#if !defined (__SAIMYMAC_H_)
+#define __SAIMYMAC_H_
+
+#include <saitypes.h>
+
+/**
+ * @brief My MAC entry attribute IDs
+ */
+typedef enum _sai_my_mac_attr_t
+{
+    /**
+     * @brief Start of attributes
+     */
+    SAI_MY_MAC_ATTR_START,
+
+    /**
+     * @brief Priority
+     *
+     * Value must be in the range defined in
+     * \[#SAI_MY_MAC_TABLE_ATTR_MINIMUM_PRIORITY,
+     * #SAI_MY_MAC_TABLE_ATTR_MAXIMUM_PRIORITY\]
+     * (default = #SAI_MY_MAC_TABLE_ATTR_MINIMUM_PRIORITY)
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_MY_MAC_ATTR_PRIORITY = SAI_MY_MAC_ATTR_START,
+
+    /**
+     * @brief Object id of the My MAC table
+     *
+     * @type sai_object_id_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @objects SAI_OBJECT_TYPE_MY_MAC_TABLE
+     */
+    SAI_MY_MAC_ATTR_TABLE_ID,
+
+    /**
+     * @brief Associated Port, LAG object id,
+     * if not specified any port will match
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_ONLY
+     * @objects SAI_OBJECT_TYPE_PORT, SAI_OBJECT_TYPE_LAG
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_MY_MAC_ATTR_PORT_ID,
+
+    /**
+     * @brief Associated Vlan,
+     * if not specified any vlan will match
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_ONLY
+     * @objects SAI_OBJECT_TYPE_VLAN
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_MY_MAC_ATTR_VLAN_ID,
+
+    /**
+     * @brief MAC Address
+     *
+     * @type sai_mac_t
+     * @flags CREATE_AND_SET
+     * @default vendor
+     */
+    SAI_MY_MAC_ATTR_MAC_ADDRESS,
+
+    /**
+     * @brief MAC Address Mask
+     *
+     * @type sai_mac_t
+     * @flags CREATE_AND_SET
+     * @default vendor
+     */
+    SAI_MY_MAC_ATTR_MAC_ADDRESS_MASK,
+
+    /**
+     * @brief Admin V4 enable
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_MY_MAC_ATTR_V4_ENABLE,
+
+    /**
+     * @brief Admin V6 enable
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_MY_MAC_ATTR_V6_ENABLE,
+
+    /**
+     * @brief V4 mcast enable
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_MY_MAC_ATTR_V4_MCAST_ENABLE,
+
+    /**
+     * @brief V6 mcast enable
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_MY_MAC_ATTR_V6_MCAST_ENABLE,
+
+    /**
+     * @brief Admin MPLS state
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_MY_MAC_ATTR_MPLS_ENABLE,
+
+    /**
+     * @brief End of attributes
+     */
+    SAI_MY_MAC_ATTR_END,
+
+    /** Custom range base value */
+    SAI_MY_MAC_ATTR_CUSTOM_RANGE_START = 0x10000000,
+
+    /** End of custom range base */
+    SAI_MY_MAC_ATTR_CUSTOM_RANGE_END
+
+} sai_my_mac_attr_t;
+
+/**
+ * @brief Create My MAC entry.
+ *
+ * @param[out] my_mac_id My MAC id
+ * @param[in] switch_id Switch id
+ * @param[in] attr_count Number of attributes
+ * @param[in] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_create_my_mac_fn)(
+        _Out_ sai_object_id_t *my_mac_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list);
+
+/**
+ * @brief Remove My MAC entry
+ *
+ * @param[in] my_mac_id My MAC Id
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_remove_my_mac_fn)(
+        _In_ sai_object_id_t my_mac_id);
+
+/**
+ * @brief Set My MAC entry attribute
+ *
+ * @param[in] my_mac_id My MAC id
+ * @param[in] attr Attribute
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_set_my_mac_attribute_fn)(
+        _In_ sai_object_id_t my_mac_id,
+        _In_ const sai_attribute_t *attr);
+
+/**
+ * @brief Get My MAC entry attribute
+ *
+ * @param[in] my_mac_id My MAC id
+ * @param[in] attr_count Number of attributes
+ * @param[inout] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_my_mac_attribute_fn)(
+        _In_ sai_object_id_t my_mac_id,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list);
+
+/**
+ * @brief My MAC table attribute IDs
+ */
+typedef enum _sai_my_mac_table_attr_t
+{
+    /**
+     * @brief Start of attributes
+     */
+    SAI_MY_MAC_TABLE_ATTR_START,
+
+    /**
+     * @brief Minimum priority for My MAC
+     *
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_MY_MAC_TABLE_ATTR_MINIMUM_PRIORITY = SAI_MY_MAC_TABLE_ATTR_START,
+
+    /**
+     * @brief Maximum priority for My MAC
+     *
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_MY_MAC_TABLE_ATTR_MAXIMUM_PRIORITY,
+
+    /**
+     * @brief Number of My MAC entries installed on the switch
+     *
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_MY_MAC_TABLE_ATTR_INSTALLED_ENTRIES,
+
+    /**
+     * @brief Number of available My MAC entries
+     *
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_MY_MAC_TABLE_ATTR_AVAILABLE_ENTRIES,
+
+    /**
+     * @brief My MAC entries installed on the switch
+     *
+     * @type sai_object_list_t
+     * @flags READ_ONLY
+     * @objects SAI_OBJECT_TYPE_MY_MAC
+     */
+    SAI_MY_MAC_TABLE_ATTR_LIST,
+
+    /**
+     * @brief End of attributes
+     */
+    SAI_MY_MAC_TABLE_ATTR_END,
+
+    /** Custom range base value */
+    SAI_MY_MAC_TABLE_ATTR_CUSTOM_RANGE_START = 0x10000000,
+
+    /** End of custom range base */
+    SAI_MY_MAC_TABLE_ATTR_CUSTOM_RANGE_END
+
+} sai_my_mac_table_attr_t;
+
+/**
+ * @brief Create My MAC table.
+ *
+ * @param[out] my_mac_table_id My MAC id
+ * @param[in] switch_id Switch id
+ * @param[in] attr_count Number of attributes
+ * @param[in] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_create_my_mac_table_fn)(
+        _Out_ sai_object_id_t *my_mac_table_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list);
+
+/**
+ * @brief Remove My MAC table
+ *
+ * @param[in] my_mac_table_id My MAC Id
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_remove_my_mac_table_fn)(
+        _In_ sai_object_id_t my_mac_table_id);
+
+/**
+ * @brief Set My MAC table attribute
+ *
+ * @param[in] my_mac_table_id My MAC id
+ * @param[in] attr Attribute
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_set_my_mac_table_attribute_fn)(
+        _In_ sai_object_id_t my_mac_table_id,
+        _In_ const sai_attribute_t *attr);
+
+/**
+ * @brief Get My MAC table attribute
+ *
+ * @param[in] my_mac_table_id My MAC id
+ * @param[in] attr_count Number of attributes
+ * @param[inout] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_my_mac_table_attribute_fn)(
+        _In_ sai_object_id_t my_mac_table_id,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list);
+
+/**
+ * @brief My MAC methods table retrieved with sai_api_query()
+ */
+typedef struct _sai_my_mac_api_t
+{
+    sai_create_my_mac_fn                create_my_mac;
+    sai_remove_my_mac_fn                remove_my_mac;
+    sai_set_my_mac_attribute_fn         set_my_mac_attribute;
+    sai_get_my_mac_attribute_fn         get_my_mac_attribute;
+    sai_create_my_mac_table_fn          create_my_mac_table;
+    sai_remove_my_mac_table_fn          remove_my_mac_table;
+    sai_set_my_mac_table_attribute_fn   set_my_mac_table_attribute;
+    sai_get_my_mac_table_attribute_fn   get_my_mac_table_attribute;
+
+} sai_my_mac_api_t;
+
+#endif /** __SAIMYMAC_H_ */

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -2546,6 +2546,15 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_AVAILABLE_DOUBLE_NAPT_ENTRY,
 
     /**
+     * @brief Object id of the My MAC table
+     *
+     * @type sai_object_id_t
+     * @flags READ_ONLY
+     * @objects SAI_OBJECT_TYPE_MY_MAC_TABLE
+     */
+    SAI_SWITCH_ATTR_MY_MAC_TABLE_ID,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -278,6 +278,8 @@ typedef enum _sai_object_type_t
     SAI_OBJECT_TYPE_SYSTEM_PORT              = 93,
     SAI_OBJECT_TYPE_FINE_GRAINED_HASH_FIELD  = 94,
     SAI_OBJECT_TYPE_SWITCH_TUNNEL            = 95,
+    SAI_OBJECT_TYPE_MY_MAC                   = 96,
+    SAI_OBJECT_TYPE_MY_MAC_TABLE             = 97,
     SAI_OBJECT_TYPE_MAX,  /* Must remain in last position */
 } sai_object_type_t;
 

--- a/meta/saiserializetest.c
+++ b/meta/saiserializetest.c
@@ -464,9 +464,9 @@ void test_serialize_enum()
 
     ASSERT_STR_EQ(buf, "-1", res);
 
-    res = sai_serialize_enum(buf, &sai_metadata_enum_sai_object_type_t, 100);
+    res = sai_serialize_enum(buf, &sai_metadata_enum_sai_object_type_t, 128);
 
-    ASSERT_STR_EQ(buf, "100", res);
+    ASSERT_STR_EQ(buf, "128", res);
 
     /* test all enums */
 


### PR DESCRIPTION
RIF Source MAC is used to set the Source MAC address in transmitted packet.
It can also be used to match the Destination MAC address in received packet.
This proposal provides the capability to program the 
MAC address used in the receive path.