### PR TITLE
[meta] Add support for mixed conditions

### DIFF
--- a/meta/acronyms.txt
+++ b/meta/acronyms.txt
@@ -18,6 +18,8 @@ CCITT - Comite Consultatif International de Telegraphique et Telephonique
 CFI - Canonical Format Indicator
 CIDR - Classless Inter Domain Routing
 CIR - Committed Information Rate
+CPLD - Complex programmable logic device
+CPLD - Complex programmable logic device
 CPU - Central Processing Unit
 CRC - Cyclic Redundancy Code
 DHCP - Dynamic Host Configuration Protocol
@@ -27,6 +29,8 @@ DLDR - Dead Lock Detection and Recovery
 DLL - Dynamic Link Library
 DLR - Dead Lock Recovery
 DMA - Direct Memory Access
+DNAPT - Destination Network Address Port Translation
+DNAPT - Destination Network Address Port Trasnlation
 DNAT - Destination Network Address Translation
 DSCP - Differentiated Services Code Point
 DTEL - Data Plane Telemetry
@@ -35,18 +39,24 @@ ECMP - Equal Cost Multi-Path
 ECN - Explicit Congestion Notification
 ECT - ECN Capable Transport
 EEE - Electrical and Electronics Engineering
+EEPROM - Electrically erasable programmable read-only memory
+EEPROM - Electrically erasable programmable read-only memory
 ERSPAN - Encapsulated Remote SPAN
 FCS - Frame Check Sequence
 FD - File Descriptor
 FDB - Forwarding Data Base
 FEC - Forward Error Correction
 FPGA - Field Programmable Gate Array
+FW  - Firmware
+FW  - Firmware
 GCM - Galois Counter Mode
 GMII - Gigabit Media-Independent Interface
 GPB - Google Protocol Buffers
 GRE - Generic Routing Encapsulation
 GRPC - GRPC Remote Procedure Call
 HW - Hardware
+I2C - I squared C
+I2C - I squared C
 I2C - Inter Integrated Circuit
 ICMP - Internet Control Message Protocol
 ICMPV6 - Internet Control Message Procotol for IPv6
@@ -58,9 +68,9 @@ IGMP - Internet Group Management Protocol
 IHL - Internet Header Length
 IOAM - In-situ Operations And Management
 IP - Internet Protocol
-IPG - Inter-Packet Gap
-IPFIX - IP Flow Information Export
 IP2ME - IP packets to local router IP
+IPFIX - IP Flow Information Export
+IPG - Inter-Packet Gap
 IPMC - Intelligent Platform Management Controller
 L2 - Layer 2
 L2MC - Layer 2 Multi Cast
@@ -69,9 +79,15 @@ LAG - Link Aggregation Group
 LPM - Longest Prefix Match
 LSP - Label Switched Path
 MAC - Medium Access Control
+MDIO - Management Data Input/Output
+MDIO - Management Data Input/Output
+MDIX - Medium Dependent Interface Crossover
+MDIX - Medium Dependent Interface Crossover
 MMU - Memory Management Unit
 MPLS - Multi Protocol Label Switching
 MTU - Maximum Transmission Unit
+NAPT - Network Address Port Translation
+NAPT - Network Address Port Translation
 NHLFE - Next Hop Label Forwarding Entry
 NPU - Numeric Processing Unit
 NRZ - Non Return to Zero
@@ -81,31 +97,41 @@ OUI - Organizationally Unique Identifier
 PAM4 - Pulse Amplitude Modulation 4-level
 PBS - Peak Burst Size
 PCI - Peripheral Component Interconnect
-PHP - Penultimate Hop Pop
 PFC - Priority Flow Control
+PHP - Penultimate Hop Pop
 PIR - Peak Information Rate
 PN - Packet Number
+PRBS - Pseudorandom binary sequence
+PRBS - Pseudorandom binary sequence
 PSC - PHB Scheduling Class
+PSP - Penultimate Segment Pop
 PTP - Precision time protocol
 QOS - Quality of Service
 RARP - Reverse Address Resolution Protocol
 RFC - Request For Comment
 RPF - Reverse Path Forwarding
+RPN - Reverse Polish Notation
 RSPAN - Remote Span
 SA - Secure Association
