### PR TITLE
[PoC][Dont Merge]Add platform support and a sanity test sample

### DIFF
--- a/meta/sai_rpc_frontend.cpp
+++ b/meta/sai_rpc_frontend.cpp
@@ -1,14 +1,16 @@
-/*
-Copyright 2013-present Barefoot Networks, Inc.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+/* Copyright 2021-present Intel Corporation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 */
 
 #include <arpa/inet.h>
@@ -461,6 +463,7 @@ void convert_attr_thrift_to_sai(const sai_object_type_t sai_ot,
     case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
     case SAI_ATTR_VALUE_TYPE_TIMESPEC:
     case SAI_ATTR_VALUE_TYPE_NAT_ENTRY_DATA:
+      // not supported
       break;
     default:
       break;
@@ -741,6 +744,7 @@ void convert_attr_sai_to_thrift(const sai_object_type_t sai_ot,
     case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
     case SAI_ATTR_VALUE_TYPE_TIMESPEC:
     case SAI_ATTR_VALUE_TYPE_NAT_ENTRY_DATA:
+      // not supported
       break;
     default:
       break;
@@ -748,7 +752,7 @@ void convert_attr_sai_to_thrift(const sai_object_type_t sai_ot,
 }
 
 // very hacky but this means we never have to modify the generated file
-#include "generated/sai_rpc_server.cpp"
+#include "sai_rpc_server.cpp"
 
 class sai_rpcHandlerFrontend : virtual public sai_rpcHandler {
   int64_t sai_thrift_object_type_get_availability(

--- a/meta/sai_rpc_frontend.cpp
+++ b/meta/sai_rpc_frontend.cpp
@@ -670,7 +670,7 @@ void convert_attr_sai_to_thrift(const sai_object_type_t sai_ot,
     case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_IP_ADDRESS:
     case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_ID:
     case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_LIST:
-      // TODO(bfn)
+      //TODO
       break;
 
     case SAI_ATTR_VALUE_TYPE_ACL_CAPABILITY: {

--- a/meta/sai_rpc_frontend.cpp
+++ b/meta/sai_rpc_frontend.cpp
@@ -1,0 +1,857 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <arpa/inet.h>
+
+#include <iostream>
+#include <cstring>
+#include "sai_rpc.h"
+
+extern "C" {
+#include "sai.h"
+#include "saitypes.h"
+#include "saimetadatatypes.h"
+#include "saimetadatautils.h"
+#include "saimetadata.h"
+}
+
+using namespace ::sai;
+
+unsigned int sai_thrift_mac_t_parse(const std::string s, void *data) {
+  unsigned int i, j = 0;
+  unsigned char *m = static_cast<unsigned char *>(data);
+  memset(m, 0, 6);
+  for (i = 0; i < s.size(); i++) {
+    char let = s.c_str()[i];
+    if (let >= '0' && let <= '9') {
+      m[j / 2] = (m[j / 2] << 4) + (let - '0');
+      j++;
+    } else if (let >= 'a' && let <= 'f') {
+      m[j / 2] = (m[j / 2] << 4) + (let - 'a' + 10);
+      j++;
+    } else if (let >= 'A' && let <= 'F') {
+      m[j / 2] = (m[j / 2] << 4) + (let - 'A' + 10);
+      j++;
+    }
+  }
+  return (j == 12);
+}
+
+void sai_thrift_ip4_t_parse(const std::string s, unsigned int *m) {
+  unsigned char r = 0;
+  unsigned int i;
+  *m = 0;
+  for (i = 0; i < s.size(); i++) {
+    char let = s.c_str()[i];
+    if (let >= '0' && let <= '9') {
+      r = (r * 10) + (let - '0');
+    } else {
+      *m = (*m << 8) | r;
+      r = 0;
+    }
+  }
+  *m = (*m << 8) | (r & 0xFF);
+  *m = htonl(*m);
+  return;
+}
+
+void sai_thrift_ip6_t_parse(const std::string s, unsigned char *v6_ip) {
+  const char *v6_str = s.c_str();
+  inet_pton(AF_INET6, v6_str, v6_ip);
+  return;
+}
+
+void sai_thrift_ip_address_t_parse(
+    const sai_thrift_ip_address_t &thrift_ip_address,
+    sai_ip_address_t *ip_address) {
+  ip_address->addr_family = (sai_ip_addr_family_t)thrift_ip_address.addr_family;
+  if ((sai_ip_addr_family_t)thrift_ip_address.addr_family ==
+      SAI_IP_ADDR_FAMILY_IPV4) {
+    sai_thrift_ip4_t_parse(thrift_ip_address.addr.ip4, &ip_address->addr.ip4);
+  } else {
+    sai_thrift_ip6_t_parse(thrift_ip_address.addr.ip6, ip_address->addr.ip6);
+  }
+}
+
+void sai_thrift_ip_prefix_t_parse(
+    const sai_thrift_ip_prefix_t &thrift_ip_prefix,
+    sai_ip_prefix_t *ip_prefix) {
+  ip_prefix->addr_family = (sai_ip_addr_family_t)thrift_ip_prefix.addr_family;
+  if ((sai_ip_addr_family_t)thrift_ip_prefix.addr_family ==
+      SAI_IP_ADDR_FAMILY_IPV4) {
+    sai_thrift_ip4_t_parse(thrift_ip_prefix.addr.ip4, &ip_prefix->addr.ip4);
+    sai_thrift_ip4_t_parse(thrift_ip_prefix.mask.ip4, &ip_prefix->mask.ip4);
+  } else {
+    sai_thrift_ip6_t_parse(thrift_ip_prefix.addr.ip6, ip_prefix->addr.ip6);
+    sai_thrift_ip6_t_parse(thrift_ip_prefix.mask.ip6, ip_prefix->mask.ip6);
+  }
+}
+
+void convert_attr_thrift_to_sai(const sai_object_type_t sai_ot,
+                                const sai_thrift_attribute_t &thrift_attr,
+                                sai_attribute_t *sai_attr) {
+  const auto attr_md = sai_metadata_get_attr_metadata(sai_ot, thrift_attr.id);
+  sai_attr->id = thrift_attr.id;
+
+  if (attr_md == NULL) {
+    return;
+  }
+
+  switch (attr_md->attrvaluetype) {
+    case SAI_ATTR_VALUE_TYPE_BOOL:
+      sai_attr->value.booldata = thrift_attr.value.booldata;
+      break;
+    case SAI_ATTR_VALUE_TYPE_CHARDATA:
+      // 32 is chardata size in saitypes.h
+      std::memcpy(
+          sai_attr->value.chardata, thrift_attr.value.chardata.c_str(), 32);
+      break;
+    case SAI_ATTR_VALUE_TYPE_UINT8:
+      sai_attr->value.u8 = thrift_attr.value.u8;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT8:
+      sai_attr->value.s8 = thrift_attr.value.s8;
+      break;
+    case SAI_ATTR_VALUE_TYPE_UINT16:
+      sai_attr->value.u16 = thrift_attr.value.u16;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT16:
+      sai_attr->value.s16 = thrift_attr.value.s16;
+      break;
+    case SAI_ATTR_VALUE_TYPE_UINT32:
+      sai_attr->value.u32 = thrift_attr.value.u32;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT32:
+      sai_attr->value.s32 = thrift_attr.value.s32;
+      break;
+    case SAI_ATTR_VALUE_TYPE_UINT64:
+      sai_attr->value.u64 = thrift_attr.value.u64;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT64:
+      sai_attr->value.s64 = thrift_attr.value.s64;
+      break;
+    case SAI_ATTR_VALUE_TYPE_POINTER:
+      // not supported
+      break;
+    case SAI_ATTR_VALUE_TYPE_MAC:
+      sai_thrift_mac_t_parse(thrift_attr.value.mac, &sai_attr->value.mac);
+      break;
+    case SAI_ATTR_VALUE_TYPE_IPV4:
+      sai_thrift_ip4_t_parse(thrift_attr.value.ip4, &sai_attr->value.ip4);
+      break;
+    case SAI_ATTR_VALUE_TYPE_IPV6:
+      sai_thrift_ip6_t_parse(thrift_attr.value.ip6, sai_attr->value.ip6);
+      break;
+    case SAI_ATTR_VALUE_TYPE_IP_ADDRESS:
+      sai_thrift_ip_address_t_parse(thrift_attr.value.ipaddr,
+                                    &sai_attr->value.ipaddr);
+      break;
+    case SAI_ATTR_VALUE_TYPE_IP_PREFIX:
+      sai_thrift_ip_prefix_t_parse(thrift_attr.value.ipprefix,
+                                   &sai_attr->value.ipprefix);
+      break;
+    case SAI_ATTR_VALUE_TYPE_OBJECT_ID:
+      sai_attr->value.oid = thrift_attr.value.oid;
+      break;
+    case SAI_ATTR_VALUE_TYPE_OBJECT_LIST: {
+      sai_attr->value.objlist.list = (sai_object_id_t *)malloc(
+          sizeof(sai_object_id_t) * thrift_attr.value.objlist.count);
+      int i = 0;
+      for (auto obj : thrift_attr.value.objlist.idlist)
+        sai_attr->value.objlist.list[i++] = obj;
+      sai_attr->value.objlist.count = thrift_attr.value.objlist.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_UINT8_LIST: {
+      sai_attr->value.u8list.list =
+          (uint8_t *)malloc(sizeof(uint8_t) * thrift_attr.value.u8list.count);
+      int i = 0;
+      for (auto u8 : thrift_attr.value.u8list.uint8list)
+        sai_attr->value.u8list.list[i++] = u8;
+      sai_attr->value.u8list.count = thrift_attr.value.u8list.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_INT8_LIST: {
+      sai_attr->value.s8list.list =
+          (int8_t *)malloc(sizeof(int8_t) * thrift_attr.value.s8list.count);
+      int i = 0;
+      for (auto s8 : thrift_attr.value.s8list.int8list)
+        sai_attr->value.s8list.list[i++] = s8;
+      sai_attr->value.s8list.count = thrift_attr.value.s8list.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_UINT16_LIST: {
+      sai_attr->value.u16list.list = (uint16_t *)malloc(
+          sizeof(uint16_t) * thrift_attr.value.u16list.count);
+      int i = 0;
+      for (auto u16 : thrift_attr.value.u16list.uint16list)
+        sai_attr->value.u16list.list[i++] = u16;
+      sai_attr->value.u16list.count = thrift_attr.value.u16list.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_INT16_LIST: {
+      sai_attr->value.s16list.list =
+          (int16_t *)malloc(sizeof(int16_t) * thrift_attr.value.s16list.count);
+      int i = 0;
+      for (auto s16 : thrift_attr.value.s16list.int16list)
+        sai_attr->value.s16list.list[i++] = s16;
+      sai_attr->value.s16list.count = thrift_attr.value.s16list.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_UINT32_LIST: {
+      sai_attr->value.u32list.list = (uint32_t *)malloc(
+          sizeof(uint32_t) * thrift_attr.value.u32list.count);
+      int i = 0;
+      for (auto u32 : thrift_attr.value.u32list.uint32list)
+        sai_attr->value.u32list.list[i++] = u32;
+      sai_attr->value.u32list.count = thrift_attr.value.u32list.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_INT32_LIST: {
+      sai_attr->value.s32list.list =
+          (int32_t *)malloc(sizeof(int32_t) * thrift_attr.value.s32list.count);
+      int i = 0;
+      for (auto s32 : thrift_attr.value.s32list.int32list)
+        sai_attr->value.s32list.list[i++] = s32;
+      sai_attr->value.s32list.count = thrift_attr.value.s32list.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_UINT32_RANGE:
+      sai_attr->value.u32range.min = thrift_attr.value.u32range.min;
+      sai_attr->value.u32range.max = thrift_attr.value.u32range.max;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT32_RANGE:
+      sai_attr->value.s32range.min = thrift_attr.value.s32range.min;
+      sai_attr->value.s32range.max = thrift_attr.value.s32range.max;
+      break;
+
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_BOOL:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.booldata =
+          thrift_attr.value.aclfield.data.booldata;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.u8 = thrift_attr.value.aclfield.data.u8;
+      sai_attr->value.aclfield.mask.u8 = thrift_attr.value.aclfield.mask.u8;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_INT8:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.s8 = thrift_attr.value.aclfield.data.s8;
+      sai_attr->value.aclfield.mask.s8 = thrift_attr.value.aclfield.mask.s8;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT16:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.u16 = thrift_attr.value.aclfield.data.u16;
+      sai_attr->value.aclfield.mask.u16 = thrift_attr.value.aclfield.mask.u16;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_INT16:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.s16 = thrift_attr.value.aclfield.data.s16;
+      sai_attr->value.aclfield.mask.s16 = thrift_attr.value.aclfield.mask.s16;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT32:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.u32 = thrift_attr.value.aclfield.data.u32;
+      sai_attr->value.aclfield.mask.u32 = thrift_attr.value.aclfield.mask.u32;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_INT32:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.s32 = thrift_attr.value.aclfield.data.s32;
+      sai_attr->value.aclfield.mask.s32 = thrift_attr.value.aclfield.mask.s32;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_MAC:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_thrift_mac_t_parse(thrift_attr.value.aclfield.data.mac,
+                             &sai_attr->value.aclfield.data.mac);
+      sai_thrift_mac_t_parse(thrift_attr.value.aclfield.mask.mac,
+                             &sai_attr->value.aclfield.mask.mac);
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_IPV4:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_thrift_ip4_t_parse(thrift_attr.value.aclfield.data.ip4,
+                             &sai_attr->value.aclfield.data.ip4);
+      sai_thrift_ip4_t_parse(thrift_attr.value.aclfield.mask.ip4,
+                             &sai_attr->value.aclfield.mask.ip4);
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_IPV6:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_thrift_ip6_t_parse(thrift_attr.value.aclfield.data.ip6,
+                             sai_attr->value.aclfield.data.ip6);
+      sai_thrift_ip6_t_parse(thrift_attr.value.aclfield.mask.ip6,
+                             sai_attr->value.aclfield.mask.ip6);
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_OBJECT_ID:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.oid = thrift_attr.value.aclfield.data.oid;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_OBJECT_LIST: {
+      int i = 0;
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.objlist.list = (sai_object_id_t *)malloc(
+          sizeof(sai_object_id_t) *
+          thrift_attr.value.aclfield.data.objlist.count);
+      for (auto obj : thrift_attr.value.aclfield.data.objlist.idlist)
+        sai_attr->value.aclfield.data.objlist.list[i++] = obj;
+      sai_attr->value.aclfield.data.objlist.count =
+          thrift_attr.value.aclfield.data.objlist.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST: {
+      int i = 0;
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.u8list.list = (uint8_t *)malloc(
+          sizeof(uint8_t) * thrift_attr.value.aclfield.data.u8list.count);
+      for (auto obj : thrift_attr.value.aclfield.data.u8list.uint8list)
+        sai_attr->value.aclfield.data.u8list.list[i++] = obj;
+      sai_attr->value.aclfield.data.u8list.count =
+          thrift_attr.value.aclfield.data.u8list.count;
+      i = 0;
+      sai_attr->value.aclfield.mask.u8list.list = (uint8_t *)malloc(
+          sizeof(uint8_t) * thrift_attr.value.aclfield.mask.u8list.count);
+      for (auto obj : thrift_attr.value.aclfield.mask.u8list.uint8list)
+        sai_attr->value.aclfield.mask.u8list.list[i++] = obj;
+      sai_attr->value.aclfield.mask.u8list.count =
+          thrift_attr.value.aclfield.mask.u8list.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_BOOL:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.booldata =
+          thrift_attr.value.aclaction.parameter.booldata;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_UINT8:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.u8 =
+          thrift_attr.value.aclaction.parameter.u8;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_INT8:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.s8 =
+          thrift_attr.value.aclaction.parameter.s8;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_UINT16:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.u16 =
+          thrift_attr.value.aclaction.parameter.u16;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_INT16:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.s16 =
+          thrift_attr.value.aclaction.parameter.s16;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_UINT32:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.u32 =
+          thrift_attr.value.aclaction.parameter.u32;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_INT32:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.s32 =
+          thrift_attr.value.aclaction.parameter.s32;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_MAC:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_thrift_mac_t_parse(thrift_attr.value.aclaction.parameter.mac,
+                             &sai_attr->value.aclaction.parameter.mac);
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_IPV4:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_thrift_ip4_t_parse(thrift_attr.value.aclaction.parameter.ip4,
+                             &sai_attr->value.aclaction.parameter.ip4);
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_IPV6:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_thrift_ip6_t_parse(thrift_attr.value.aclaction.parameter.ip6,
+                             sai_attr->value.aclaction.parameter.ip6);
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_IP_ADDRESS:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_thrift_ip_address_t_parse(
+          thrift_attr.value.aclaction.parameter.ipaddr,
+          &sai_attr->value.aclaction.parameter.ipaddr);
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_ID:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.oid =
+          thrift_attr.value.aclaction.parameter.oid;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_LIST: {
+      int i = 0;
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.objlist.list =
+          (sai_object_id_t *)malloc(
+              sizeof(sai_object_id_t) *
+              thrift_attr.value.aclaction.parameter.objlist.count);
+      for (auto obj : thrift_attr.value.aclaction.parameter.objlist.idlist)
+        sai_attr->value.aclaction.parameter.objlist.list[i++] = obj;
+      sai_attr->value.aclaction.parameter.objlist.count =
+          thrift_attr.value.aclaction.parameter.objlist.count;
+    } break;
+
+    case SAI_ATTR_VALUE_TYPE_ACL_CAPABILITY: {
+      sai_attr->value.aclcapability.is_action_list_mandatory =
+          thrift_attr.value.aclcapability.is_action_list_mandatory;
+      sai_attr->value.aclcapability.action_list.list = (int32_t *)malloc(
+          sizeof(int32_t) * thrift_attr.value.aclcapability.action_list.count);
+      int i = 0;
+      for (auto s32 : thrift_attr.value.aclcapability.action_list.int32list)
+        sai_attr->value.aclcapability.action_list.list[i++] = s32;
+      sai_attr->value.aclcapability.action_list.count =
+          thrift_attr.value.aclcapability.action_list.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_ACL_RESOURCE_LIST: {
+      sai_attr->value.aclresource.list = (sai_acl_resource_t *)malloc(
+          sizeof(sai_acl_resource_t) * thrift_attr.value.aclresource.count);
+      int i = 0;
+      for (auto resource : thrift_attr.value.aclresource.resourcelist) {
+        sai_attr->value.aclresource.list[i].stage =
+            static_cast<sai_acl_stage_t>(resource.stage);
+        sai_attr->value.aclresource.list[i].bind_point =
+            static_cast<sai_acl_bind_point_type_t>(resource.bind_point);
+        sai_attr->value.aclresource.list[i++].avail_num = resource.avail_num;
+      }
+      sai_attr->value.aclresource.count = thrift_attr.value.aclresource.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST: {
+      sai_attr->value.ipaddrlist.list = (sai_ip_address_t *)malloc(
+          sizeof(sai_ip_address_t) * thrift_attr.value.ipaddrlist.count);
+      int i = 0;
+      for (auto address : thrift_attr.value.ipaddrlist.addresslist) {
+        sai_thrift_ip_address_t_parse(address,
+                                      &sai_attr->value.ipaddrlist.list[i++]);
+      }
+      sai_attr->value.ipaddrlist.count = thrift_attr.value.ipaddrlist.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_MAP_LIST:
+    case SAI_ATTR_VALUE_TYPE_VLAN_LIST:
+    case SAI_ATTR_VALUE_TYPE_QOS_MAP_LIST: {
+      sai_attr->value.qosmap.list = (sai_qos_map_t *)malloc(
+          sizeof(sai_qos_map_t) * thrift_attr.value.qosmap.count);
+      int i = 0;
+      for (auto qosmap : thrift_attr.value.qosmap.maplist) {
+        // key
+        sai_attr->value.qosmap.list[i].key.tc = qosmap.key.tc;
+        sai_attr->value.qosmap.list[i].key.dscp = qosmap.key.dscp;
+        sai_attr->value.qosmap.list[i].key.dot1p = qosmap.key.dot1p;
+        sai_attr->value.qosmap.list[i].key.prio = qosmap.key.prio;
+        sai_attr->value.qosmap.list[i].key.pg = qosmap.key.pg;
+        sai_attr->value.qosmap.list[i].key.queue_index = qosmap.key.queue_index;
+        sai_attr->value.qosmap.list[i].key.color =
+            static_cast<sai_packet_color_t>(qosmap.key.color);
+        sai_attr->value.qosmap.list[i].key.mpls_exp = qosmap.key.mpls_exp;
+        // value
+        sai_attr->value.qosmap.list[i].value.tc = qosmap.value.tc;
+        sai_attr->value.qosmap.list[i].value.dscp = qosmap.value.dscp;
+        sai_attr->value.qosmap.list[i].value.dot1p = qosmap.value.dot1p;
+        sai_attr->value.qosmap.list[i].value.prio = qosmap.value.prio;
+        sai_attr->value.qosmap.list[i].value.pg = qosmap.value.pg;
+        sai_attr->value.qosmap.list[i].value.queue_index =
+            qosmap.value.queue_index;
+        sai_attr->value.qosmap.list[i].value.color =
+            static_cast<sai_packet_color_t>(qosmap.value.color);
+        sai_attr->value.qosmap.list[i].value.mpls_exp = qosmap.value.mpls_exp;
+        i++;
+      }
+      sai_attr->value.qosmap.count = thrift_attr.value.qosmap.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_TLV_LIST:
+    case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
+    case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
+    case SAI_ATTR_VALUE_TYPE_TIMESPEC:
+    case SAI_ATTR_VALUE_TYPE_NAT_ENTRY_DATA:
+      break;
+    default:
+      break;
+  }
+}
+
+std::string sai_ip4_t_to_thrift(const sai_ip4_t ip4) {
+  char str[INET_ADDRSTRLEN];
+  inet_ntop(AF_INET, &(ip4), str, INET_ADDRSTRLEN);
+  return str;
+}
+
+std::string sai_ip6_t_to_thrift(const sai_ip6_t ip6) {
+  char str[INET6_ADDRSTRLEN];
+  inet_ntop(AF_INET6, ip6, str, INET6_ADDRSTRLEN);
+  return str;
+}
+
+void sai_ip_address_t_to_thrift(sai_thrift_ip_address_t &thrift_ip,
+                                const sai_ip_address_t ip) {
+  if (ip.addr_family == SAI_IP_ADDR_FAMILY_IPV4) {
+    thrift_ip.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    thrift_ip.addr.ip4 = sai_ip4_t_to_thrift(ip.addr.ip4);
+  } else if (ip.addr_family == SAI_IP_ADDR_FAMILY_IPV6) {
+    thrift_ip.addr_family = SAI_IP_ADDR_FAMILY_IPV6;
+    thrift_ip.addr.ip6 = sai_ip6_t_to_thrift(ip.addr.ip6);
+  }
+}
+
+void sai_ip_prefix_t_to_thrift(sai_thrift_ip_prefix_t &thrift_ip,
+                               const sai_ip_prefix_t ip) {
+  if (ip.addr_family == SAI_IP_ADDR_FAMILY_IPV4) {
+    thrift_ip.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    thrift_ip.addr.ip4 = sai_ip4_t_to_thrift(ip.addr.ip4);
+    thrift_ip.mask.ip4 = sai_ip4_t_to_thrift(ip.mask.ip4);
+  } else if (ip.addr_family == SAI_IP_ADDR_FAMILY_IPV6) {
+    thrift_ip.addr_family = SAI_IP_ADDR_FAMILY_IPV6;
+    thrift_ip.addr.ip6 = sai_ip6_t_to_thrift(ip.addr.ip6);
+    thrift_ip.mask.ip6 = sai_ip6_t_to_thrift(ip.mask.ip6);
+  }
+}
+
+void sai_thrift_nat_type_t_parse(const sai_thrift_nat_type_t &thrift_nat_type,
+                                 sai_nat_type_t *nat_type) {
+  *nat_type = (sai_nat_type_t)thrift_nat_type;
+}
+
+void convert_attr_sai_to_thrift(const sai_object_type_t sai_ot,
+                                const sai_attribute_t &sai_attr,
+                                sai_thrift_attribute_t &thrift_attr) {
+  const auto attr_md = sai_metadata_get_attr_metadata(sai_ot, sai_attr.id);
+  thrift_attr.id = sai_attr.id;
+
+  if (attr_md == NULL) {
+    return;
+  }
+
+  switch (attr_md->attrvaluetype) {
+    case SAI_ATTR_VALUE_TYPE_BOOL:
+      thrift_attr.value.booldata = sai_attr.value.booldata;
+      break;
+    case SAI_ATTR_VALUE_TYPE_CHARDATA:
+      thrift_attr.value.chardata = sai_attr.value.chardata;
+      break;
+    case SAI_ATTR_VALUE_TYPE_UINT8:
+      thrift_attr.value.u8 = sai_attr.value.u8;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT8:
+      thrift_attr.value.s8 = sai_attr.value.s8;
+      break;
+    case SAI_ATTR_VALUE_TYPE_UINT16:
+      thrift_attr.value.u16 = sai_attr.value.u16;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT16:
+      thrift_attr.value.s16 = sai_attr.value.s16;
+      break;
+    case SAI_ATTR_VALUE_TYPE_UINT32:
+      thrift_attr.value.u32 = sai_attr.value.u32;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT32:
+      thrift_attr.value.s32 = sai_attr.value.s32;
+      break;
+    case SAI_ATTR_VALUE_TYPE_UINT64:
+      thrift_attr.value.u64 = sai_attr.value.u64;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT64:
+      thrift_attr.value.s64 = sai_attr.value.s64;
+      break;
+    case SAI_ATTR_VALUE_TYPE_POINTER:
+      // not supported
+      break;
+    case SAI_ATTR_VALUE_TYPE_MAC: {
+      char mac_str[18];
+      snprintf(mac_str,
+               sizeof(mac_str),
+               "%02x:%02x:%02x:%02x:%02x:%02x",
+               sai_attr.value.mac[0],
+               sai_attr.value.mac[1],
+               sai_attr.value.mac[2],
+               sai_attr.value.mac[3],
+               sai_attr.value.mac[4],
+               sai_attr.value.mac[5]);
+      thrift_attr.value.mac = mac_str;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_IPV4:
+      thrift_attr.value.ip4 = sai_ip4_t_to_thrift(sai_attr.value.ip4);
+      break;
+    case SAI_ATTR_VALUE_TYPE_IPV6:
+      thrift_attr.value.ip6 = sai_ip6_t_to_thrift(sai_attr.value.ip6);
+      break;
+    case SAI_ATTR_VALUE_TYPE_IP_ADDRESS:
+      sai_ip_address_t_to_thrift(thrift_attr.value.ipaddr,
+                                 sai_attr.value.ipaddr);
+      break;
+    case SAI_ATTR_VALUE_TYPE_IP_PREFIX:
+      sai_ip_prefix_t_to_thrift(thrift_attr.value.ipprefix,
+                                sai_attr.value.ipprefix);
+      break;
+    case SAI_ATTR_VALUE_TYPE_OBJECT_ID:
+      thrift_attr.value.oid = sai_attr.value.oid;
+      break;
+    case SAI_ATTR_VALUE_TYPE_OBJECT_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.objlist.count; i++) {
+        thrift_attr.value.objlist.idlist.push_back(
+            sai_attr.value.objlist.list[i]);
+      }
+      thrift_attr.value.objlist.count = sai_attr.value.objlist.count;
+      free(sai_attr.value.objlist.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_UINT8_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.u8list.count; i++)
+        thrift_attr.value.u8list.uint8list.push_back(
+            sai_attr.value.u8list.list[i]);
+      thrift_attr.value.u8list.count = sai_attr.value.u8list.count;
+      free(sai_attr.value.u8list.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_INT8_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.s8list.count; i++)
+        thrift_attr.value.s8list.int8list.push_back(
+            sai_attr.value.s8list.list[i]);
+      thrift_attr.value.s8list.count = sai_attr.value.s8list.count;
+      free(sai_attr.value.s8list.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_UINT16_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.u16list.count; i++)
+        thrift_attr.value.u16list.uint16list.push_back(
+            sai_attr.value.u16list.list[i]);
+      thrift_attr.value.u16list.count = sai_attr.value.u16list.count;
+      free(sai_attr.value.u16list.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_INT16_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.s16list.count; i++)
+        thrift_attr.value.s16list.int16list.push_back(
+            sai_attr.value.s16list.list[i]);
+      thrift_attr.value.s16list.count = sai_attr.value.s16list.count;
+      free(sai_attr.value.s16list.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_UINT32_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.u32list.count; i++)
+        thrift_attr.value.u32list.uint32list.push_back(
+            sai_attr.value.u32list.list[i]);
+      thrift_attr.value.u32list.count = sai_attr.value.u32list.count;
+      free(sai_attr.value.u32list.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_INT32_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.s32list.count; i++)
+        thrift_attr.value.s32list.int32list.push_back(
+            sai_attr.value.s32list.list[i]);
+      thrift_attr.value.s32list.count = sai_attr.value.s32list.count;
+      free(sai_attr.value.s32list.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_UINT32_RANGE:
+      thrift_attr.value.u32range.min = sai_attr.value.u32range.min;
+      thrift_attr.value.u32range.max = sai_attr.value.u32range.max;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT32_RANGE:
+      thrift_attr.value.s32range.min = sai_attr.value.s32range.min;
+      thrift_attr.value.s32range.max = sai_attr.value.s32range.max;
+      break;
+
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_BOOL:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_INT8:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT16:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_INT16:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT32:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_INT32:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_MAC:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_IPV4:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_IPV6:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_OBJECT_ID:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_OBJECT_LIST:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_BOOL:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_UINT8:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_INT8:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_UINT16:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_INT16:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_UINT32:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_INT32:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_MAC:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_IPV4:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_IPV6:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_IP_ADDRESS:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_ID:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_LIST:
+      // TODO(bfn)
+      break;
+
+    case SAI_ATTR_VALUE_TYPE_ACL_CAPABILITY: {
+      for (unsigned int i = 0;
+           i < sai_attr.value.aclcapability.action_list.count;
+           i++) {
+        thrift_attr.value.aclcapability.action_list.int32list.push_back(
+            sai_attr.value.aclcapability.action_list.list[i]);
+      }
+      thrift_attr.value.aclcapability.action_list.count =
+          sai_attr.value.aclcapability.action_list.count;
+      free(sai_attr.value.aclcapability.action_list.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_ACL_RESOURCE_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.aclresource.count; i++) {
+        sai_thrift_acl_resource_t resource = {};
+        resource.stage = sai_attr.value.aclresource.list[i].stage;
+        resource.bind_point = sai_attr.value.aclresource.list[i].bind_point;
+        resource.avail_num = sai_attr.value.aclresource.list[i].avail_num;
+        thrift_attr.value.aclresource.resourcelist.push_back(resource);
+      }
+      thrift_attr.value.aclresource.count = sai_attr.value.aclresource.count;
+      free(sai_attr.value.aclresource.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.ipaddrlist.count; i++) {
+        sai_thrift_ip_address_t thrift_ip;
+        sai_ip_address_t_to_thrift(thrift_ip,
+                                   sai_attr.value.ipaddrlist.list[i]);
+        thrift_attr.value.ipaddrlist.addresslist.push_back(thrift_ip);
+      }
+      thrift_attr.value.ipaddrlist.count = sai_attr.value.ipaddrlist.count;
+      free(sai_attr.value.ipaddrlist.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_MAP_LIST:
+    case SAI_ATTR_VALUE_TYPE_VLAN_LIST:
+    case SAI_ATTR_VALUE_TYPE_QOS_MAP_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.qosmap.count; i++) {
+        sai_thrift_qos_map_t thrift_qos_map;
+        // key
+        thrift_qos_map.key.tc = sai_attr.value.qosmap.list[i].key.tc;
+        thrift_qos_map.key.dscp = sai_attr.value.qosmap.list[i].key.dscp;
+        thrift_qos_map.key.dot1p = sai_attr.value.qosmap.list[i].key.dot1p;
+        thrift_qos_map.key.prio = sai_attr.value.qosmap.list[i].key.prio;
+        thrift_qos_map.key.pg = sai_attr.value.qosmap.list[i].key.pg;
+        thrift_qos_map.key.queue_index =
+            sai_attr.value.qosmap.list[i].key.queue_index;
+        thrift_qos_map.key.color =
+            static_cast<int32_t>(sai_attr.value.qosmap.list[i].key.color);
+        thrift_qos_map.key.mpls_exp =
+            sai_attr.value.qosmap.list[i].key.mpls_exp;
+        // value
+        thrift_qos_map.value.tc = sai_attr.value.qosmap.list[i].value.tc;
+        thrift_qos_map.value.dscp = sai_attr.value.qosmap.list[i].value.dscp;
+        thrift_qos_map.value.dot1p = sai_attr.value.qosmap.list[i].value.dot1p;
+        thrift_qos_map.value.prio = sai_attr.value.qosmap.list[i].value.prio;
+        thrift_qos_map.value.pg = sai_attr.value.qosmap.list[i].value.pg;
+        thrift_qos_map.value.queue_index =
+            sai_attr.value.qosmap.list[i].value.queue_index;
+        thrift_qos_map.value.color =
+            static_cast<int32_t>(sai_attr.value.qosmap.list[i].value.color);
+        thrift_qos_map.value.mpls_exp =
+            sai_attr.value.qosmap.list[i].value.mpls_exp;
+        thrift_attr.value.qosmap.maplist.push_back(thrift_qos_map);
+      }
+      thrift_attr.value.qosmap.count = sai_attr.value.qosmap.count;
+      free(sai_attr.value.qosmap.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_TLV_LIST:
+    case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
+    case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
+    case SAI_ATTR_VALUE_TYPE_TIMESPEC:
+    case SAI_ATTR_VALUE_TYPE_NAT_ENTRY_DATA:
+      break;
+    default:
+      break;
+  }
+}
+
+// very hacky but this means we never have to modify the generated file
+#include "generated/sai_rpc_server.cpp"
+
+class sai_rpcHandlerFrontend : virtual public sai_rpcHandler {
+  int64_t sai_thrift_object_type_get_availability(
+      const sai_thrift_object_type_t object_type,
+      const sai_thrift_attr_id_t attr_id,
+      const int32_t attr_type) {
+    sai_attribute_t attr = {};
+    attr.id = attr_id;
+    attr.value.s32 = attr_type;
+    uint64_t count = 0;
+
+    sai_object_type_get_availability(
+        switch_id, (sai_object_type_t)object_type, 1, &attr, &count);
+    return count;
+  }
+
+  void sai_thrift_query_attribute_enum_values_capability(
+      std::vector<int32_t> &thrift_enum_caps,
+      const sai_thrift_object_type_t object_type,
+      const sai_thrift_attr_id_t attr_id,
+      const int32_t caps_count) {
+    sai_status_t status = SAI_STATUS_SUCCESS;
+    sai_s32_list_t enum_values_capability;
+    int32_t *caps_list = NULL;
+
+    if (!caps_count) {
+      return;
+    }
+    caps_list = (int32_t *)malloc(sizeof(int32_t) * caps_count);
+    if (!caps_list) {
+      return;
+    }
+    enum_values_capability.list = caps_list;
+    enum_values_capability.count = caps_count;
+    status = sai_query_attribute_enum_values_capability(
+        (sai_object_id_t)switch_id,
+        (sai_object_type_t)object_type,
+        (sai_attr_id_t)attr_id,
+        &enum_values_capability);
+    if (SAI_STATUS_SUCCESS != status) {
+      free(caps_list);
+      return;
+    }
+
+    for (uint32_t i = 0; i < enum_values_capability.count; ++i) {
+      thrift_enum_caps.push_back(enum_values_capability.list[i]);
+    }
+    free(caps_list);
+  }
+};
+
+static pthread_mutex_t cookie_mutex;
+static pthread_cond_t cookie_cv;
+static void *cookie;
+
+static void *sai_thrift_rpc_server_thread(void *arg) {
+  int port = *(int *)arg;
+  std::shared_ptr<sai_rpcHandlerFrontend> handler(new sai_rpcHandlerFrontend());
+  std::shared_ptr<TProcessor> processor(new sai_rpcProcessor(handler));
+  std::shared_ptr<TServerTransport> serverTransport(new TServerSocket(port));
+  std::shared_ptr<TTransportFactory> transportFactory(
+      new TBufferedTransportFactory());
+  std::shared_ptr<TProtocolFactory> protocolFactory(
+      new TBinaryProtocolFactory());
+
+  TSimpleServer server(
+      processor, serverTransport, transportFactory, protocolFactory);
+  pthread_mutex_lock(&cookie_mutex);
+  cookie = (void *)processor.get();
+  pthread_cond_signal(&cookie_cv);
+  pthread_mutex_unlock(&cookie_mutex);
+  server.serve();
+  return 0;
+}
+
+static pthread_t sai_thrift_rpc_thread;
+
+extern "C" {
+int start_p4_sai_thrift_rpc_server(char *port) {
+  static int *param = (int *)malloc(sizeof(int));
+  *param = atoi(port);
+  std::cerr << "Starting SAI RPC server on port " << port << std::endl;
+
+  cookie = NULL;
+  int status = pthread_create(
+      &sai_thrift_rpc_thread, NULL, sai_thrift_rpc_server_thread, param);
+  if (status) return status;
+  pthread_mutex_lock(&cookie_mutex);
+  while (!cookie) {
+    pthread_cond_wait(&cookie_cv, &cookie_mutex);
+  }
+  pthread_mutex_unlock(&cookie_mutex);
+  pthread_mutex_destroy(&cookie_mutex);
+  pthread_cond_destroy(&cookie_cv);
+  return status;
+}
+
+int stop_p4_sai_thrift_rpc_server(void) {
+  int status = pthread_cancel(sai_thrift_rpc_thread);
+  if (status == 0) {
+    int s = pthread_join(sai_thrift_rpc_thread, NULL);
+    if (s) return s;
+  }
+  return status;
+}
+}

--- a/ptf/platform_helper/bfn_sai_helper.py
+++ b/ptf/platform_helper/bfn_sai_helper.py
@@ -1,0 +1,9 @@
+import sys
+sys.path.append("..")
+from  sai_base_test import *
+
+class BfnSaiHelper(SaiHelper):
+    platform = 'bfn'
+    
+    def recreate_ports(self):
+        print("BfnSaiHelper::recreate_ports")  

--- a/ptf/platform_helper/brcm_sai_helper.py
+++ b/ptf/platform_helper/brcm_sai_helper.py
@@ -1,0 +1,25 @@
+import sys
+sys.path.append("..")
+from  sai_base_test import *
+
+class BrcmSaiHelper(SaiHelper):
+    platform = 'brcm'
+    
+    def recreate_ports(self):
+        print("BrcmSaiHelperBase::recreate_ports does not support.") 
+
+
+    def check_cpu_port_hdl(self, num_queues):
+        for queue in range(0, num_queues):
+            queue_id = attr['qos_queue_list'].idlist[queue]
+            setattr(self, 'cpu_queue%s' % queue, queue_id)
+            q_attr = sai_thrift_get_queue_attribute(
+                self.client,
+                queue_id,
+                port=True,
+                index=True,
+                parent_scheduler_node=True)
+            self.assertTrue(queue == q_attr['index'])
+            #in broadcom platform, the q_attr["port"] is not equals to cpu_port_hdl
+            # cpu_port_hdl is ahead of the cpu_port list
+            self.cpu_port = q_attr["port"]

--- a/ptf/platform_helper/common_sai_helper.py
+++ b/ptf/platform_helper/common_sai_helper.py
@@ -1,0 +1,6 @@
+import sys
+sys.path.append("..")
+from  sai_base_test import *
+
+class CommonSaiHelper(SaiHelper):
+    platform = 'common'

--- a/ptf/platform_helper/mlnx_sai_helper.py
+++ b/ptf/platform_helper/mlnx_sai_helper.py
@@ -1,0 +1,7 @@
+import sys
+sys.path.append("..")
+from  sai_base_test import *
+
+
+class MlnxSaiHelper(SaiHelper):
+    platform = 'mlnx'

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -127,7 +127,6 @@ class ThriftInterfaceDataPlane(ThriftInterface):
         super(ThriftInterfaceDataPlane, self).setUp()
 
         self.dataplane = ptf.dataplane_instance
-        self.removeCpuPort()
         if self.dataplane is not None:
             self.dataplane.flush()
             if config['log_dir'] is not None:

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -384,58 +384,17 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
             setattr(self, 'dev_port%d' % dev_no, port)
             dev_no += 1
 
-    def printNumberOfAvaiableResources(self):
+    def printNumberOfAvaiableResources(self, resources_dict):
         """
         Prints numbers of available resources
+
+        Args:
+            resources_dict (dict): a dictionary with resources numbers
         """
         print("***** Number of available resources *****")
 
-        print("available_ipv4_route_entry %d"
-              % self.available_ipv4_route_entry)
-        print("available_ipv6_route_entry %d"
-              % self.available_ipv6_route_entry)
-        print("available_ipv4_nexthop_entry %d"
-              % self.available_ipv4_nexthop_entry)
-        print("available_ipv6_nexthop_entry %d"
-              % self.available_ipv6_nexthop_entry)
-        print("available_ipv4_neighbor_entry %d"
-              % self.available_ipv4_neighbor_entry)
-        print("available_ipv6_neighbor_entry %d"
-              % self.available_ipv6_neighbor_entry)
-        print("available_next_hop_group_entry %d"
-              % self.available_next_hop_group_entry)
-        print("available_next_hop_group_member_entry %d"
-              % self.available_next_hop_group_member_entry)
-        print("available_fdb_entry %d"
-              % self.available_fdb_entry)
-        print("available_l2mc_entry %d"
-              % self.available_l2mc_entry)
-        print("available_ipmc_entry %d"
-              % self.available_ipmc_entry)
-        print("available_snat_entry %d"
-              % self.available_snat_entry)
-        print("available_dnat_entry %d"
-              % self.available_dnat_entry)
-        print("available_double_nat_entry %d"
-              % self.available_double_nat_entry)
-        print("available_acl_table %d"
-              % self.available_acl_table)
-        print("available_acl_table_group %d"
-              % self.available_acl_table_group)
-        print("available_my_sid_entry %d"
-              % self.available_my_sid_entry)
-        print("available_snapt_entry %d"
-              % self.available_snapt_entry)
-        print("available_dnapt_entry %d"
-              % self.available_dnapt_entry)
-        print("available_double_napt_entry %d"
-              % self.available_double_napt_entry)
-        print("available_my_mac_entries %d"
-              % self.available_my_mac_entries)
-        print("number_of_ecmp_groups %d"
-              % self.number_of_ecmp_groups)
-        print("ecmp_members %d"
-              % self.ecmp_members)
+        for key, value in resources_dict:
+            print(key, ": ", value)
 
     def saveNumberOfAvaiableResources(self, debug=False):
         """

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -92,8 +92,8 @@ class ThriftInterface(BaseTest):
             user_input = self.test_params['port_map_file']
             with open(user_input, 'r') as map_file:
                 for line in map_file:
-                    if (line and
-                        (line[0] == '#' or line[0] == ';' or line[0] == '/')):
+                    if (line and (line[0] == '#' or
+                                  line[0] == ';' or line[0] == '/')):
                         continue
                     iface_front_pair = line.split("@")
                     self.interface_to_front_mapping[iface_front_pair[0]] =  \
@@ -299,19 +299,19 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         Parse port_config.ini file
 
         Example of supported format for port_config.ini:
-        # name          lanes         alias       index    speed    autoneg   fec
-        Ethernet0         0           Ethernet0       1    25000      off     none
-        Ethernet1         1           Ethernet1       1    25000      off     none
-        Ethernet2         2           Ethernet2       1    25000      off     none
-        Ethernet3         3           Ethernet3       1    25000      off     none
-        Ethernet4         4           Ethernet4       2    25000      off     none
-        Ethernet5         5           Ethernet5       2    25000      off     none
-        Ethernet6         6           Ethernet6       2    25000      off     none
-        Ethernet7         7           Ethernet7       2    25000      off     none
-        Ethernet8         8           Ethernet8       3    25000      off     none
-        Ethernet9         9           Ethernet9       3    25000      off     none
-        Ethernet10        10          Ethernet10      3    25000      off     none
-        Ethernet11        11          Ethernet11      3    25000      off     none
+        # name        lanes       alias       index    speed    autoneg   fec
+        Ethernet0       0         Ethernet0     1      25000      off     none
+        Ethernet1       1         Ethernet1     1      25000      off     none
+        Ethernet2       2         Ethernet2     1      25000      off     none
+        Ethernet3       3         Ethernet3     1      25000      off     none
+        Ethernet4       4         Ethernet4     2      25000      off     none
+        Ethernet5       5         Ethernet5     2      25000      off     none
+        Ethernet6       6         Ethernet6     2      25000      off     none
+        Ethernet7       7         Ethernet7     2      25000      off     none
+        Ethernet8       8         Ethernet8     3      25000      off     none
+        Ethernet9       9         Ethernet9     3      25000      off     none
+        Ethernet10      10        Ethernet10    3      25000      off     none
+        Ethernet11      11        Ethernet11    3      25000      off     none
         etc
 
         Args:
@@ -342,7 +342,7 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
                             continue
                         data[titles[i]] = item
                     data['lanes'] = [int(lane)
-                                    for lane in data['lanes'].split(',')]
+                                     for lane in data['lanes'].split(',')]
                     data['speed'] = int(data['speed'])
                     ports[name] = data
             return ports
@@ -391,8 +391,8 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         Args:
             resources_dict (dict): a dictionary with resources numbers
         """
-        print("***** Number of available resources *****")
 
+        print("***** Number of available resources *****")
         for key, value in resources_dict:
             print(key, ": ", value)
 
@@ -418,23 +418,15 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
             available_next_hop_group_entry=True,
             available_next_hop_group_member_entry=True,
             available_fdb_entry=True,
-            available_l2mc_entry=True,
             available_ipmc_entry=True,
             available_snat_entry=True,
             available_dnat_entry=True,
             available_double_nat_entry=True,
-            available_acl_table=True,
-            available_acl_table_group=True,
-            available_my_sid_entry=True,
-            available_snapt_entry=True,
-            available_dnapt_entry=True,
-            available_double_napt_entry=True,
-            available_my_mac_entries=True,
             number_of_ecmp_groups=True,
             ecmp_members=True)
 
         if debug:
-            self.printNumberOfAvaiableResources()
+            self.printNumberOfAvaiableResources(switch_resources)
 
         return switch_resources
 
@@ -461,18 +453,10 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
             available_next_hop_group_entry=True,
             available_next_hop_group_member_entry=True,
             available_fdb_entry=True,
-            available_l2mc_entry=True,
             available_ipmc_entry=True,
             available_snat_entry=True,
             available_dnat_entry=True,
             available_double_nat_entry=True,
-            available_acl_table=True,
-            available_acl_table_group=True,
-            available_my_sid_entry=True,
-            available_snapt_entry=True,
-            available_dnapt_entry=True,
-            available_double_napt_entry=True,
-            available_my_mac_entries=True,
             number_of_ecmp_groups=True,
             ecmp_members=True)
 
@@ -795,7 +779,7 @@ Common ports configuration:
             vlan_id=self.vlan30,
             bridge_port_id=self.lag5_bp,
             vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
-        self.vlan_member_list.append(self.vlan30_member1)
+        self.vlan_member_list.append(self.vlan30_member2)
 
         # setup untagged ports
         sai_thrift_set_port_attribute(self.client, self.port0, port_vlan_id=10)
@@ -860,14 +844,18 @@ Common ports configuration:
         self.rif_list.append(self.port13_rif)
 
     def tearDown(self):
+        sai_thrift_set_port_attribute(self.client, self.port2, port_vlan_id=0)
+        sai_thrift_set_lag_attribute(self.client, self.lag1, port_vlan_id=0)
+        sai_thrift_set_port_attribute(self.client, self.port0, port_vlan_id=0)
+
         for rif in self.rif_list:
             sai_thrift_remove_router_interface(self.client, rif)
 
         for vlan_member in self.vlan_member_list:
             sai_thrift_remove_vlan_member(self.client, vlan_member)
 
-        for vlan in self.vlan_list:
-            sai_thrift_remove_vlan(self.client, vlan)
+        for bridge_port in self.bridge_port_list:
+            sai_thrift_remove_bridge_port(self.client, bridge_port)
 
         for lag_member in self.lag_member_list:
             sai_thrift_remove_lag_member(self.client, lag_member)
@@ -875,8 +863,8 @@ Common ports configuration:
         for lag in self.lag_list:
             sai_thrift_remove_lag(self.client, lag)
 
-        for bridge_port in self.bridge_port_list:
-            sai_thrift_remove_bridge_port(self.client, bridge_port)
+        for vlan in self.vlan_list:
+            sai_thrift_remove_vlan(self.client, vlan)
 
         super(SaiHelper, self).tearDown()
 
@@ -904,7 +892,7 @@ class MinimalPortVlanConfig(SaiHelperBase):
         if self.port_num > self.active_ports_no:
             raise ValueError('Number of ports to configure %d is higher '
                              'than number of active ports %d'
-                             %(self.port_num, self.active_ports_no))
+                             % (self.port_num, self.active_ports_no))
 
         self.bridge_port_list = []
         self.vlan_member_list = []

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -1,0 +1,1203 @@
+"""
+Base classes for test cases
+
+Tests will usually inherit from one of these classes to have the controller
+and/or dataplane automatically set up.
+"""
+
+from __future__ import print_function
+
+import os
+import time
+import socket
+import struct
+
+from collections import OrderedDict
+from functools import wraps
+
+import ptf
+from ptf import config
+from ptf.base_tests import BaseTest
+import ptf.testutils as testutils
+from ptf.packet import *
+
+from thrift.transport import TSocket
+from thrift.transport import TTransport
+from thrift.protocol import TBinaryProtocol
+
+import sai_thrift.sai_rpc as sai_rpc
+
+# Import both adapter module and all its functions
+import sai_adapter as adapter
+from sai_utils import *
+
+################################################################
+#
+# Thrift interface base tests
+#
+################################################################
+
+ROUTER_MAC = '00:77:66:55:44:00'
+
+
+class ThriftInterface(BaseTest):
+    """
+    The class gets and formats a port map and creates an RPC client.
+
+    Sets the following class attributes:
+        self.transport
+        self.protocol
+        self.client
+        self.test_params
+
+    Removes objects created in setup
+    """
+
+    def loadPortMap(self):
+        """
+        Method to get and format portmap
+        """
+        if self.port_map_loaded:
+            print('port_map already loaded')
+            return
+
+        if "port_map" in self.test_params:
+            user_input = self.test_params['port_map']
+            splitted_map = user_input.split(",")
+            for item in splitted_map:
+                interface_front_pair = item.split("@")
+                self.interface_to_front_mapping[interface_front_pair[0]] =  \
+                    interface_front_pair[1]
+        elif "port_map_file" in self.test_params:
+            user_input = self.test_params['port_map_file']
+            map_file = open(user_input, 'r')
+            for line in map_file:
+                if (line and (
+                        line[0] == '#' or line[0] == ';' or line[0] == '/')):
+                    continue
+                interface_front_pair = line.split("@")
+                self.interface_to_front_mapping[interface_front_pair[0]] =  \
+                    interface_front_pair[1].strip()
+
+        self.port_map_loaded = True
+
+        return
+
+    def createRpcClient(self):
+        """
+        Set up thrift client and contact server
+        """
+
+        if "thrift_server" in self.test_params:
+            server = self.test_params['thrift_server']
+        else:
+            server = 'localhost'
+
+        self.transport = TSocket.TSocket(server, 9092)
+        self.transport = TTransport.TBufferedTransport(self.transport)
+        self.protocol = TBinaryProtocol.TBinaryProtocol(self.transport)
+
+        self.client = sai_rpc.Client(self.protocol)
+        self.transport.open()
+        return
+
+    def setUp(self):
+        self.interface_to_front_mapping = {}
+        self.port_map_loaded = False
+        BaseTest.setUp(self)
+        self.test_params = testutils.test_params_get()
+        self.loadPortMap()
+        self.createRpcClient()
+        return
+
+    def tearDown(self):
+        BaseTest.tearDown(self)
+        self.transport.close()
+
+
+class ThriftInterfaceDataPlane(ThriftInterface):
+    """
+    Root class that sets up the thrift interface and dataplane
+    """
+
+    def removeCpuPort(self):
+        """
+        Remove CPU port from port map
+        """
+        test_params = testutils.test_params_get()
+        for _, port, _ in config["interfaces"]:
+            if test_params['arch'] == "tofino2":
+                if port == 320:
+                    continue
+                if port == 2:
+                    self.dataplane.port_remove(0, port)
+                    ptf.config["port_map"].pop((0, port), None)
+                    continue
+            else:
+                if port == 64 or port == 320:
+                    self.dataplane.port_remove(0, port)
+                    ptf.config["port_map"].pop((0, port), None)
+                    continue
+
+    def setUp(self):
+        ThriftInterface.setUp(self)
+        self.dataplane = ptf.dataplane_instance
+        self.removeCpuPort()
+        if self.dataplane is not None:
+            self.dataplane.flush()
+            if config["log_dir"] is not None:
+                filename = os.path.join(config["log_dir"], str(self)) + ".pcap"
+                self.dataplane.start_pcap(filename)
+
+    def tearDown(self):
+        if config["log_dir"] is not None:
+            self.dataplane.stop_pcap()
+        ThriftInterface.tearDown(self)
+
+
+def parse_port_config(port_config_file):
+    '''
+    Parses port_config.ini file.
+
+    Example of supported format for port_config.ini:
+    # name          lanes         alias       index    speed    autoneg   fec
+    Ethernet0         0           Ethernet0       1    25000      off     none
+    Ethernet1         1           Ethernet1       1    25000      off     none
+    Ethernet2         2           Ethernet2       1    25000      off     none
+    Ethernet3         3           Ethernet3       1    25000      off     none
+    Ethernet4         4           Ethernet4       2    25000      off     none
+    Ethernet5         5           Ethernet5       2    25000      off     none
+    Ethernet6         6           Ethernet6       2    25000      off     none
+    Ethernet7         7           Ethernet7       2    25000      off     none
+    Ethernet8         8           Ethernet8       3    25000      off     none
+    Ethernet9         9           Ethernet9       3    25000      off     none
+    Ethernet10        10          Ethernet10      3    25000      off     none
+    Ethernet11        11          Ethernet11      3    25000      off     none
+    etc
+
+    Args:
+        port_config_file (string): path to port config file
+
+    Returns:
+        dict: port configuation from file
+
+    Raises:
+        e: exit if file not found
+    '''
+    ports = OrderedDict()
+    try:
+        with open(port_config_file) as conf:
+            for line in conf:
+                if line.startswith('#'):
+                    if "name" in line:
+                        titles = line.strip('#').split()
+                    continue
+                tokens = line.split()
+                if len(tokens) < 2:
+                    continue
+                name_index = titles.index('name')
+                name = tokens[name_index]
+                data = {}
+                for i, item in enumerate(tokens):
+                    if i == name_index:
+                        continue
+                    data[titles[i]] = item
+                data['lanes'] = [int(lane)
+                                 for lane in data['lanes'].split(',')]
+                data['speed'] = int(data['speed'])
+                ports[name] = data
+        return ports
+    except Exception as e:
+        raise e
+
+
+class SaiHelperBase(ThriftInterfaceDataPlane):
+    '''
+    SAI test helper base class without initial common switch setup.
+
+    Sets the following class attributes:
+        self.default_vlan_id
+        self.default_vrf
+        self.default_1q_bridge
+        self.cpu_port_hdl
+        self.acl_stage_ingress
+        self.self.acl_stage_egress
+        self.active_ports - number of active ports
+        self.port_list - list of all active port objects
+        self.portX objects for all active ports
+    '''
+
+    def setUp(self):
+        ThriftInterfaceDataPlane.setUp(self)
+        self.getSwitchPorts()
+
+        # Initialize switch
+        self.switch_id = sai_thrift_create_switch(
+            self.client, init_switch=True, src_mac_address=ROUTER_MAC)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.saveNumberOfAvaiableResources()
+
+        # get default vlan
+        attr = sai_thrift_get_switch_attribute(
+            self.client, default_vlan_id=True)
+        self.default_vlan_id = attr['default_vlan_id']
+
+        if 'port_config_ini' in self.test_params:
+            if 'createPorts_has_been_called' not in config:
+                self.createPorts()
+                # check if ports became UP
+                # self.checkPortsUp()
+                config['createPorts_has_been_called'] = 1
+
+        # get number of active ports
+        attr = sai_thrift_get_switch_attribute(
+            self.client, number_of_active_ports=True)
+        self.active_ports = attr['number_of_active_ports']
+
+        # get port list
+        attr = sai_thrift_get_switch_attribute(
+            self.client, port_list=sai_thrift_object_list_t(
+                idlist=[], count=self.active_ports))
+        self.assertEqual(self.active_ports, attr['port_list'].count)
+        self.port_list = attr['port_list'].idlist
+        for index in range(0, len(self.port_list)):
+            setattr(self, 'port%s' % index, self.port_list[index])
+
+        # get default vrf
+        attr = sai_thrift_get_switch_attribute(
+            self.client, default_virtual_router_id=True)
+        self.default_vrf = attr['default_virtual_router_id']
+        self.assertTrue(self.default_vrf != 0)
+
+        # get default 1Q bridge OID
+        attr = sai_thrift_get_switch_attribute(
+            self.client, default_1q_bridge_id=True)
+        self.default_1q_bridge = attr['default_1q_bridge_id']
+        self.assertTrue(self.default_1q_bridge != 0)
+
+        # get cpu port
+        attr = sai_thrift_get_switch_attribute(self.client, cpu_port=True)
+        self.cpu_port_hdl = attr['cpu_port']
+        self.assertTrue(self.cpu_port_hdl != 0)
+
+        # get cpu port queue handles
+        attr = sai_thrift_get_port_attribute(self.client,
+                                             self.cpu_port_hdl,
+                                             qos_number_of_queues=True)
+        num_queues = attr["qos_number_of_queues"]
+        q_list = sai_thrift_object_list_t(count=num_queues)
+        attr = sai_thrift_get_port_attribute(self.client,
+                                             self.cpu_port_hdl,
+                                             qos_queue_list=q_list)
+        for queue in range(0, num_queues):
+            queue_id = attr["qos_queue_list"].idlist[queue]
+            setattr(self, 'cpu_queue%s' % queue, queue_id)
+            q_attr = sai_thrift_get_queue_attribute(
+                self.client,
+                queue_id,
+                port=True,
+                index=True,
+                parent_scheduler_node=True)
+            self.assertTrue(queue == q_attr["index"])
+            self.assertTrue(self.cpu_port_hdl == q_attr["port"])
+
+        # get ACL capability
+        attr = sai_thrift_get_switch_attribute(
+            self.client, max_acl_action_count=True)
+        max_acl_action_count = attr['max_acl_action_count']
+        s32 = sai_thrift_s32_list_t(int32list=[], count=max_acl_action_count)
+        cap = sai_thrift_acl_capability_t(action_list=s32)
+        attr = sai_thrift_get_switch_attribute(
+            self.client, acl_stage_ingress=cap)
+        self.acl_stage_ingress = \
+            attr['acl_stage_ingress'].action_list.int32list
+        self.assertTrue(len(self.acl_stage_ingress) != 0)
+        attr = sai_thrift_get_switch_attribute(
+            self.client, acl_stage_egress=cap)
+        self.acl_stage_egress = attr['acl_stage_egress'].action_list.int32list
+        self.assertTrue(len(self.acl_stage_egress) != 0)
+
+    def createPorts(self):
+        """
+        Create ports after reading from port config file
+        """
+
+        def fec_str_to_int(fec):
+            """
+            Convert fec string to SAI enum
+
+            Args:
+                fec (string): fec string from port_config
+
+            Returns:
+                int: SAI enum value
+            """
+            fec_dict = {
+                'rs': SAI_PORT_FEC_MODE_RS,
+                'fc': SAI_PORT_FEC_MODE_FC
+            }
+            return fec_dict.get(fec, SAI_PORT_FEC_MODE_NONE)
+
+        # delete the existing ports
+        attr = sai_thrift_get_switch_attribute(
+            self.client, number_of_active_ports=True)
+        self.active_ports = attr['number_of_active_ports']
+        attr = sai_thrift_get_switch_attribute(
+            self.client, port_list=sai_thrift_object_list_t(
+                idlist=[], count=self.active_ports))
+        if self.active_ports:
+            self.port_list = attr['port_list'].idlist
+            for port in self.port_list:
+                sai_thrift_remove_port(self.client, port)
+
+        # add new ports from port config file
+        self.ports_config = parse_port_config(
+            self.test_params['port_config_ini'])
+        for name, port in self.ports_config.items():
+            print("Creating port: %s" % name)
+            fec_mode = fec_str_to_int(port.get('fec', None))
+            auto_neg_mode = True if port.get(
+                'autoneg', "").lower() == "on" else False
+            sai_list = sai_thrift_u32_list_t(
+                count=len(port['lanes']), uint32list=port['lanes'])
+            sai_thrift_create_port(
+                self.client,
+                hw_lane_list=sai_list,
+                fec_mode=fec_mode,
+                auto_neg_mode=auto_neg_mode,
+                speed=port['speed'],
+                admin_state=True)
+
+    def checkPortsUp(self):
+        '''
+        Wait for all ports to be UP
+        '''
+
+        for _ in range(1, 5):
+            allup = True
+            for port in self.port_list:
+                attr = sai_thrift_get_port_attribute(
+                    self.client, port, oper_status=True)
+                if attr['oper_status'] != SAI_SWITCH_OPER_STATUS_UP:
+                    allup = False
+                    break
+            if allup:
+                break
+            time.sleep(10)
+        self.assertTrue(allup)
+
+    def tearDown(self):
+        try:
+            for port in self.port_list:
+                sai_thrift_clear_port_stats(self.client, port)
+                sai_thrift_set_port_attribute(
+                    self.client, port, port_vlan_id=0)
+
+            self.assertEqual(True, self.verifyNumberOfAvaiableResources(
+                debug=False))
+
+        finally:
+            ThriftInterfaceDataPlane.tearDown(self)
+
+    def getSwitchPorts(self):
+        """
+        Gets device port numbers
+        """
+        test_params = testutils.test_params_get()
+        dev_no = 0
+        cpu_no = 0
+        for _, port, _ in config["interfaces"]:
+            if test_params['arch'] == "tofino2":
+                if port == 320:
+                    continue
+                if port == 2:
+                    setattr(self, 'cpu_port%d' % cpu_no, port)
+                    cpu_no += 1
+                    continue
+            else:
+                if port == 64 or port == 320:
+                    setattr(self, 'cpu_port%d' % cpu_no, port)
+                    cpu_no += 1
+                    continue
+
+            setattr(self, 'dev_port%d' % dev_no, port)
+            dev_no += 1
+
+    def printNumberOfAvaiableResources(self):
+        """
+        Prints numbers of available resources
+        """
+        try:
+            print("***** Number of available resources")
+            print("self.available_next_hop_group_entry=",
+                  self.available_next_hop_group_entry)
+            print("self.available_next_hop_group_member_entry=",
+                  self.available_next_hop_group_member_entry)
+            print("self.available_ipv4_nexthop_entry=",
+                  self.available_ipv4_nexthop_entry)
+            print("self.available_ipv6_nexthop_entry=",
+                  self.available_ipv6_nexthop_entry)
+            print("self.available_fdb_entry=", self.available_fdb_entry)
+            print("self.available_ipv6_route_entry=",
+                  self.available_ipv6_route_entry)
+            print("self.available_ipv4_route_entry=",
+                  self.available_ipv4_route_entry)
+        finally:
+            pass
+
+    def saveNumberOfAvaiableResources(self, debug=False):
+        """
+        Saves numbers of available resources
+
+        Args:
+            debug (boolean): enables debug option
+        """
+        if debug:
+            print("saveNumberOfAvaiableResources")
+        try:
+            attr_list = sai_thrift_get_switch_attribute(
+                self.client,
+                number_of_ecmp_groups=True,
+                ecmp_members=True,
+                available_next_hop_group_entry=True,
+                available_next_hop_group_member_entry=True,
+                available_ipv6_nexthop_entry=True,
+                available_ipv4_nexthop_entry=True,
+                available_fdb_entry=True,
+                available_ipv6_route_entry=True,
+                available_ipv4_route_entry=True)
+            self.available_next_hop_group_entry = attr_list[
+                "SAI_SWITCH_ATTR_AVAILABLE_NEXT_HOP_GROUP_ENTRY"]
+            self.available_next_hop_group_member_entry = attr_list[
+                "SAI_SWITCH_ATTR_AVAILABLE_NEXT_HOP_GROUP_MEMBER_ENTRY"]
+            self.available_ipv4_nexthop_entry = attr_list[
+                "SAI_SWITCH_ATTR_AVAILABLE_IPV4_NEXTHOP_ENTRY"]
+            self.available_ipv6_nexthop_entry = attr_list[
+                "SAI_SWITCH_ATTR_AVAILABLE_IPV6_NEXTHOP_ENTRY"]
+            self.available_fdb_entry = attr_list[
+                "SAI_SWITCH_ATTR_AVAILABLE_FDB_ENTRY"]
+            self.available_ipv6_route_entry = attr_list[
+                "SAI_SWITCH_ATTR_AVAILABLE_IPV6_ROUTE_ENTRY"]
+            self.available_ipv4_route_entry = attr_list[
+                "SAI_SWITCH_ATTR_AVAILABLE_IPV4_ROUTE_ENTRY"]
+            if debug:
+                self.printNumberOfAvaiableResources()
+        finally:
+            pass
+
+    def verifyNumberOfAvaiableResources(self, debug=False):
+        """
+        Verifies numbers of available resources
+
+        Args:
+            debug (boolean): enables debug option
+
+        Returns:
+            boolean: verification result
+        """
+        result = True
+        try:
+            attr_list = sai_thrift_get_switch_attribute(
+                self.client,
+                number_of_ecmp_groups=True,
+                ecmp_members=True,
+                available_next_hop_group_entry=True,
+                available_next_hop_group_member_entry=True,
+                available_ipv6_nexthop_entry=True,
+                available_ipv4_nexthop_entry=True,
+                available_fdb_entry=True,
+                available_ipv6_route_entry=True,
+                available_ipv4_route_entry=True)
+            available_next_hop_group_entry = attr_list[
+                "SAI_SWITCH_ATTR_AVAILABLE_NEXT_HOP_GROUP_ENTRY"]
+            available_next_hop_group_member_entry = attr_list[
+                "SAI_SWITCH_ATTR_AVAILABLE_NEXT_HOP_GROUP_MEMBER_ENTRY"]
+            available_ipv4_nexthop_entry = attr_list[
+                "SAI_SWITCH_ATTR_AVAILABLE_IPV4_NEXTHOP_ENTRY"]
+            available_ipv6_nexthop_entry = attr_list[
+                "SAI_SWITCH_ATTR_AVAILABLE_IPV6_NEXTHOP_ENTRY"]
+            available_fdb_entry = attr_list[
+                "SAI_SWITCH_ATTR_AVAILABLE_FDB_ENTRY"]
+            available_ipv6_route_entry = attr_list[
+                "SAI_SWITCH_ATTR_AVAILABLE_IPV6_ROUTE_ENTRY"]
+            available_ipv4_route_entry = attr_list[
+                "SAI_SWITCH_ATTR_AVAILABLE_IPV4_ROUTE_ENTRY"]
+
+            resources_dict = {
+                "available_next_hop_group_entry": [
+                    available_next_hop_group_entry,
+                    self.available_next_hop_group_entry],
+                "available_next_hop_group_member_entry": [
+                    available_next_hop_group_member_entry,
+                    self.available_next_hop_group_member_entry],
+                "available_ipv4_nexthop_entry": [
+                    available_ipv4_nexthop_entry,
+                    self.available_ipv4_nexthop_entry],
+                "available_ipv6_nexthop_entry": [
+                    available_ipv6_nexthop_entry,
+                    self.available_ipv6_nexthop_entry],
+                "available_fdb_entry": [
+                    available_fdb_entry,
+                    self.available_fdb_entry],
+                "available_ipv6_route_entry": [
+                    available_ipv6_route_entry,
+                    self.available_ipv6_route_entry],
+                "available_ipv4_route_entry": [
+                    available_ipv4_route_entry,
+                    self.available_ipv4_route_entry]}
+
+            for key in resources_dict:
+                if (resources_dict[key][0] !=
+                        resources_dict[key][1]):
+                    if debug:
+                        print(key,
+                              " != ",
+                              available_next_hop_group_entry[key][0])
+                    result = False
+                    break
+
+            if debug:
+                if result:
+                    print("Number of resources OK")
+                else:
+                    print("Number of resources NOT OK")
+
+        finally:
+            pass
+
+        return result
+
+    @staticmethod
+    def status():
+        """
+        Returns the last operation status.
+
+        Returns:
+            int: sai call result
+        """
+        return adapter.status
+
+
+class SaiHelper(SaiHelperBase):
+    """
+    Sets common base configuration for tests
+
+    Common configuration:
+    +------------+------------+-----------+-----------+
+    |    Name    |   Vlan ID  |  Ports    |  Tagging  |
+    +============+============+===========+===========+
+    |   vlan10   |     10     |   port0   |  untagged |
+    |            |            |   port1   |    tagged |
+    |            |            |    lag1   |  untagged |
+    +------------+------------+-----------+-----------+
+    |   vlan20   |     20     |   port2   |  untagged |
+    |            |            |   port3   |    tagged |
+    |            |            |    lag2   |    tagged |
+    +------------+------------+-----------+-----------+
+    |    lag1    |     --     |   port4   |     --    |
+    |            |            |   port5   |           |
+    |            |            |   port6   |           |
+    +------------+------------+-----------+-----------+
+    |    lag2    |     --     |   port7   |     --    |
+    |            |            |   port8   |           |
+    |            |            |   port9   |           |
+    +------------+------------+-----------+-----------+
+    | port10_rif |     --     |  port10   |     --    |
+    +------------+------------+-----------+-----------+
+    | port11_rif |     --     |  port11   |     --    |
+    +------------+------------+-----------+-----------+
+    | port12_rif |     --     |  port12   |     --    |
+    +------------+------------+-----------+-----------+
+    | port13_rif |     --     |  port13   |     --    |
+    +------------+------------+-----------+-----------+
+    |    lag3    |     --     |  port14   |     --    |
+    |  lag3_rif  |            |  port15   |           |
+    |            |            |  port16   |           |
+    +------------+------------+-----------+-----------+
+    |    lag4    |     --     |  port17   |     --    |
+    |  lag4_rif  |            |  port18   |           |
+    |            |            |  port19   |           |
+    +------------+------------+-----------+-----------+
+    |   vlan30   |     30     |  port20   |  untagged |
+    | vlan30_rif |            |  port21   |    tagged |
+    |            |            |    lag5   |    tagged |
+    +------------+------------+-----------+-----------+
+    |    lag5    |     --     |  port22   |     --    |
+    |            |            |  port23   |           |
+    +------------+------------+-----------+-----------+
+    | Additional |     --     |  port24   |     --    |
+    |    ports   |            |  port25   |           |
+    |            |            |  port26   |           |
+    |            |            |  port27   |           |
+    |            |            |  port28   |           |
+    |            |            |  port29   |           |
+    |            |            |  port30   |           |
+    |            |            |  port31   |           |
+    +------------+------------+-----------+-----------+
+    """
+
+    def setUp(self):
+        SaiHelperBase.setUp(self)
+
+        # create bridge ports
+        self.port0_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.port0,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertTrue(self.port0_bp != 0)
+        self.port1_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.port1,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertTrue(self.port1_bp != 0)
+        self.port2_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.port2,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertTrue(self.port2_bp != 0)
+        self.port3_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.port3,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertTrue(self.port3_bp != 0)
+        self.port20_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.port20,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertTrue(self.port20_bp != 0)
+        self.port21_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.port21,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertTrue(self.port21_bp != 0)
+
+        # create LAGs
+        self.lag1 = sai_thrift_create_lag(self.client)
+        self.assertTrue(self.lag1 != 0)
+        self.lag1_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.lag1,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertTrue(self.lag1_bp != 0)
+        self.lag1_member4 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag1, port_id=self.port4)
+        self.lag1_member5 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag1, port_id=self.port5)
+        self.lag1_member6 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag1, port_id=self.port6)
+
+        self.lag2 = sai_thrift_create_lag(self.client)
+        self.assertTrue(self.lag2 != 0)
+        self.lag2_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.lag2,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertTrue(self.lag2_bp != 0)
+        self.lag2_member7 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag2, port_id=self.port7)
+        self.lag2_member8 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag2, port_id=self.port8)
+        self.lag2_member9 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag2, port_id=self.port9)
+
+        # L3 lags
+        self.lag3 = sai_thrift_create_lag(self.client)
+        self.assertTrue(self.lag3 != 0)
+        self.lag3_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.lag3,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertTrue(self.lag3_bp != 0)
+        self.lag3_member14 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag3, port_id=self.port14)
+        self.lag3_member15 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag3, port_id=self.port15)
+        self.lag3_member16 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag3, port_id=self.port16)
+
+        self.lag4 = sai_thrift_create_lag(self.client)
+        self.assertTrue(self.lag4 != 0)
+        self.lag4_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.lag4,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertTrue(self.lag4_bp != 0)
+        self.lag4_member17 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag4, port_id=self.port17)
+        self.lag4_member18 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag4, port_id=self.port18)
+        self.lag4_member19 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag4, port_id=self.port19)
+
+        self.lag5 = sai_thrift_create_lag(self.client)
+        self.assertTrue(self.lag5 != 0)
+        self.lag5_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.lag5,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertTrue(self.lag5_bp != 0)
+        self.lag5_member22 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag5, port_id=self.port22)
+        self.lag5_member23 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag5, port_id=self.port23)
+
+        # create vlan 10 with port0, port1 and lag1
+        self.vlan10 = sai_thrift_create_vlan(self.client, vlan_id=10)
+        self.assertTrue(self.vlan10 != 0)
+        self.vlan10_member0 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan10,
+            bridge_port_id=self.port0_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        self.vlan10_member1 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan10,
+            bridge_port_id=self.port1_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
+        self.vlan10_member2 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan10,
+            bridge_port_id=self.lag1_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
+
+        # create vlan 20 with port2, port3 and lag2
+        self.vlan20 = sai_thrift_create_vlan(self.client, vlan_id=20)
+        self.assertTrue(self.vlan20 != 0)
+        self.vlan20_member0 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan20,
+            bridge_port_id=self.port2_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        self.vlan20_member1 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan20,
+            bridge_port_id=self.port3_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
+        self.vlan20_member2 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan20,
+            bridge_port_id=self.lag2_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
+
+        # create vlan 30 with port20, port21 and lag5
+        self.vlan30 = sai_thrift_create_vlan(self.client, vlan_id=30)
+        self.assertTrue(self.vlan30 != 0)
+        self.vlan30_member0 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan30,
+            bridge_port_id=self.port20_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        self.vlan30_member1 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan30,
+            bridge_port_id=self.port21_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
+        self.vlan30_member2 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan30,
+            bridge_port_id=self.lag5_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
+
+        # setup untagged ports
+        sai_thrift_set_port_attribute(self.client, self.port0, port_vlan_id=10)
+        sai_thrift_set_lag_attribute(self.client, self.lag1, port_vlan_id=10)
+        sai_thrift_set_port_attribute(self.client, self.port2, port_vlan_id=20)
+
+        # create L3 configuration
+        self.vlan30_rif = sai_thrift_create_router_interface(
+            self.client,
+            type=SAI_ROUTER_INTERFACE_TYPE_VLAN,
+            virtual_router_id=self.default_vrf,
+            vlan_id=self.vlan30)
+        self.assertTrue(self.vlan30_rif != 0)
+
+        self.lag3_rif = sai_thrift_create_router_interface(
+            self.client,
+            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+            virtual_router_id=self.default_vrf,
+            port_id=self.lag3)
+        self.assertTrue(self.lag3_rif != 0)
+
+        self.lag4_rif = sai_thrift_create_router_interface(
+            self.client,
+            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+            virtual_router_id=self.default_vrf,
+            port_id=self.lag4)
+        self.assertTrue(self.lag4_rif != 0)
+
+        self.port10_rif = sai_thrift_create_router_interface(
+            self.client,
+            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+            virtual_router_id=self.default_vrf,
+            port_id=self.port10)
+        self.assertTrue(self.port10_rif != 0)
+
+        self.port11_rif = sai_thrift_create_router_interface(
+            self.client,
+            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+            virtual_router_id=self.default_vrf,
+            port_id=self.port11)
+        self.assertTrue(self.port11_rif != 0)
+
+        self.port12_rif = sai_thrift_create_router_interface(
+            self.client,
+            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+            virtual_router_id=self.default_vrf,
+            port_id=self.port12)
+        self.assertTrue(self.port12_rif != 0)
+
+        self.port13_rif = sai_thrift_create_router_interface(
+            self.client,
+            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+            virtual_router_id=self.default_vrf,
+            port_id=self.port13)
+        self.assertTrue(self.port13_rif != 0)
+
+    @staticmethod
+    def saiWaitFdbAge(timeout):
+        """ sai_wait_fdb_age() - Wait for fdb entry to ageout
+
+        Args:
+            timeout (int): Timeout value in seconds
+        """
+        print("Waiting for fdb entry to Age")
+        aging_interval_buffer = 10
+        time.sleep(timeout + aging_interval_buffer)
+
+    def tearDown(self):
+        sai_thrift_remove_router_interface(self.client, self.vlan30_rif)
+        sai_thrift_remove_router_interface(self.client, self.port10_rif)
+        sai_thrift_remove_router_interface(self.client, self.port11_rif)
+        sai_thrift_remove_router_interface(self.client, self.port12_rif)
+        sai_thrift_remove_router_interface(self.client, self.port13_rif)
+        sai_thrift_remove_router_interface(self.client, self.lag3_rif)
+        sai_thrift_remove_router_interface(self.client, self.lag4_rif)
+
+        sai_thrift_set_port_attribute(self.client, self.port2, port_vlan_id=0)
+        sai_thrift_set_lag_attribute(self.client, self.lag1, port_vlan_id=0)
+        sai_thrift_set_port_attribute(self.client, self.port0, port_vlan_id=0)
+
+        # remove vlan config
+        sai_thrift_remove_vlan_member(self.client, self.vlan30_member2)
+        sai_thrift_remove_vlan_member(self.client, self.vlan30_member1)
+        sai_thrift_remove_vlan_member(self.client, self.vlan30_member0)
+        sai_thrift_remove_vlan(self.client, self.vlan30)
+        sai_thrift_remove_vlan_member(self.client, self.vlan20_member2)
+        sai_thrift_remove_vlan_member(self.client, self.vlan20_member1)
+        sai_thrift_remove_vlan_member(self.client, self.vlan20_member0)
+        sai_thrift_remove_vlan(self.client, self.vlan20)
+        sai_thrift_remove_vlan_member(self.client, self.vlan10_member2)
+        sai_thrift_remove_vlan_member(self.client, self.vlan10_member1)
+        sai_thrift_remove_vlan_member(self.client, self.vlan10_member0)
+        sai_thrift_remove_vlan(self.client, self.vlan10)
+
+        # remove lag config
+        sai_thrift_remove_lag_member(self.client, self.lag5_member22)
+        sai_thrift_remove_lag_member(self.client, self.lag5_member23)
+        sai_thrift_remove_bridge_port(self.client, self.lag5_bp)
+        sai_thrift_remove_lag(self.client, self.lag5)
+        sai_thrift_remove_lag_member(self.client, self.lag4_member19)
+        sai_thrift_remove_lag_member(self.client, self.lag4_member18)
+        sai_thrift_remove_lag_member(self.client, self.lag4_member17)
+        sai_thrift_remove_bridge_port(self.client, self.lag4_bp)
+        sai_thrift_remove_lag(self.client, self.lag4)
+        sai_thrift_remove_lag_member(self.client, self.lag3_member16)
+        sai_thrift_remove_lag_member(self.client, self.lag3_member15)
+        sai_thrift_remove_lag_member(self.client, self.lag3_member14)
+        sai_thrift_remove_bridge_port(self.client, self.lag3_bp)
+        sai_thrift_remove_lag(self.client, self.lag3)
+        sai_thrift_remove_lag_member(self.client, self.lag2_member9)
+        sai_thrift_remove_lag_member(self.client, self.lag2_member8)
+        sai_thrift_remove_lag_member(self.client, self.lag2_member7)
+        sai_thrift_remove_bridge_port(self.client, self.lag2_bp)
+        sai_thrift_remove_lag(self.client, self.lag2)
+        sai_thrift_remove_lag_member(self.client, self.lag1_member6)
+        sai_thrift_remove_lag_member(self.client, self.lag1_member5)
+        sai_thrift_remove_lag_member(self.client, self.lag1_member4)
+        sai_thrift_remove_bridge_port(self.client, self.lag1_bp)
+        sai_thrift_remove_lag(self.client, self.lag1)
+
+        # remove bridge ports
+        sai_thrift_remove_bridge_port(self.client, self.port21_bp)
+        sai_thrift_remove_bridge_port(self.client, self.port20_bp)
+        sai_thrift_remove_bridge_port(self.client, self.port3_bp)
+        sai_thrift_remove_bridge_port(self.client, self.port2_bp)
+        sai_thrift_remove_bridge_port(self.client, self.port1_bp)
+        sai_thrift_remove_bridge_port(self.client, self.port0_bp)
+
+        SaiHelperBase.tearDown(self)
+
+
+class MinimalPortVlanConfig(SaiHelperBase):
+    '''
+    Minimal port and vlan configuration. Creates port_num bridge ports and adds
+    them to VLAN with vlan_id. Configures ports as untagged.
+    '''
+
+    def __init__(self, port_num, vlan_id=100):
+        '''
+        Args:
+            port_num (int): Number of ports to configure
+            vlan_id (int): ID of VLAN that will be created
+        '''
+        super(MinimalPortVlanConfig, self).__init__()
+
+        self.port_num = port_num
+        self.vlan_id = vlan_id
+
+    def setUp(self):
+        super(MinimalPortVlanConfig, self).setUp()
+
+        if self.port_num > self.active_ports:
+            raise ValueError('Number of ports to configure ({}) is higher '
+                             'than number of active ports ({})'.format(
+                                 self.port_num, self.active_ports))
+
+        self.bridge_port = []
+        self.vlan_member = []
+
+        # create bridge ports
+        for i in range(0, self.port_num):
+            bp = sai_thrift_create_bridge_port(
+                self.client, bridge_id=self.default_1q_bridge,
+                port_id=self.port_list[i], type=SAI_BRIDGE_PORT_TYPE_PORT,
+                admin_state=True)
+
+            self.assertGreater(bp, 0)
+            self.bridge_port.append(bp)
+
+        # create vlan
+        self.vlan = sai_thrift_create_vlan(self.client, vlan_id=self.vlan_id)
+        self.assertGreater(self.vlan, 0)
+
+        # add ports to vlan
+        for i in range(0, self.port_num):
+            vm = sai_thrift_create_vlan_member(
+                self.client, vlan_id=self.vlan,
+                bridge_port_id=self.bridge_port[i],
+                vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
+
+            self.assertGreater(vm, 0)
+            self.vlan_member.append(vm)
+
+        # setup untagged ports
+        for i in range(0, self.port_num):
+            status = sai_thrift_set_port_attribute(
+                self.client, self.port_list[i], port_vlan_id=self.vlan_id)
+
+            self.assertEqual(status, SAI_STATUS_SUCCESS)
+
+    def tearDown(self):
+        # revert untagged ports configuration
+        for i in range(0, self.port_num):
+            sai_thrift_set_port_attribute(
+                self.client, self.port_list[i], port_vlan_id=0)
+
+        # remove ports from vlan
+        for i in range(0, self.port_num):
+            sai_thrift_remove_vlan_member(self.client, self.vlan_member[i])
+
+        # remove vlan
+        sai_thrift_remove_vlan(self.client, self.vlan)
+
+        # remove bridge ports
+        for i in range(0, self.port_num):
+            sai_thrift_remove_bridge_port(self.client, self.bridge_port[i])
+
+        super(MinimalPortVlanConfig, self).tearDown()
+
+
+def sai_ipaddress(addr_str):
+    """
+    Sets SAI ip address parameters, assigns the appropriate type
+    to these parameters and returns a sai_thrift_ip_address_t struct
+    containing them
+
+    Args:
+        addr_str (str): SAI IP address
+
+    Returns:
+        sai_thrift_ip_address_t: object containing
+        family and addr parameters
+    """
+
+    if '.' in addr_str:
+        family = SAI_IP_ADDR_FAMILY_IPV4
+        addr = sai_thrift_ip_addr_t(ip4=addr_str)
+    if ':' in addr_str:
+        family = SAI_IP_ADDR_FAMILY_IPV6
+        addr = sai_thrift_ip_addr_t(ip6=addr_str)
+    ip_addr = sai_thrift_ip_address_t(addr_family=family, addr=addr)
+    return ip_addr
+
+
+def num_to_dotted_quad(number, ipv4=True):
+    """
+    Converts the ip address to the appropriate format
+
+    Args:
+        number (str): IP address in the form of a number
+        ipv4 (boolean): determines whether IPv4 address standard is handled
+
+    Returns:
+        str: formatted IP address
+    """
+    if ipv4 is True:
+        mask = (1 << 32) - (1 << 32 >> int(number))
+        return socket.inet_ntop(socket.AF_INET, struct.pack('>L', mask))
+
+    mask = (1 << 128) - (1 << 128 >> int(number))
+    i = 0
+    result = ''
+    for sign in str(hex(mask)[2:]):
+        if (i + 1) % 4 == 0:
+            result = result + sign + ':'
+        else:
+            result = result + sign
+        i += 1
+    return result[:-1]
+
+
+def sai_ipprefix(prefix_str):
+    """
+    Sets IP address prefix and mask and returns ip_prefix object
+
+    Args:
+        prefix_str (str): contains an IP address with mask
+
+    Return:
+        sai_thrift_ip_prefix_t: IP prefix object
+    """
+    addr_mask = prefix_str.split('/')
+    if len(addr_mask) != 2:
+        print('Invalid IP prefix format')
+        return None
+
+    if '.' in prefix_str:
+        family = SAI_IP_ADDR_FAMILY_IPV4
+        addr = sai_thrift_ip_addr_t(ip4=addr_mask[0])
+        mask = num_to_dotted_quad(addr_mask[1])
+        mask = sai_thrift_ip_addr_t(ip4=mask)
+    if ':' in prefix_str:
+        family = SAI_IP_ADDR_FAMILY_IPV6
+        addr = sai_thrift_ip_addr_t(ip6=addr_mask[0])
+        mask = num_to_dotted_quad(int(addr_mask[1]), ipv4=False)
+        mask = sai_thrift_ip_addr_t(ip6=mask)
+
+    ip_prefix = sai_thrift_ip_prefix_t(
+        addr_family=family, addr=addr, mask=mask)
+    return ip_prefix
+
+
+def delay_wrapper(func, delay=2):
+    """
+    A wrapper extending given function by a delay.
+
+    Args:
+        func (function): function to be wrapped
+        delay (int): delay period
+
+    Return:
+        wrapped_function: wrapped function
+    """
+    @wraps(func)
+    def wrapped_function(*args, **kwargs):
+        """
+        A wrapper function adding a delay.
+
+        Args:
+            args (tuple): function arguments
+            kwargs (dict): keyword function arguments
+
+        Return:
+            status: original function return value
+        """
+        test_params = testutils.test_params_get()
+        if test_params['target'] != "hw":
+            time.sleep(delay)
+
+        status = func(*args, **kwargs)
+        return status
+
+    return wrapped_function
+
+
+sai_thrift_flush_fdb_entries = delay_wrapper(sai_thrift_flush_fdb_entries)  # noqa pylint: disable=invalid-name
+
+
+def open_packet_socket(hostif_name):
+    """
+    Open a linux socket
+
+    Args:
+        hostif_name (str): socket interface name
+
+    Return:
+        sock: socket ID
+    """
+    eth_p_all = 3
+    sock = socket.socket(socket.AF_PACKET, socket.SOCK_RAW,
+                         socket.htons(eth_p_all))
+    sock.bind((hostif_name, eth_p_all))
+    sock.setblocking(0)
+    return sock
+
+
+def socket_verify_packet(pkt, sock, timeout=2):
+    """
+    Verify packet on a socket
+
+    Args:
+        pkt (packet): packet to match with
+        sock (int): socket ID
+        timeout (int): timeout
+
+    Return:
+        match: match or no
+    """
+    max_pkt_size = 9100
+    timeout = time.time() + timeout
+    match = False
+
+    if isinstance(pkt, ptf.mask.Mask):
+        if not pkt.is_valid():
+            return False
+
+    while time.time() < timeout:
+        try:
+            packet_from_tap_device = Ether(sock.recv(max_pkt_size))
+
+            if isinstance(pkt, ptf.mask.Mask):
+                match = pkt.pkt_match(packet_from_tap_device)
+            else:
+                match = (str(packet_from_tap_device) == str(pkt))
+
+            if match:
+                break
+
+        except BaseException:
+            pass
+
+    return match

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -40,9 +40,7 @@ from thrift.protocol import TBinaryProtocol
 
 from sai_thrift import sai_rpc
 
-# Import both adapter module and all its functions
-import sai_adapter as adapter
-from sai_utils import *
+from sai_adapter import *
 
 ROUTER_MAC = '00:77:66:55:44:00'
 THRIFT_PORT = 9092
@@ -536,7 +534,7 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         Returns:
             int: sai call result
         """
-        return adapter.status
+        return status
 
     @staticmethod
     def saiWaitFdbAge(timeout):

--- a/ptf/sai_utils.py
+++ b/ptf/sai_utils.py
@@ -16,8 +16,6 @@
 Thrift SAI interface basic utils.
 """
 
-from sai_adapter import *
-
 
 def sai_thrift_query_attribute_enum_values_capability(client,
                                                       obj_type,
@@ -65,58 +63,44 @@ def sai_thrift_object_type_get_availability(client,
     return availability_cnt
 
 
-def sai_thrift_get_port_stats_ext_overwrite(client,
-                                            port_oid,
-                                            counter_ids,
-                                            mode):
+def sai_thrift_get_debug_counter_port_stats(client, port_oid, counter_ids):
     """
-    sai_get_port_stats_ext() - RPC client function implementation.
-    WARNING: This function overwrites sai_adapter.py function and will be
-             removed when the sai_adapter.py function has been fixed.
+    Get port statistics for given debug counters
 
     Args:
         client (Client): SAI RPC client
-        port_oid(sai_thrift_object_id_t): object_id IN argument
-        counter_ids(sai_stat_id_t): list of requested counter ids
-        mode(sai_thrift_stats_mode_t): stats_mode IN argument
+        port_oid (sai_thrift_object_id_t): object_id IN argument
+        counter_ids (sai_stat_id_t): list of requested counters
 
     Returns:
         Dict[str, sai_thrift_uint64_t]: stats
     """
 
     stats = dict()
-    counters = client.sai_thrift_get_port_stats_ext(port_oid, counter_ids,
-                                                    mode)
+    counters = client.sai_thrift_get_port_stats(port_oid, counter_ids)
+
     for i, counter_id in enumerate(counter_ids):
         stats[counter_id] = counters[i]
 
     return stats
 
 
-sai_thrift_get_port_stats_ext = sai_thrift_get_port_stats_ext_overwrite
-
-
-def sai_thrift_get_switch_stats_ext_overwrite(client, counter_ids, mode):
+def sai_thrift_get_debug_counter_switch_stats(client, counter_ids):
     """
-    sai_get_switch_stats_ext() - RPC client function implementation.
-    WARNING: This function overwrites sai_adapter.py function and will be
-             removed when the sai_adapter.py function has been fixed.
+    Get switch statistics for given debug counters
 
     Args:
         client (Client): SAI RPC client
-        counter_ids(sai_stat_id_t): list of requested counter ids
-        mode(sai_thrift_stats_mode_t): stats_mode IN argument
+        counter_ids (sai_stat_id_t): list of requested counters
 
     Returns:
         Dict[str, sai_thrift_uint64_t]: stats
     """
 
     stats = dict()
-    counters = client.sai_thrift_get_switch_stats_ext(counter_ids, mode)
+    counters = client.sai_thrift_get_switch_stats(counter_ids)
+
     for i, counter_id in enumerate(counter_ids):
         stats[counter_id] = counters[i]
 
     return stats
-
-
-sai_thrift_get_switch_stats_ext = sai_thrift_get_switch_stats_ext_overwrite

--- a/ptf/sai_utils.py
+++ b/ptf/sai_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020-present Barefoot Networks, Inc.
+# Copyright 2021-present Intel Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,22 +16,23 @@
 Thrift SAI interface basic utils.
 """
 
-# pylint: disable=too-many-arguments,too-many-branches,line-too-long
-# pylint: disable=invalid-name
 from sai_adapter import *
 
 
 def sai_thrift_query_attribute_enum_values_capability(client,
                                                       obj_type,
-                                                      attr_id):
+                                                      attr_id=None):
     """
-    function calls the sai_thrift_query_attribute_enum_values_capability()
-    and returns the list of supported aattr_is enum capabilities
+    Call the sai_thrift_query_attribute_enum_values_capability() function
+    and return the list of supported aattr_is enum capabilities
+
     Args:
         client (Client): SAI RPC client
-        For the other parameters, see documentation.
+        obj_type (enum): SAI object type
+        attr_id (attr): SAI attribute name
+
     Returns:
-        list: list of switch object type enum capabilities.
+        list: list of switch object type enum capabilities
     """
 
     enum_cap_list = client.sai_thrift_query_attribute_enum_values_capability(
@@ -46,14 +47,16 @@ def sai_thrift_object_type_get_availability(client,
                                             attr_type=None):
     """
     sai_thrift_object_type_get_availability() RPC client function
-    implementation.
+    implementation
 
     Args:
         client (Client): SAI RPC client
-        For the other parameters, see documentation.
+        obj_type (enum): SAI object type
+        attr_id (attr): SAI attribute name
+        attr_type (type): SAI attribute type
 
     Returns:
-        uint: availability_cnt, object type switch availability counter.
+        uint: number of available resources with given parameters
     """
     availability_cnt = client.sai_thrift_object_type_get_availability(
         obj_type, attr_id, attr_type)
@@ -61,12 +64,14 @@ def sai_thrift_object_type_get_availability(client,
     return availability_cnt
 
 
-def sai_thrift_get_port_stats_ext_overwrite(client, port_oid, counter_ids,
+def sai_thrift_get_port_stats_ext_overwrite(client,
+                                            port_oid,
+                                            counter_ids,
                                             mode):
     """
     sai_get_port_stats_ext() - RPC client function implementation.
     WARNING: This function overwrites sai_adapter.py function and will be
-             removed when th sai_adapter.py function has been fixed.
+             removed when the sai_adapter.py function has been fixed.
 
     Args:
         client (Client): SAI RPC client

--- a/ptf/sai_utils.py
+++ b/ptf/sai_utils.py
@@ -1,0 +1,116 @@
+# Copyright 2020-present Barefoot Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Thrift SAI interface basic utils.
+"""
+
+# pylint: disable=too-many-arguments,too-many-branches,line-too-long
+# pylint: disable=invalid-name
+from sai_adapter import *
+
+
+def sai_thrift_query_attribute_enum_values_capability(client,
+                                                      obj_type,
+                                                      attr_id):
+    """
+    function calls the sai_thrift_query_attribute_enum_values_capability()
+    and returns the list of supported aattr_is enum capabilities
+    Args:
+        client (Client): SAI RPC client
+        For the other parameters, see documentation.
+    Returns:
+        list: list of switch object type enum capabilities.
+    """
+
+    enum_cap_list = client.sai_thrift_query_attribute_enum_values_capability(
+        obj_type, attr_id, 20)
+
+    return enum_cap_list
+
+
+def sai_thrift_object_type_get_availability(client,
+                                            obj_type,
+                                            attr_id=None,
+                                            attr_type=None):
+    """
+    sai_thrift_object_type_get_availability() RPC client function
+    implementation.
+
+    Args:
+        client (Client): SAI RPC client
+        For the other parameters, see documentation.
+
+    Returns:
+        uint: availability_cnt, object type switch availability counter.
+    """
+    availability_cnt = client.sai_thrift_object_type_get_availability(
+        obj_type, attr_id, attr_type)
+
+    return availability_cnt
+
+
+def sai_thrift_get_port_stats_ext_overwrite(client, port_oid, counter_ids,
+                                            mode):
+    """
+    sai_get_port_stats_ext() - RPC client function implementation.
+    WARNING: This function overwrites sai_adapter.py function and will be
+             removed when th sai_adapter.py function has been fixed.
+
+    Args:
+        client (Client): SAI RPC client
+        port_oid(sai_thrift_object_id_t): object_id IN argument
+        counter_ids(sai_stat_id_t): list of requested counter ids
+        mode(sai_thrift_stats_mode_t): stats_mode IN argument
+
+    Returns:
+        Dict[str, sai_thrift_uint64_t]: stats
+    """
+
+    stats = dict()
+    counters = client.sai_thrift_get_port_stats_ext(port_oid, counter_ids,
+                                                    mode)
+    for i, counter_id in enumerate(counter_ids):
+        stats[counter_id] = counters[i]
+
+    return stats
+
+
+sai_thrift_get_port_stats_ext = sai_thrift_get_port_stats_ext_overwrite
+
+
+def sai_thrift_get_switch_stats_ext_overwrite(client, counter_ids, mode):
+    """
+    sai_get_switch_stats_ext() - RPC client function implementation.
+    WARNING: This function overwrites sai_adapter.py function and will be
+             removed when th sai_adapter.py function has been fixed.
+
+    Args:
+        client (Client): SAI RPC client
+        counter_ids(sai_stat_id_t): list of requested counter ids
+        mode(sai_thrift_stats_mode_t): stats_mode IN argument
+
+    Returns:
+        Dict[str, sai_thrift_uint64_t]: stats
+    """
+
+    stats = dict()
+    counters = client.sai_thrift_get_switch_stats_ext(counter_ids, mode)
+    for i, counter_id in enumerate(counter_ids):
+        stats[counter_id] = counters[i]
+
+    return stats
+
+
+sai_thrift_get_switch_stats_ext = sai_thrift_get_switch_stats_ext_overwrite

--- a/ptf/sai_utils.py
+++ b/ptf/sai_utils.py
@@ -16,6 +16,18 @@
 Thrift SAI interface basic utils.
 """
 
+import time
+import struct
+import socket
+
+from functools import wraps
+
+import ptf
+from ptf.packet import *
+from ptf import testutils
+
+from sai_adapter import *
+
 
 def sai_thrift_query_attribute_enum_values_capability(client,
                                                       obj_type,
@@ -76,7 +88,7 @@ def sai_thrift_get_debug_counter_port_stats(client, port_oid, counter_ids):
         Dict[str, sai_thrift_uint64_t]: stats
     """
 
-    stats = dict()
+    stats = {}
     counters = client.sai_thrift_get_port_stats(port_oid, counter_ids)
 
     for i, counter_id in enumerate(counter_ids):
@@ -97,10 +109,184 @@ def sai_thrift_get_debug_counter_switch_stats(client, counter_ids):
         Dict[str, sai_thrift_uint64_t]: stats
     """
 
-    stats = dict()
+    stats = {}
     counters = client.sai_thrift_get_switch_stats(counter_ids)
 
     for i, counter_id in enumerate(counter_ids):
         stats[counter_id] = counters[i]
 
     return stats
+
+
+def sai_ipaddress(addr_str):
+    """
+    Set SAI IP address, assign appropriate type and return
+    sai_thrift_ip_address_t object
+
+    Args:
+        addr_str (str): IP address string
+
+    Returns:
+        sai_thrift_ip_address_t: object containing IP address family and number
+    """
+
+    if '.' in addr_str:
+        family = SAI_IP_ADDR_FAMILY_IPV4
+        addr = sai_thrift_ip_addr_t(ip4=addr_str)
+    if ':' in addr_str:
+        family = SAI_IP_ADDR_FAMILY_IPV6
+        addr = sai_thrift_ip_addr_t(ip6=addr_str)
+    ip_addr = sai_thrift_ip_address_t(addr_family=family, addr=addr)
+
+    return ip_addr
+
+
+def sai_ipprefix(prefix_str):
+    """
+    Set IP address prefix and mask and return ip_prefix object
+
+    Args:
+        prefix_str (str): IP address and mask string (with slash notation)
+
+    Return:
+        sai_thrift_ip_prefix_t: IP prefix object
+    """
+    addr_mask = prefix_str.split('/')
+    if len(addr_mask) != 2:
+        print("Invalid IP prefix format")
+        return None
+
+    if '.' in prefix_str:
+        family = SAI_IP_ADDR_FAMILY_IPV4
+        addr = sai_thrift_ip_addr_t(ip4=addr_mask[0])
+        mask = num_to_dotted_quad(addr_mask[1])
+        mask = sai_thrift_ip_addr_t(ip4=mask)
+    if ':' in prefix_str:
+        family = SAI_IP_ADDR_FAMILY_IPV6
+        addr = sai_thrift_ip_addr_t(ip6=addr_mask[0])
+        mask = num_to_dotted_quad(int(addr_mask[1]), ipv4=False)
+        mask = sai_thrift_ip_addr_t(ip6=mask)
+
+    ip_prefix = sai_thrift_ip_prefix_t(
+        addr_family=family, addr=addr, mask=mask)
+    return ip_prefix
+
+
+def num_to_dotted_quad(address, ipv4=True):
+    """
+    Helper function to convert the ip address
+
+    Args:
+        address (str): IP address
+        ipv4 (bool): determines what IP version is handled
+
+    Returns:
+        str: formatted IP address
+    """
+    if ipv4 is True:
+        mask = (1 << 32) - (1 << 32 >> int(address))
+        return socket.inet_ntop(socket.AF_INET, struct.pack('>L', mask))
+
+    mask = (1 << 128) - (1 << 128 >> int(address))
+    i = 0
+    result = ''
+    for sign in str(hex(mask)[2:]):
+        if (i + 1) % 4 == 0:
+            result = result + sign + ':'
+        else:
+            result = result + sign
+        i += 1
+    return result[:-1]
+
+
+def open_packet_socket(hostif_name):
+    """
+    Open a linux socket
+
+    Args:
+        hostif_name (str): socket interface name
+
+    Return:
+        sock: socket ID
+    """
+    eth_p_all = 3
+    sock = socket.socket(socket.AF_PACKET, socket.SOCK_RAW,
+                         socket.htons(eth_p_all))
+    sock.bind((hostif_name, eth_p_all))
+    sock.setblocking(0)
+
+    return sock
+
+
+def socket_verify_packet(pkt, sock, timeout=2):
+    """
+    Verify packet was received on a socket
+
+    Args:
+        pkt (packet): packet to match with
+        sock (int): socket ID
+        timeout (int): timeout
+
+    Return:
+        bool: True if packet matched
+    """
+    max_pkt_size = 9100
+    timeout = time.time() + timeout
+    match = False
+
+    if isinstance(pkt, ptf.mask.Mask):
+        if not pkt.is_valid():
+            return False
+
+    while time.time() < timeout:
+        try:
+            packet_from_tap_device = Ether(sock.recv(max_pkt_size))
+
+            if isinstance(pkt, ptf.mask.Mask):
+                match = pkt.pkt_match(packet_from_tap_device)
+            else:
+                match = (str(packet_from_tap_device) == str(pkt))
+
+            if match:
+                break
+
+        except BaseException:
+            pass
+
+    return match
+
+
+def delay_wrapper(func, delay=2):
+    """
+    A wrapper extending given function by a delay
+
+    Args:
+        func (function): function to be wrapped
+        delay (int): delay period in sec
+
+    Return:
+        wrapped_function: wrapped function
+    """
+    @wraps(func)
+    def wrapped_function(*args, **kwargs):
+        """
+        A wrapper function adding a delay
+
+        Args:
+            args (tuple): function arguments
+            kwargs (dict): keyword function arguments
+
+        Return:
+            status: original function return value
+        """
+        test_params = testutils.test_params_get()
+        if test_params['target'] != "hw":
+            time.sleep(delay)
+
+        status = func(*args, **kwargs)
+        return status
+
+    return wrapped_function
+
+
+sai_thrift_flush_fdb_entries = delay_wrapper(sai_thrift_flush_fdb_entries)

--- a/ptf/sai_utils.py
+++ b/ptf/sai_utils.py
@@ -34,9 +34,10 @@ def sai_thrift_query_attribute_enum_values_capability(client,
     Returns:
         list: list of switch object type enum capabilities
     """
+    max_cap_no = 20
 
     enum_cap_list = client.sai_thrift_query_attribute_enum_values_capability(
-        obj_type, attr_id, 20)
+        obj_type, attr_id, max_cap_no)
 
     return enum_cap_list
 
@@ -99,7 +100,7 @@ def sai_thrift_get_switch_stats_ext_overwrite(client, counter_ids, mode):
     """
     sai_get_switch_stats_ext() - RPC client function implementation.
     WARNING: This function overwrites sai_adapter.py function and will be
-             removed when th sai_adapter.py function has been fixed.
+             removed when the sai_adapter.py function has been fixed.
 
     Args:
         client (Client): SAI RPC client

--- a/ptf/saisanity.py
+++ b/ptf/saisanity.py
@@ -1,0 +1,339 @@
+
+from __future__ import print_function
+
+from sai_thrift.sai_headers import *
+
+from ptf.testutils import *
+from ptf.dataplane import DataPlane
+from ptf.packet import *
+from ptf.thriftutils import *
+
+from sai_base_test import *
+
+class L2SanityTest(PlatformSaiHelper):
+    def gen_mac(self):
+         #Gets self.portX objects for all active ports
+        for index in range(0, len(self.port_list)):
+            mac = "00"
+            if index < 9 :
+                section = ":" + "0" + str(index+1)
+            else:
+                section= ":" + str(index+1)
+            mac += (section*5)
+            setattr(self, 'mac%s' % index, mac)
+
+    
+    def create_bridge_ports(self):
+        for index in range(0, len(self.port_list)):
+            port_id = getattr(self, 'port%s' % index)
+            port_bp = sai_thrift_create_bridge_port(
+                self.client,
+                bridge_id=self.default_1q_bridge,
+                port_id=port_id,
+                type=SAI_BRIDGE_PORT_TYPE_PORT,
+                admin_state=True)
+            setattr(self, 'port%s_bp' % index, port_bp)
+            self.assertTrue(getattr(self, 'port%s_bp' % index) != 0)
+
+
+    def create_vlan_ports(self, vlanid, vlan_oid):
+        for index in range(0, len(self.port_list)):
+            port_bp = getattr(self, 'port%s_bp' % index)
+            if index%2 == 0:
+                vlan_member = sai_thrift_create_vlan_member(
+                    self.client,
+                    vlan_id=self.vlan_oid,
+                    bridge_port_id=port_bp,
+                    vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
+            else:
+                vlan_member = sai_thrift_create_vlan_member(
+                    self.client,
+                    vlan_id=self.vlan_oid,
+                    bridge_port_id=port_bp,
+                    vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
+
+            setattr(self, 'vlan%s_member%s' % (vlanid, index), vlan_member)
+
+
+    def set_port_vlan(self, vlan_id):
+        for index in range(0, len(self.port_list)):
+            port_id=getattr(self, 'port%s' % index)
+            sai_thrift_set_port_attribute(self.client, port_id, port_vlan_id=vlan_id)
+
+
+    def create_port_fdb(self, vlan_id, vlan_oid, mac_action):
+        for index in range(0, len(self.port_list)):
+            mac=getattr(self, 'mac%s' % index)
+            port_bp = getattr(self, 'port%s_bp' % index)
+            fdb_entry = sai_thrift_fdb_entry_t(
+                switch_id=self.switch_id, mac_address=mac, bv_id=vlan_oid)
+            sai_thrift_create_fdb_entry(
+                self.client,
+                fdb_entry,
+                type=SAI_FDB_ENTRY_TYPE_STATIC,
+                bridge_port_id=port_bp,
+                packet_action=mac_action)
+            setattr(self, 'fdb_entry%s' % index, fdb_entry)
+
+
+    def create_pkt(self, vlan_id):
+        for index in range(0, len(self.port_list)):
+            target_mac = getattr(self, 'mac%s' % index)
+            if index%2 == 0:                
+                pkt = simple_tcp_packet(eth_src=self.src_mac,
+                                        eth_dst=target_mac,
+                                        ip_dst='172.16.0.1',
+                                        ip_id=101,
+                                        ip_ttl=64)                
+            else:
+                pkt = simple_tcp_packet(eth_dst=target_mac,
+                                        eth_src=self.src_mac,
+                                        dl_vlan_enable=True,
+                                        vlan_vid=vlan_id,
+                                        ip_dst='172.16.0.1',
+                                        ip_id=102,
+                                        ip_ttl=64)
+            setattr(self, 'pkt%s' % index, pkt)
+
+    def create_exp_pkt(self, vlan_id):
+        for index in range(0, len(self.port_list)):
+            target_mac = getattr(self, 'mac%s' % index)
+            if index%2 == 0:                
+                exp_pkt = getattr(self, 'pkt%s' % index)                
+            else:
+                exp_pkt = simple_tcp_packet(eth_dst=target_mac,
+                                        eth_src=self.src_mac,
+                                        ip_dst='172.16.0.1',
+                                        ip_id=102,
+                                        dl_vlan_enable=True,
+                                        vlan_vid=vlan_id,
+                                        ip_ttl=64)
+            setattr(self, 'exp_pkt%s' % index, exp_pkt)
+
+
+    def setUp(self):
+        #Init switch
+        SaiHelperBase.setUp(self)
+
+        self.vlan_id = 10
+        self.gen_mac()
+        self.src_mac=self.mac0
+        mac_action = SAI_PACKET_ACTION_FORWARD
+
+        self.src_port = self.port0
+        self.dst_port = self.port1
+
+        # create bridge ports
+        self.create_bridge_ports()
+
+        # create vlan 10 with ports
+        self.vlan_oid = sai_thrift_create_vlan(self.client, vlan_id=self.vlan_id)
+        self.assertTrue(self.vlan_oid != 0)
+        self.create_vlan_ports(self.vlan_id, self.vlan_oid)
+
+        #set port vlan attribute
+        self.set_port_vlan(self.vlan_id)
+
+        #set fdb
+        self.create_port_fdb(self.vlan_id, self.vlan_oid, mac_action)
+
+        #create send pkt and rcv pkt
+        self.create_pkt(self.vlan_id)
+        self.create_exp_pkt(self.vlan_id)
+
+
+    def runTest(self):
+        try:
+            for index in range(1, len(self.port_list)):
+                target_pkt = getattr(self, 'pkt%s' % index)
+                target_mac = getattr(self, 'mac%s' % index)
+                target_port = getattr(self, 'dev_port%s' % index)
+                exp_pkt = getattr(self, 'exp_pkt%s' % index)
+                
+                send_packet(self, self.dev_port0, target_pkt)
+                verify_packet(self, exp_pkt, index) 
+                #res = verify_any_packet_on_ports_list(self, [exp_pkt], [[i for i in range(0,32)]])
+        finally:
+            pass
+
+    
+    def tearDown(self):
+        #reset port vlan id
+        #?reset to 0 or 1?
+        self.reset_port_vlan(1)
+
+        #remove fdb
+        self.remove_fdb()
+
+        #remove vlan member
+        self.remove_vlan_member(self.vlan_id)        
+
+        #remove bridge port
+        self.remove_bridge_port()
+
+        sai_thrift_remove_vlan(self.client, self.vlan_oid)
+
+    def reset_port_vlan(self, reset_vlan_id):
+        for index in range(0, len(self.port_list)):
+            port_id=getattr(self, 'port%s' % index)
+            sai_thrift_set_port_attribute(self.client, port_id, port_vlan_id=reset_vlan_id)
+
+    def remove_fdb(self):
+        for index in range(0, len(self.port_list)):
+            fdb_entry=getattr(self, 'fdb_entry%s' % index)
+            sai_thrift_remove_fdb_entry(self.client, fdb_entry)
+
+
+    def remove_vlan_member(self, vlan_id):
+        for index in range(0, len(self.port_list)):
+            vlan_member=getattr(self, 'vlan%s_member%s' % (vlan_id, index))
+            sai_thrift_remove_vlan_member(self.client, vlan_member)
+
+    def remove_bridge_port(self):
+        for index in range(0, len(self.port_list)):
+            port_bp = getattr(self, 'port%s_bp' % index)
+            sai_thrift_remove_bridge_port(self.client, port_bp)
+
+
+
+
+###############################################################################
+# Helper functions                                                            #
+# Hack for now, need to be removed or upstreamed                              #
+###############################################################################
+# pylint: disable=dangerous-default-value,too-many-arguments
+def verify_any_packet_on_ports_list(
+        test,
+        pkts=[],
+        ports=[],
+        device_number=0,
+        timeout=2,
+        no_flood=False):
+    """
+    Ports is list of port lists
+    Check that _any_ packet is received atleast once in every sublist in
+    ports belonging to the given device (default device_number is 0).
+
+    Also verifies that the packet is ot received on any other ports for this
+    device, and that no other packets are received on the device
+    (unless --relax is in effect).
+    Args:
+        test (testcase): Test case
+        pkts (packets): list of packets
+        ports (ports): list of ports
+        device_number (int): device under test
+        timeout (int): timeout
+        no_flood (int): do not flood
+    Returns:
+        rcv_idx: list of port indices
+    """
+    rcv_idx = []
+    failures = {}
+    pkt_cnt = 0
+    for port_list in ports:
+        rcv_ports = set()
+        remaining_timeout = timeout
+        port_sub_list_failures = []
+        port_sub_list_poll_success = False
+        if remaining_timeout > 0:
+            port_idx = 0
+            port_list_len = len(port_list)
+            while remaining_timeout > 0 or port_idx > 0:
+                port = port_list[port_idx]
+                port_idx = (port_idx + 1) % port_list_len
+                remaining_timeout = remaining_timeout - 0.1
+                (rcv_device, rcv_port, rcv_pkt, _) = test.dataplane.poll(
+                    port_number=port, timeout=0.1, filters=get_filters())
+                print("port {} received, received port id: {}".format(port, rcv_port))
+                if rcv_device != device_number:
+                    continue
+                for pkt in pkts:
+                    logging.debug("Checking for pkt on device %d, port %d",
+                                  device_number, port)
+                    if ptf.dataplane.match_exp_pkt(pkt, rcv_pkt):
+                        pkt_cnt += 1
+                        rcv_ports.add(port_list.index(rcv_port))
+                        port_sub_list_failures = []
+                        port_sub_list_poll_success = True
+                        break
+                    else:
+                        port_sub_list_failures.append(
+                            (port, DataPlane.PollFailure(pkt, [rcv_pkt], 1)))
+                if port_sub_list_poll_success and no_flood:
+                    break
+        # Either no expected packets received or unexpected packets recieved
+        if not port_sub_list_poll_success or port_sub_list_failures:
+            port_tuple = tuple(port_list)
+            failures.setdefault(port_tuple, [])
+            failures[port_tuple] = failures[port_tuple] + \
+                port_sub_list_failures
+        rcv_idx.append(rcv_ports)
+
+    verify_no_other_packets(test)
+    if failures:
+        def format_per_port_failure(port, failure):
+            # pylint: disable=missing-return-doc,missing-return-type-doc
+            """
+            Format one port
+            Args:
+              port (int): port
+              failure (str): message
+            """
+            return "On port {}\n{}".format(port, failure.format())
+
+        def format_per_port_failures(fail_list):
+            # pylint: disable=missing-return-doc,missing-return-type-doc
+            """
+            Format one port all failures
+            Args:
+              fail_list (array): port and failures
+            """
+            return "\n".join([format_per_port_failure(port, failure)
+                              for (port, failure) in fail_list])
+
+        def format_port_list_failures(port_list, fail_list):
+            # pylint: disable=missing-return-doc,missing-return-type-doc
+            """
+            Format all port all failures
+            Args:
+              port_list (array): ports
+              fail_list (array): port and failures
+            """
+            return "None of the exp pkts rx'd for port list {}: \n{}".format(
+                port_list, format_per_port_failures(fail_list))
+        failure_report = "\n".join([
+            format_port_list_failures(port_list, fail_list)
+            for port_list, fail_list in list(failures.items())
+        ])
+        test.fail(
+            "Did not receive expected packets on any of {} for device {}. \n{}"
+            .format(ports, device_number, failure_report))
+
+    test.assertTrue(
+        pkt_cnt >= len(ports),
+        "Did not receive pkt on one of ports %r for device %d" %
+        (ports, device_number))
+    return rcv_idx
+
+
+def set_vlan_data(vlan_id=0, ports=None, untagged=None, large_port=0):
+    """
+    Creates dictionary with vlan data
+
+    Args:
+        vlan_id (int): VLAN ID number
+        ports (list): ports numbers
+        untagged (list): list of untagged ports
+        large_port (int): the largest port in vlan
+
+    Return:
+        dictionary: vlan_data_dict
+    """
+    vlan_data_dict = {
+        "vlan_id": vlan_id,
+        "ports": ports,
+        "untagged": untagged,
+        "large_port": large_port
+    }
+    return vlan_data_dict
+

--- a/ptf/saitest.py
+++ b/ptf/saitest.py
@@ -1,4 +1,4 @@
-# Copyright 2020-present Barefoot Networks, Inc.
+# Copyright 2021-present Intel Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 Thrift SAI interface tester
 """
 
-from __future__ import print_function
-
 from sai_thrift.sai_headers import *
 
 from ptf.testutils import *
@@ -29,13 +27,12 @@ from sai_base_test import *
 
 class FrameworkTester(SaiHelper):
     """
-    Test auto-generated framework itself.
-    The intention of this test is to check
-    if basic features works as expected.
+    Test auto-generated framework itself
+    The intention of this test is to check if basic features works as expected
     """
 
     def setUp(self):
-        SaiHelper.setUp(self)
+        super(FrameworkTester, self).setUp()
 
         # test fdb creation
         self.fdb_entry = sai_thrift_fdb_entry_t(
@@ -119,32 +116,29 @@ class FrameworkTester(SaiHelper):
             map_to_value_list=self.qos_map_list)
 
     def runTest(self):
-        try:
-            attr = sai_thrift_get_next_hop_attribute(
-                self.client, self.nhop, ip='0.0.0.0')
-            self.assertEqual(attr['ip'].addr.ip4, '10.10.10.1')
-            attr = sai_thrift_get_next_hop_attribute(
-                self.client, self.nhop1, ip='0.0.0.0')
-            self.assertEqual(attr['ip'].addr.ip6, '4444::1')
+        attr = sai_thrift_get_next_hop_attribute(
+            self.client, self.nhop, ip='0.0.0.0')
+        self.assertEqual(attr['ip'].addr.ip4, '10.10.10.1')
+        attr = sai_thrift_get_next_hop_attribute(
+            self.client, self.nhop1, ip='0.0.0.0')
+        self.assertEqual(attr['ip'].addr.ip6, '4444::1')
 
-            attr = sai_thrift_get_neighbor_entry_attribute(
-                self.client, self.neigh_entry, dst_mac_address=True)
-            self.assertEqual(attr['dst_mac_address'], '00:11:22:33:44:66')
+        attr = sai_thrift_get_neighbor_entry_attribute(
+            self.client, self.neigh_entry, dst_mac_address=True)
+        self.assertEqual(attr['dst_mac_address'], '00:11:22:33:44:66')
 
-            attr = sai_thrift_get_qos_map_attribute(
-                self.client,
-                self.qos_map,
-                map_to_value_list=sai_thrift_qos_map_list_t(
-                    count=2, maplist=[]))
-            self.assertEqual(attr['map_to_value_list'].count,
-                             self.qos_map_list.count)
-            for i in range(0, self.qos_map_list.count):
-                self.assertEqual(attr['map_to_value_list'].maplist[i].key.dscp,
-                                 self.qos_map_list.maplist[i].key.dscp)
-                self.assertEqual(attr['map_to_value_list'].maplist[i].value.tc,
-                                 self.qos_map_list.maplist[i].value.tc)
-        finally:
-            pass
+        attr = sai_thrift_get_qos_map_attribute(
+            self.client,
+            self.qos_map,
+            map_to_value_list=sai_thrift_qos_map_list_t(
+                count=2, maplist=[]))
+        self.assertEqual(attr['map_to_value_list'].count,
+                            self.qos_map_list.count)
+        for i in range(0, self.qos_map_list.count):
+            self.assertEqual(attr['map_to_value_list'].maplist[i].key.dscp,
+                                self.qos_map_list.maplist[i].key.dscp)
+            self.assertEqual(attr['map_to_value_list'].maplist[i].value.tc,
+                                self.qos_map_list.maplist[i].value.tc)
 
     def tearDown(self):
         sai_thrift_remove_qos_map(self.client, self.qos_map)
@@ -157,4 +151,5 @@ class FrameworkTester(SaiHelper):
         sai_thrift_remove_next_hop(self.client, self.nhop1)
         sai_thrift_remove_next_hop(self.client, self.nhop)
         sai_thrift_remove_fdb_entry(self.client, self.fdb_entry)
-        SaiHelper.tearDown(self)
+
+        super(FrameworkTester, self).tearDown()

--- a/ptf/saitest.py
+++ b/ptf/saitest.py
@@ -34,6 +34,9 @@ class FrameworkTester(SaiHelper):
     def setUp(self):
         super(FrameworkTester, self).setUp()
 
+        self.route_entry_list = []
+        self.nhop_list = []
+
         # test fdb creation
         self.fdb_entry = sai_thrift_fdb_entry_t(
             switch_id=self.switch_id,
@@ -52,11 +55,14 @@ class FrameworkTester(SaiHelper):
             type=SAI_NEXT_HOP_TYPE_IP,
             router_interface_id=self.port10_rif,
             ip=sai_ipaddress('10.10.10.1'))
+        self.nhop_list.append(self.nhop)
+
         self.nhop1 = sai_thrift_create_next_hop(
             self.client,
             type=SAI_NEXT_HOP_TYPE_IP,
             router_interface_id=self.port10_rif,
             ip=sai_ipaddress('4444::1'))
+        self.nhop_list.append(self.nhop1)
 
         # test neighbor creation
         self.neigh_entry = sai_thrift_neighbor_entry_t(
@@ -72,6 +78,8 @@ class FrameworkTester(SaiHelper):
         status = sai_thrift_create_route_entry(
             self.client, self.route0, next_hop_id=self.nhop)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
+        self.route_entry_list.append(self.route0)
+
         self.route1 = sai_thrift_route_entry_t(
             switch_id=self.switch_id,
             destination=sai_ipprefix('4441::1/64'),
@@ -79,6 +87,8 @@ class FrameworkTester(SaiHelper):
         status = sai_thrift_create_route_entry(
             self.client, self.route1, next_hop_id=self.nhop)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
+        self.route_entry_list.append(self.route1)
+
         self.route2 = sai_thrift_route_entry_t(
             switch_id=self.switch_id,
             destination=sai_ipprefix('4411::1/63'),
@@ -86,6 +96,8 @@ class FrameworkTester(SaiHelper):
         status = sai_thrift_create_route_entry(
             self.client, self.route2, next_hop_id=self.nhop)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
+        self.route_entry_list.append(self.route2)
+
         self.route3 = sai_thrift_route_entry_t(
             switch_id=self.switch_id,
             destination=sai_ipprefix('4423::1/65'),
@@ -93,6 +105,8 @@ class FrameworkTester(SaiHelper):
         status = sai_thrift_create_route_entry(
             self.client, self.route3, next_hop_id=self.nhop)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
+        self.route_entry_list.append(self.route3)
+
         self.route4 = sai_thrift_route_entry_t(
             switch_id=self.switch_id,
             destination=sai_ipprefix('4444::1/127'),
@@ -100,6 +114,7 @@ class FrameworkTester(SaiHelper):
         status = sai_thrift_create_route_entry(
             self.client, self.route4, next_hop_id=self.nhop)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
+        self.route_entry_list.append(self.route4)
 
         # test qos map creation
         dscp_to_tc_1 = sai_thrift_qos_map_t(
@@ -152,14 +167,15 @@ class FrameworkTester(SaiHelper):
 
     def tearDown(self):
         sai_thrift_remove_qos_map(self.client, self.qos_map)
-        sai_thrift_remove_route_entry(self.client, self.route4)
-        sai_thrift_remove_route_entry(self.client, self.route3)
-        sai_thrift_remove_route_entry(self.client, self.route2)
-        sai_thrift_remove_route_entry(self.client, self.route1)
-        sai_thrift_remove_route_entry(self.client, self.route0)
+
+        for route_entry in self.route_entry_list:
+            sai_thrift_remove_route_entry(self.client, route_entry)
+
         sai_thrift_remove_neighbor_entry(self.client, self.neigh_entry)
-        sai_thrift_remove_next_hop(self.client, self.nhop1)
-        sai_thrift_remove_next_hop(self.client, self.nhop)
+
+        for nhop in self.nhop_list:
+            sai_thrift_remove_next_hop(self.client, nhop)
+
         sai_thrift_remove_fdb_entry(self.client, self.fdb_entry)
 
         super(FrameworkTester, self).tearDown()

--- a/ptf/saitest.py
+++ b/ptf/saitest.py
@@ -1,0 +1,160 @@
+# Copyright 2020-present Barefoot Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Thrift SAI interface tester
+"""
+
+from __future__ import print_function
+
+from sai_thrift.sai_headers import *
+
+from ptf.testutils import *
+from ptf.packet import *
+from ptf.thriftutils import *
+
+from sai_base_test import *
+
+
+class FrameworkTester(SaiHelper):
+    """
+    Test auto-generated framework itself.
+    The intention of this test is to check
+    if basic features works as expected.
+    """
+
+    def setUp(self):
+        SaiHelper.setUp(self)
+
+        # test fdb creation
+        self.fdb_entry = sai_thrift_fdb_entry_t(
+            switch_id=self.switch_id,
+            mac_address="00:11:22:33:44:55",
+            bv_id=self.vlan10)
+        status = sai_thrift_create_fdb_entry(
+            self.client,
+            self.fdb_entry,
+            type=SAI_FDB_ENTRY_TYPE_STATIC,
+            bridge_port_id=self.port0_bp)
+        self.assertEqual(status, SAI_STATUS_SUCCESS)
+
+        # test nhop creation
+        self.nhop = sai_thrift_create_next_hop(
+            self.client,
+            type=SAI_NEXT_HOP_TYPE_IP,
+            router_interface_id=self.port10_rif,
+            ip=sai_ipaddress('10.10.10.1'))
+        self.nhop1 = sai_thrift_create_next_hop(
+            self.client,
+            type=SAI_NEXT_HOP_TYPE_IP,
+            router_interface_id=self.port10_rif,
+            ip=sai_ipaddress('4444::1'))
+
+        # test neighbor creation
+        self.neigh_entry = sai_thrift_neighbor_entry_t(
+            self.switch_id, self.port10_rif, sai_ipaddress('10.10.10.1'))
+        self.neigh = sai_thrift_create_neighbor_entry(
+            self.client, self.neigh_entry, dst_mac_address='00:11:22:33:44:66')
+
+        # test route creation
+        self.route0 = sai_thrift_route_entry_t(
+            switch_id=self.switch_id,
+            destination=sai_ipprefix('20.20.20.1/16'),
+            vr_id=self.default_vrf)
+        status = sai_thrift_create_route_entry(
+            self.client, self.route0, next_hop_id=self.nhop)
+        self.assertEqual(status, SAI_STATUS_SUCCESS)
+        self.route1 = sai_thrift_route_entry_t(
+            switch_id=self.switch_id,
+            destination=sai_ipprefix('4441::1/64'),
+            vr_id=self.default_vrf)
+        status = sai_thrift_create_route_entry(
+            self.client, self.route1, next_hop_id=self.nhop)
+        self.assertEqual(status, SAI_STATUS_SUCCESS)
+        self.route2 = sai_thrift_route_entry_t(
+            switch_id=self.switch_id,
+            destination=sai_ipprefix('4411::1/63'),
+            vr_id=self.default_vrf)
+        status = sai_thrift_create_route_entry(
+            self.client, self.route2, next_hop_id=self.nhop)
+        self.assertEqual(status, SAI_STATUS_SUCCESS)
+        self.route3 = sai_thrift_route_entry_t(
+            switch_id=self.switch_id,
+            destination=sai_ipprefix('4423::1/65'),
+            vr_id=self.default_vrf)
+        status = sai_thrift_create_route_entry(
+            self.client, self.route3, next_hop_id=self.nhop)
+        self.assertEqual(status, SAI_STATUS_SUCCESS)
+        self.route4 = sai_thrift_route_entry_t(
+            switch_id=self.switch_id,
+            destination=sai_ipprefix('4444::1/127'),
+            vr_id=self.default_vrf)
+        status = sai_thrift_create_route_entry(
+            self.client, self.route4, next_hop_id=self.nhop)
+        self.assertEqual(status, SAI_STATUS_SUCCESS)
+
+        # test qos map creation
+        dscp_to_tc_1 = sai_thrift_qos_map_t(
+            key=sai_thrift_qos_map_params_t(dscp=2),
+            value=sai_thrift_qos_map_params_t(tc=16))
+        dscp_to_tc_2 = sai_thrift_qos_map_t(
+            key=sai_thrift_qos_map_params_t(dscp=4),
+            value=sai_thrift_qos_map_params_t(tc=24))
+        self.qos_map_list = sai_thrift_qos_map_list_t(
+            count=2, maplist=[dscp_to_tc_1, dscp_to_tc_2])
+        self.qos_map = sai_thrift_create_qos_map(
+            self.client,
+            SAI_QOS_MAP_TYPE_DSCP_TO_TC,
+            map_to_value_list=self.qos_map_list)
+
+    def runTest(self):
+        try:
+            attr = sai_thrift_get_next_hop_attribute(
+                self.client, self.nhop, ip='0.0.0.0')
+            self.assertEqual(attr['ip'].addr.ip4, '10.10.10.1')
+            attr = sai_thrift_get_next_hop_attribute(
+                self.client, self.nhop1, ip='0.0.0.0')
+            self.assertEqual(attr['ip'].addr.ip6, '4444::1')
+
+            attr = sai_thrift_get_neighbor_entry_attribute(
+                self.client, self.neigh_entry, dst_mac_address=True)
+            self.assertEqual(attr['dst_mac_address'], '00:11:22:33:44:66')
+
+            attr = sai_thrift_get_qos_map_attribute(
+                self.client,
+                self.qos_map,
+                map_to_value_list=sai_thrift_qos_map_list_t(
+                    count=2, maplist=[]))
+            self.assertEqual(attr['map_to_value_list'].count,
+                             self.qos_map_list.count)
+            for i in range(0, self.qos_map_list.count):
+                self.assertEqual(attr['map_to_value_list'].maplist[i].key.dscp,
+                                 self.qos_map_list.maplist[i].key.dscp)
+                self.assertEqual(attr['map_to_value_list'].maplist[i].value.tc,
+                                 self.qos_map_list.maplist[i].value.tc)
+        finally:
+            pass
+
+    def tearDown(self):
+        sai_thrift_remove_qos_map(self.client, self.qos_map)
+        sai_thrift_remove_route_entry(self.client, self.route4)
+        sai_thrift_remove_route_entry(self.client, self.route3)
+        sai_thrift_remove_route_entry(self.client, self.route2)
+        sai_thrift_remove_route_entry(self.client, self.route1)
+        sai_thrift_remove_route_entry(self.client, self.route0)
+        sai_thrift_remove_neighbor_entry(self.client, self.neigh_entry)
+        sai_thrift_remove_next_hop(self.client, self.nhop1)
+        sai_thrift_remove_next_hop(self.client, self.nhop)
+        sai_thrift_remove_fdb_entry(self.client, self.fdb_entry)
+        SaiHelper.tearDown(self)

--- a/ptf/saitest.py
+++ b/ptf/saitest.py
@@ -116,6 +116,16 @@ class FrameworkTester(SaiHelper):
             map_to_value_list=self.qos_map_list)
 
     def runTest(self):
+        attr = sai_thrift_get_fdb_entry_attribute(
+            self.client, self.fdb_entry, bridge_port_id=True)
+        self.assertEqual(attr['bridge_port_id'], self.port0_bp)
+
+        for route in [self.route0, self.route1, self.route2,
+                      self.route3, self.route4]:
+            attr = sai_thrift_get_route_entry_attribute(
+                self.client, route, next_hop_id=True)
+            self.assertEqual(attr['next_hop_id'], self.nhop)
+
         attr = sai_thrift_get_next_hop_attribute(
             self.client, self.nhop, ip='0.0.0.0')
         self.assertEqual(attr['ip'].addr.ip4, '10.10.10.1')


### PR DESCRIPTION
Add a middle layer (strategy and factory) under the test cases which can
1. no more if-else for platform selecting
1. no more code injection for different platforms, just need to abstract to a method on the differences
1. auto select the platform by the parameters in the test starter (shell)
1. easy-distinct structure for the difference from platforms
1. prepared for future statistic 

Add a sanity sample, it can
1. configure across all the ports (base on port's configuration file)
1. simple FDB and VLAN naming according to port's number
1. make a basic check on the status of the devices
1. use as a sample for how to use the new middle layer

testing done:
barefoot and broadcom platforms