### PR TITLE
[SAI]fix saiserver, support PACKENT_EVENT_NOTIFY in mode BCMSIM

### DIFF
--- a/test/saithrift/src/saiserver.cpp
+++ b/test/saithrift/src/saiserver.cpp
@@ -395,9 +395,10 @@ main(int argc, char* argv[])
     sai_api_initialize(0, &test_services);
     sai_api_query(SAI_API_SWITCH, (void**)&sai_switch_api);
 
-    constexpr std::uint32_t attrSz = 6;
+    constexpr std::uint32_t attrSz = 5;
 
     sai_attribute_t attr[attrSz];
+
     std::memset(attr, '\0', sizeof(attr));
 
     attr[0].id = SAI_SWITCH_ATTR_INIT_SWITCH;
@@ -415,13 +416,21 @@ main(int argc, char* argv[])
     attr[4].id = SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY;
     attr[4].value.ptr = reinterpret_cast<sai_pointer_t>(&on_port_state_change);
 
-    attr[5].id = SAI_SWITCH_ATTR_PACKET_EVENT_NOTIFY;
-    attr[5].value.ptr = reinterpret_cast<sai_pointer_t>(&on_packet_event);
-
     sai_status_t status = sai_switch_api->create_switch(&gSwitchId, attrSz, attr);
     if (status != SAI_STATUS_SUCCESS)
     {
+        printf("Error: Failed to create switch: %d \n", status);
         exit(EXIT_FAILURE);
+    }
+
+    //in case of the brcm switch not (!defined(INCLUDE_KNET) && !defined(BCMSIM))
+    sai_attribute_t attr_pkt;
+    attr_pkt.id = SAI_SWITCH_ATTR_PACKET_EVENT_NOTIFY;
+    attr_pkt.value.ptr = reinterpret_cast<sai_pointer_t>(&on_packet_event);
+    status = sai_switch_api->set_switch_attribute(gSwitchId, &attr_pkt);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        printf("Warn: Failed to set_switch_attribute SAI_SWITCH_ATTR_PACKET_EVENT_NOTIFY : %d \n", status);
     }
 
     handleInitScript(options.initScript);


### PR DESCRIPTION
test done:
tested with deploy the saiserver to saiserver docker manually
tested with saiserver docker which build by sonic-imagebuild and contains the saiserver binary
run test case from PTF to saiserver in both the environments above
**note: token BCMSIM only defined in brcm saisdk with version 1.7. it maps to sonic version 202012 only**