-SAK - Secure Association Key
 SAI - Switch Abstraction Interface
-SCI - Secure Channel Identifier
+SAK - Secure Association Key
 SC - Secure Channel
+SCI - Secure Channel Identifier
 SDK - Software Development Kit
 SFI - SerDes Framer Interface
 SFLOW - Sampled Flow
 SG - (S,G) Source-specific multicast
+SGMII - Serial Gigabit Media Independent Interface
+SGMII - Serial Gigabit Media Independent Interface
+SNAPT - Source Network Address Port Translation
+SNAPT - Source Network Address Port Translation
 SNAT - Source Network Address Translation
 SNMP - Simple Network Management Protocol
 SNR - Signal to Noise Ratio
 SPAN - Switched Port Analyzer
 SQE - Signal Quality Errors
+SRH - Segment Routing Header
+SRV6 - Segment Routing with IPv6
 SSCI - Short Secure Channel Identifier
 SSH - Secure Shell
 SSL - Secure Socket Layer
@@ -119,9 +145,11 @@ TPID - Tag Protocol Identifier
 TTL - Time to Leave
 UDF - User-Defined Field
 UDP - User Datagram Protocol
-VOQ - Virtual Output Queue
+USD - Ultimate Segment Decapsulation
+USP - Ultimate Segment Pop
 VNI - Virtual Network Interface
 VNID - Virtual Network Identifier
+VOQ - Virtual Output Queue
 VR - Virtual Router
 VRF - Virtual Route Forwarding
 VRRP - Virtual Router Redundancy Protocol
@@ -134,22 +162,6 @@ XFI - 10 Gbps Chip to Chip Interface
 XG - (*,G) Any-source Multicast4
 XGMII - 10 Gbps Media Independent Interface
 XLAUI - 40 Gbps Attachment Unit Interface
-XPN - Extended Packet Number
 XOFF - Transmitter Off
 XON - Transmitter On
-FW  - Firmware
-MDIO - Management Data Input/Output
-I2C - I squared C
-CPLD - Complex programmable logic device
-EEPROM - Electrically erasable programmable read-only memory
-PRBS - Pseudorandom binary sequence
-NAPT - Network Address Port Translation
-SNAPT - Source Network Address Port Translation
-DNAPT - Destination Network Address Port Translation
-SRH - Segment Routing Header
-SRV6 - Segment Routing with IPv6
-PSP - Penultimate Segment Pop
-USP - Ultimate Segment Pop
-USD - Ultimate Segment Decapsulation
-SGMII - Serial Gigabit Media Independent Interface
-MDIX - Medium Dependent Interface Crossover
+XPN - Extended Packet Number

--- a/meta/acronyms.txt
+++ b/meta/acronyms.txt
@@ -19,7 +19,6 @@ CFI - Canonical Format Indicator
 CIDR - Classless Inter Domain Routing
 CIR - Committed Information Rate
 CPLD - Complex programmable logic device
-CPLD - Complex programmable logic device
 CPU - Central Processing Unit
 CRC - Cyclic Redundancy Code
 DHCP - Dynamic Host Configuration Protocol
@@ -40,7 +39,6 @@ ECN - Explicit Congestion Notification
 ECT - ECN Capable Transport
 EEE - Electrical and Electronics Engineering
 EEPROM - Electrically erasable programmable read-only memory
-EEPROM - Electrically erasable programmable read-only memory
 ERSPAN - Encapsulated Remote SPAN
 FCS - Frame Check Sequence
 FD - File Descriptor
@@ -48,14 +46,12 @@ FDB - Forwarding Data Base
 FEC - Forward Error Correction
 FPGA - Field Programmable Gate Array
 FW  - Firmware
-FW  - Firmware
 GCM - Galois Counter Mode
 GMII - Gigabit Media-Independent Interface
 GPB - Google Protocol Buffers
 GRE - Generic Routing Encapsulation
 GRPC - GRPC Remote Procedure Call
 HW - Hardware
-I2C - I squared C
 I2C - I squared C
 I2C - Inter Integrated Circuit
 ICMP - Internet Control Message Protocol
@@ -80,13 +76,10 @@ LPM - Longest Prefix Match
 LSP - Label Switched Path
 MAC - Medium Access Control
 MDIO - Management Data Input/Output
