### PR TITLE
Unset SAI_PORT_ATTR_HW_LANE_LIST as key

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -745,7 +745,7 @@ typedef enum _sai_port_attr_t
      * @brief Hardware Lane list
      *
      * @type sai_u32_list_t
-     * @flags MANDATORY_ON_CREATE | CREATE_ONLY | KEY
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
      */
     SAI_PORT_ATTR_HW_LANE_LIST,
 


### PR DESCRIPTION
The reason is that we are using one syncd process to support multiple phy chips and for the ports from different phys, they may
have the same value on SAI_PORT_ATTR_HW_LANE_LIST.

This change is depended by https://github.com/Azure/sonic-buildimage/pull/8146. Specifically, multiple switches are defined under guid 1 as below, however, ports from different switches may have the value on SAI_PORT_ATTR_HW_LANE_LIST.
        {
            "guid" : 1,
            "name" : "phys",                                                                                                                                                                                                                                                                "dbAsic" : "GB_ASIC_DB",
            "dbCounters" : "GB_COUNTERS_DB",
            "dbFlex": "GB_FLEX_COUNTER_DB",
            "dbState" : "STATE_DB",
            "zmq_enable" : false,
            "zmq_endpoint": "tcp://127.0.0.1:5565",                                                                                                                                                                                                                                         
            "zmq_ntf_endpoint": "tcp://127.0.0.1:5566",
            "switches": [
                {                                                                                                                       
                    "index" : 0,
                    "hwinfo" : "mdio0_0_0/0"
                },
                {                                                                                                                       
                    "index" : 1,
                    "hwinfo" : "mdio1_0_0/0"
                }
        }

Signed-off-by: Boyang Yu <byu@arista.com>