### PR TITLE
[meta] Add global apis

### DIFF
--- a/meta/saidepgraphgen.cpp
+++ b/meta/saidepgraphgen.cpp
@@ -172,7 +172,7 @@ void process_colors()
             {
                 continue;
             }
-            std::cout << NN(ot) << " [color=plum, shape = rect];\n";
+            std::cout << NN(ot) << " [color=coral, shape = note];\n";
         }
     }
 

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -5371,6 +5371,21 @@ void check_object_type_extension_max_value()
     META_ASSERT_TRUE(SAI_OBJECT_TYPE_EXTENSIONS_MAX < 256, "max object type can be 255 to be encoded on single byte");
 }
 
+void check_global_apis()
+{
+    META_LOG_ENTER();
+
+    sai_global_apis_t apis;
+
+    apis.api_initialize = NULL;
+
+    META_ASSERT_TRUE(sizeof(apis)/sizeof(void*) > 15, "there should be at least 15 global apis");
+
+    sai_global_api_type_t type = SAI_GLOBAL_API_TYPE_API_INITIALIZE;
+
+    META_ASSERT_TRUE(sizeof(type) >= sizeof(int32_t), "apis type should be at least int32");
+}
+
 int main(int argc, char **argv)
 {
     debug = (argc > 1);
@@ -5414,6 +5429,7 @@ int main(int argc, char **argv)
     check_sai_version();
     check_max_conditions_len();
     check_object_type_extension_max_value();
+    check_global_apis();
 
     SAI_META_LOG_DEBUG("log test");
 


### PR DESCRIPTION
Adds global apis structure with global apis function pointers, this structure could be used to hold global apis pointers when dealing with multiple SAI libraries under the same process, and loading pointers with dlopen/dlsym