-MDIO - Management Data Input/Output
-MDIX - Medium Dependent Interface Crossover
 MDIX - Medium Dependent Interface Crossover
 MMU - Memory Management Unit
 MPLS - Multi Protocol Label Switching
 MTU - Maximum Transmission Unit
-NAPT - Network Address Port Translation
 NAPT - Network Address Port Translation
 NHLFE - Next Hop Label Forwarding Entry
 NPU - Numeric Processing Unit
@@ -101,7 +94,6 @@ PFC - Priority Flow Control
 PHP - Penultimate Hop Pop
 PIR - Peak Information Rate
 PN - Packet Number
-PRBS - Pseudorandom binary sequence
 PRBS - Pseudorandom binary sequence
 PSC - PHB Scheduling Class
 PSP - Penultimate Segment Pop
@@ -122,8 +114,6 @@ SFI - SerDes Framer Interface
 SFLOW - Sampled Flow
 SG - (S,G) Source-specific multicast
 SGMII - Serial Gigabit Media Independent Interface
-SGMII - Serial Gigabit Media Independent Interface
-SNAPT - Source Network Address Port Translation
 SNAPT - Source Network Address Port Translation
 SNAT - Source Network Address Translation
 SNMP - Simple Network Management Protocol

--- a/meta/aspell.en.pws
+++ b/meta/aspell.en.pws
@@ -6,6 +6,7 @@ an
 apache
 APIs
 attr
+attrid
 attrvalue
 AUTONEG
 bool

--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -43,6 +43,8 @@ our $XMLDIR = "xml";
 our $INCLUDE_DIR = "../inc/";
 our $EXPERIMENTAL_DIR = "../experimental/";
 
+our $MAX_CONDITIONS_LEN = 1;
+
 our %SAI_ENUMS = ();
 our %SAI_UNIONS = ();
 our %METADATA = ();
@@ -2202,6 +2204,9 @@ sub ProcessSingleObjectType
         # check enum attributes if their names are ending on enum name
 
         CheckEnumNaming($attr, $meta{type}) if $isenum eq "true" or $isenumlist eq "true";
+
+        $MAX_CONDITIONS_LEN = $conditionslen if $MAX_CONDITIONS_LEN < $conditionslen;
+        $MAX_CONDITIONS_LEN = $validonlylen if $MAX_CONDITIONS_LEN < $validonlylen;
     }
 }
 
@@ -4486,6 +4491,13 @@ sub CreateSaiSwigApiStructs
     }
 }
 
+sub CreateDefineMaxConditionsLen
+{
+    WriteSectionComment "Define SAI_METADATA_MAX_CONDITIONS_LEN";
+
+    WriteHeader "#define SAI_METADATA_MAX_CONDITIONS_LEN $MAX_CONDITIONS_LEN";
+}
+
 #
 # MAIN
 #
@@ -4521,6 +4533,8 @@ CreateMetadataHeaderAndSource();
 CreateMetadata();
 
 CreateMetadataForAttributes();
+
+CreateDefineMaxConditionsLen();
 
 CreateEnumHelperMethods();
 

--- a/meta/saimetadatatypes.h
+++ b/meta/saimetadatatypes.h
@@ -642,7 +642,32 @@ typedef enum _sai_attr_condition_type_t
      */
     SAI_ATTR_CONDITION_TYPE_AND,
 
+    /**
+     * @brief Mixed condition, can contain and/or operators as well
+     * as grouping using brackets (). Conditions are stored in RPN.
+     */
+    SAI_ATTR_CONDITION_TYPE_MIXED,
+
 } sai_attr_condition_type_t;
+
+/**
+ * @brief Condition operator (==,!=,<,>,<=.>=).
+ */
+typedef enum _sai_condition_operator_t
+{
+    SAI_CONDITION_OPERATOR_EQ = 0,
+
+    SAI_CONDITION_OPERATOR_NE,
+
+    SAI_CONDITION_OPERATOR_LT,
+
+    SAI_CONDITION_OPERATOR_GT,
+
+    SAI_CONDITION_OPERATOR_LE,
+
+    SAI_CONDITION_OPERATOR_GE,
+
+} sai_condition_operator_t;
 
 /**
  * @brief Defines attribute condition.
@@ -661,9 +686,21 @@ typedef struct _sai_attr_condition_t
      */
     const sai_attribute_value_t         condition;
 
