### PR TITLE
Ported Marvell armhf build on amd64 for debian buster to use cross-comp…

### DIFF
--- a/meta/Makefile
+++ b/meta/Makefile
@@ -68,6 +68,9 @@ $(foreach bin,$(BINS),$(if $(shell which $(bin)),,$(error "Missing $(bin) in PAT
 
 CFLAGS += -I../inc -I../experimental $(WARNINGS)
 
+CC = $(CROSS_COMPILE)gcc
+CXX = $(CROSS_COMPILE)g++
+
 DEPS = $(wildcard ../inc/*.h) $(wildcard ../experimental/*.h)
 XMLDEPS = $(wildcard xml/*.xml)
 
@@ -83,7 +86,7 @@ all: toolsversions saisanitycheck saimetadatatest saiserializetest saidepgraph.s
 
 toolsversions:
 	@make -v | grep -i make
-	@gcc --version | grep gcc
+	@$(CC) --version | grep gcc
 	@perl --version | grep version
 	@aspell --version
 	@dot -V
@@ -104,22 +107,22 @@ saimetadatatest.c saimetadata.c saimetadata.h: xml $(XMLDEPS) parse.pl $(CONSTHE
 HEADERS = saimetadata.h $(CONSTHEADERS)
 
 %.o: %.c $(HEADERS)
-	gcc -c -o $@ $< $(CFLAGS)
+	$(CC) -c -o $@ $< $(CFLAGS)
 
 %.o: %.cpp $(HEADERS)
-	gcc -c -o $@ $< $(CFLAGS)
+	$(CC) -c -o $@ $< $(CFLAGS)
 
 saisanitycheck: saisanitycheck.o $(OBJ)
-	gcc -o $@ $^
+	$(CC) -o $@ $^
 
 saimetadatatest: saimetadatatest.o $(OBJ)
-	gcc -o $@ $^
+	$(CC) -o $@ $^
 
 saiserializetest: saiserializetest.o $(OBJ)
-	gcc -o $@ $^
+	$(CC) -o $@ $^
 
 saidepgraphgen: saidepgraphgen.o $(OBJ)
-	g++ -o $@ $^
+	$(CXX) -o $@ $^
 
 %.o.symbols: %.o
 	nm $^ | ./checksymbols.pl

--- a/test/Makefile
+++ b/test/Makefile
@@ -15,7 +15,9 @@
 #    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
 #    Dell Products, L.P., Facebook, Inc
 #
-CXX = g++
+
+CXX = $(CROSS_COMPILE)g++
+
 LIBS = -lpthread 
 LDIR = ./lib
 

--- a/test/basic_router/Makefile
+++ b/test/basic_router/Makefile
@@ -21,7 +21,8 @@
 
 #Broadcom, Mellonox, Barefoot
 
-CXX = g++
+CXX = $(CROSS_COMPILE)g++
+
 LIBS = -lpthread -lsai
 SAI_IDIR = /usr/include/sai
 

--- a/test/sai_ut/Makefile
+++ b/test/sai_ut/Makefile
@@ -55,8 +55,8 @@ stp_EXEC   = sai_ut_stp
 EXEC_ALL = $(BDIR)/$(vr_EXEC) $(BDIR)/$(rif_EXEC) $(BDIR)/$(nh_EXEC) $(BDIR)/$(nhg_EXEC) $(BDIR)/$(nbr_EXEC) $(BDIR)/$(route_EXEC) $(BDIR)/$(fdb_EXEC) $(BDIR)/$(vlan_EXEC) $(BDIR)/$(lag_EXEC) $(BDIR)/$(stp_EXEC)
 
 # what to use for compiling
-CXX=g++
-AR=ar
+CXX = $(CROSS_COMPILE)g++
+AR = $(CROSS_COMPILE)ar
 
 # include dir for unit-tests
 INCLUDEFLAGS = ${SAI_INCLUDE_FLAGS} -I$(GTEST_DIR)/include 

--- a/test/saithrift/Makefile
+++ b/test/saithrift/Makefile
@@ -1,4 +1,5 @@
-CXX=g++
+CXX = $(CROSS_COMPILE)g++
+
 SAI_PREFIX = /usr
 SAI_HEADER_DIR ?= $(SAI_PREFIX)/include/sai
 SAI_HEADERS = $(SAI_HEADER_DIR)/sai*.h


### PR DESCRIPTION
…ilation instead of qemu emulation

…ilation instead of qemu emulation

Motivation:
Current armhf Sonic build on amd64 host uses qemu emulation. Due to the nature of the emulation it takes a very long time, about 22-24 hours to complete the build. The change I did to improve the building time ports Sonic armhf build on amd64 host for Marvell platform for debian buster to use cross-compilation on arm64 host for armhf target. The overall Sonic armhf building time using cross-compilation is about 6 hours.

The Sonic configure and build for the armhf cross-compilation is as following:
NOJESSIE=1 NOSTRETCH=1 BLDENV=buster CROSS_BLDENV=1 make configure PLATFORM=marvell-armhf PLATFORM_ARCH=armhf
NOJESSIE=1 NOSTRETCH=1 BLDENV=buster CROSS_BLDENV=1 make target/sonic-marvell-armhf.bin

Sonic module should check if $CROSS_BUILD_ENVIRON is 'y' to make sure that it is cross-compilation build.

