### PR TITLE
[meta] Disable enum conversion warning on metadata source

### DIFF
--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -1223,14 +1223,34 @@ sub ProcessExtraRangeDefines
     }
 }
 
-sub CreateMetadataHeaderAndSource
+sub CreateSourceIncludes
 {
+    WriteSourceSectionComment "includes";
+
     WriteSource "#include <stdio.h>";
     WriteSource "#include <string.h>";
     WriteSource "#include <stdlib.h>";
     WriteSource "#include <stddef.h>";
     WriteSource "#include \"saimetadata.h\"";
+}
 
+sub CreateSourcePragmaPush
+{
+    WriteSourceSectionComment "ignore pragmas push";
+
+    #
+    # because we are merging extension attributes into existing
+    # enums, new versions of gcc can warn when 2 different enums
+    # are mixed, so lets ignore this warning using pragmas
+    #
+
+    WriteSource "#pragma GCC diagnostic push";
+    WriteSource "#pragma GCC diagnostic ignored \"-Wpragmas\"";
+    WriteSource "#pragma GCC diagnostic ignored \"-Wenum-conversion\"";
+}
+
+sub CreateMetadataHeaderAndSource
+{
     WriteSectionComment "Enums metadata";
 
     for my $key (sort keys %SAI_ENUMS)
@@ -4241,6 +4261,13 @@ sub WriteHeaderFotter
     WriteHeader "#endif /* __SAI_METADATA_H__ */";
 }
 
+sub CreateSourcePragmaPop
+{
+    WriteSourceSectionComment "ignore pragmas pop";
+
+    WriteSource "#pragma GCC diagnostic pop";
+}
+
 sub ProcessXmlFiles
 {
     for my $file (GetSaiXmlFiles($XMLDIR))
@@ -4610,6 +4637,10 @@ ProcessSaiStatus();
 
 ProcessExtraRangeDefines();
 
+CreateSourceIncludes();
+
+CreateSourcePragmaPush();
+
 CreateMetadataHeaderAndSource();
 
 CreateMetadata();
@@ -4673,6 +4704,8 @@ CreateSaiSwigGetApiHelperFunctions();
 CreateSaiSwigApiStructs();
 
 WriteHeaderFotter();
+
+CreateSourcePragmaPop();
 
 # Test Section
 

--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -1225,7 +1225,7 @@ sub ProcessExtraRangeDefines
 
 sub CreateSourceIncludes
 {
-    WriteSourceSectionComment "includes";
+    WriteSourceSectionComment "Includes";
 
     WriteSource "#include <stdio.h>";
     WriteSource "#include <string.h>";
@@ -1236,7 +1236,7 @@ sub CreateSourceIncludes
 
 sub CreateSourcePragmaPush
 {
-    WriteSourceSectionComment "ignore pragmas push";
+    WriteSourceSectionComment "Pragma diagnostic push";
 
     #
     # because we are merging extension attributes into existing
@@ -4263,7 +4263,7 @@ sub WriteHeaderFotter
 
 sub CreateSourcePragmaPop
 {
-    WriteSourceSectionComment "ignore pragmas pop";
+    WriteSourceSectionComment "Pragma diagnostic pop";
 
     WriteSource "#pragma GCC diagnostic pop";
 }

--- a/meta/utils.pm
+++ b/meta/utils.pm
@@ -99,6 +99,13 @@ sub WriteSwig
     $SWIG_CONTENT .= $ident . $content . "\n";
 }
 
+sub WriteSourceSectionComment
+{
+    my $content = shift;
+
+    WriteSource "\n/* $content */\n";
+}
+
 sub WriteSectionComment
 {
     my $content = shift;
@@ -571,7 +578,7 @@ BEGIN
     WriteFile GetHeaderFiles GetMetaHeaderFiles GetExperimentalHeaderFiles GetMetadataSourceFiles ReadHeaderFile
     GetNonObjectIdStructNames IsSpecialObject GetStructLists GetStructKeysInOrder
     Trim ExitOnErrors ExitOnErrorsOrWarnings ProcessEnumInitializers
-    WriteHeader WriteSource WriteTest WriteSwig WriteMetaDataFiles WriteSectionComment
+    WriteHeader WriteSource WriteTest WriteSwig WriteMetaDataFiles WriteSectionComment WriteSourceSectionComment
     $errors $warnings $NUMBER_REGEX
     $HEADER_CONTENT $SOURCE_CONTENT $TEST_CONTENT
     /;


### PR DESCRIPTION
because we are merging extension attributes into existing enums, new
versions of gcc can warn when 2 different enums are mixed, so lets
ignore this warning using pragmas