-    /*
-     * In future we can add condition operator like equal, not equal, etc.
+    /**
+     * @brief Condition operator (==,!=,<,>,<=.>=).
      */
+    sai_condition_operator_t            op;
+
+    /**
+     * @brief Condition type.
+     *
+     * If main condition type is MIXED, then condition list is written in RPN
+     * (reverse polish notation) syntax notation. If this field is NONE, then
+     * this is actual condition, otherwise it can be AND,OR type which is just
+     * a operator indication that should be performed. For AND,OR case attrid
+     * is equal to SAI_INVALID_ATTRIBUTE_ID.
+     */
+    sai_attr_condition_type_t           type;
 
 } sai_attr_condition_t;
 

--- a/meta/saimetadatautils.c
+++ b/meta/saimetadatautils.c
@@ -278,6 +278,21 @@ bool sai_metadata_is_condition_met(
         return false;
     }
 
+    switch (metadata->conditiontype)
+    {
+        case SAI_ATTR_CONDITION_TYPE_AND:
+        case SAI_ATTR_CONDITION_TYPE_OR:
+            break;
+
+        default:
+
+            /* TODO check for mixed condition, and use separate path */
+
+            SAI_META_LOG_ERROR("mixed condition on %s is not supported yet, FIXME", metadata->attridname);
+
+            return false;
+    }
+
     size_t idx = 0;
 
     bool met = (metadata->conditiontype == SAI_ATTR_CONDITION_TYPE_AND);

--- a/meta/saimetadatautils.c
+++ b/meta/saimetadatautils.c
@@ -419,7 +419,7 @@ static bool sai_metadata_is_mixed_condition_list_met(
             bool value = sai_metadata_is_single_condition_met(md->objecttype, c, attr_count, attr_list);
 
             STACK_PUSH(value);
-        } 
+        }
         else if (c->type == SAI_ATTR_CONDITION_TYPE_AND)
         {
             bool a = STACK_POP();

--- a/meta/saimetadatautils.h
+++ b/meta/saimetadatautils.h
@@ -157,7 +157,7 @@ extern bool sai_metadata_is_object_type_oid(
  *
  * NOTE: When multiple attributes with the same ID are passed,
  * sai_metadata_get_attr_by_id will select only first one.
- * Function will not be able to handle multiple attributes
+ * Function will not be able to handle duplicated attributes.
  *
  * @param[in] metadata Metadata of attribute that we need to check.
  * @param[in] attr_count Number of attributes.
@@ -168,6 +168,32 @@ extern bool sai_metadata_is_object_type_oid(
  * returned if any of input pointers is NULL or attribute is not conditional.
  */
 extern bool sai_metadata_is_condition_met(
+        _In_ const sai_attr_metadata_t *metadata,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list);
+
+/**
+ * @brief Check if valid only condition is met.
+ *
+ * List of attributes will be examined in terms of valid only conditions. This
+ * is convenient since user can pass list when calling create API. If valid
+ * only condition attribute is not on the list, then default value will be
+ * examined.
+ *
+ * NOTE: When multiple attributes with the same ID are passed,
+ * sai_metadata_get_attr_by_id will select only first one. Function will not
+ * be able to handle duplicated attributes.
+ *
+ * @param[in] metadata Metadata of attribute that we need to check.
+ * @param[in] attr_count Number of attributes.
+ * @param[in] attr_list Attribute list to check. All attributes must
+ * belong to the same object type as metadata parameter.
+ *
+ * @return True if valid only condition is in force, false otherwise. False
+ * will be also returned if any of input pointers is NULL or attribute is not
+ * valid only conditional.
+ */
+extern bool sai_metadata_is_validonly_met(
         _In_ const sai_attr_metadata_t *metadata,
         _In_ uint32_t attr_count,
         _In_ const sai_attribute_t *attr_list);


### PR DESCRIPTION
Allows to specify mixed condition types for validonly and condition in attributes flags.
For example: SAI_PORT_ATTR_MEDIA_TYPE == SAI_PORT_MEDIA_TYPE_FIBER and (SAI_PORT_ATTR_SPEED == 10 or SAI_PORT_ATTR_SPEED == 1000) 
