### PR TITLE
Add a trap type for mpls lookup miss

### DIFF
--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -427,6 +427,12 @@ typedef enum _sai_hostif_trap_type_t
      */
     SAI_HOSTIF_TRAP_TYPE_MPLS_ROUTER_ALERT_LABEL = 0x00008001,
 
+    /**
+     * @brief MPLS packets discarded due to label lookup miss
+     * (default packet action is drop)
+     */
+    SAI_HOSTIF_TRAP_TYPE_MPLS_LABEL_LOOKUP_MISS = 0x00008002,
+
     /** Exception traps custom range start */
     SAI_HOSTIF_TRAP_TYPE_CUSTOM_EXCEPTION_RANGE_BASE = 0x00009000,
 


### PR DESCRIPTION
Signed-off-by: Midhun Somasundaran <msomasundaran@fb.com>

Adding a new trap type for packets discarded due to mpls label lookup miss. One use case for this new trap is to mirror the trapped packets to a host for debug purpose.