### PR TITLE
SRv6 drop reason

### DIFF
--- a/inc/saidebugcounter.h
+++ b/inc/saidebugcounter.h
@@ -312,11 +312,13 @@ typedef enum _sai_in_drop_reason_t
     SAI_IN_DROP_REASON_MPLS_MISS,
 
     /**
-     * SRV6 local SID drop
+     * @brief SRV6 local SID drop
      *
-     * e.g. : local SID missed
-     *        NH == SRH && SL == 0 for End, End.X, End.T, End.B*
-     *        NH != SRH while local SID configured for packet DA
+     * Packet is dropped due to local SID configuration or incorrect value in SRV6 packet header
+     * e.g.: Local SID packet action is set to SAI_PACKET_ACTION_DROP
+     * Next Header is SRH and Segments Left value is 0 for End, End.X, End.T, End.B* endpoint types
+     * Next Header is not SRH while local SID is configured for packet DA
+     * Segments Left value is not 0 when received packet is destined to S and S is a local SID of type End.D*
      */
     SAI_IN_DROP_REASON_SRV6_LOCAL_SID_DROP,
 

--- a/inc/saidebugcounter.h
+++ b/inc/saidebugcounter.h
@@ -311,6 +311,15 @@ typedef enum _sai_in_drop_reason_t
     /** MPLS Routing table lookup miss */
     SAI_IN_DROP_REASON_MPLS_MISS,
 
+    /**
+     * SRV6 local SID drop
+     *
+     * e.g. : local SID missed
+     *        NH == SRH && SL == 0 for End, End.X, End.T, End.B*
+     *        NH != SRH while local SID configured for packet DA
+     */
+    SAI_IN_DROP_REASON_SRV6_LOCAL_SID_DROP,
+
     /** End of in drop reasons */
     SAI_IN_DROP_REASON_END,
 

--- a/meta/checkheaders.pl
+++ b/meta/checkheaders.pl
@@ -187,6 +187,7 @@ sub CheckHash
             # ignore attributes end, since those will shift
             next if $key =~ /^SAI_\w+_ATTR_END$/;
 
+	    next if $key eq "SAI_IN_DROP_REASON_END";
             next if $key eq "SAI_ACL_TABLE_ATTR_FIELD_END";
             next if $key eq "SAI_ACL_ENTRY_ATTR_FIELD_END";
             next if $key eq "SAI_ACL_ENTRY_ATTR_ACTION_END";

--- a/meta/checkheaders.pl
+++ b/meta/checkheaders.pl
@@ -187,7 +187,7 @@ sub CheckHash
             # ignore attributes end, since those will shift
             next if $key =~ /^SAI_\w+_ATTR_END$/;
 
-	    next if $key eq "SAI_IN_DROP_REASON_END";
+            next if $key eq "SAI_IN_DROP_REASON_END";
             next if $key eq "SAI_ACL_TABLE_ATTR_FIELD_END";
             next if $key eq "SAI_ACL_ENTRY_ATTR_FIELD_END";
             next if $key eq "SAI_ACL_ENTRY_ATTR_ACTION_END";


### PR DESCRIPTION
This change simply adds a new drop reason for drops related to IPv6 Segment Routing. It will be useful for debug counters implementation for such drops.