### PR TITLE
Get Bulk Stats API

### DIFF
--- a/inc/saiobject.h
+++ b/inc/saiobject.h
@@ -259,7 +259,8 @@ sai_status_t sai_query_stats_capability(
  * @param[in] number_of_counters Number of counters in the array
  * @param[in] counter_ids Specifies the array of counter ids
  * @param[in] mode Statistics mode
- * @param[out] counters Array of resulting counter values
+ * @param[out] status Array of status for each object. Length of the array should be object_count. Should be looked only if API return is not SAI_STATUS_SUCCESS.
+ * @param[out] counters Array of resulting counter values.
  *
  * @return #SAI_STATUS_SUCCESS on success, failure status code on error
  */
@@ -271,7 +272,32 @@ typedef sai_status_t (*sai_bulk_object_get_stats_fn)(
         _In_ uint32_t number_of_counters,
         _In_ const sai_stat_id_t *counter_ids,
         _In_ sai_stats_mode_t mode,
+        _Out_ sai_status_t *status,
         _Out_ uint64_t *counters);
+
+/**
+ * @brief Bulk objects clear statistics.
+ *
+ * @param[in] switch_id SAI Switch object id
+ * @param[in] object_type Object type
+ * @param[in] object_count Number of objects to get the stats
+ * @param[in] object_key List of object keys
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Specifies the array of counter ids
+ * @param[in] mode Statistics mode
+ * @param[out] status Array of status for each object. Length of the array should be object_count. Should be looked only if API return is not SAI_STATUS_SUCCESS.
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_bulk_object_clear_stats_fn)(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Out_ sai_status_t *status);
 
 /**
  * @}

--- a/inc/saiobject.h
+++ b/inc/saiobject.h
@@ -264,7 +264,7 @@ sai_status_t sai_query_stats_capability(
  *
  * @return #SAI_STATUS_SUCCESS on success, failure status code on error
  */
-typedef sai_status_t (*sai_bulk_object_get_stats_fn)(
+sai_status_t sai_bulk_object_get_stats(
         _In_ sai_object_id_t switch_id,
         _In_ sai_object_type_t object_type,
         _In_ uint32_t object_count,
@@ -289,7 +289,7 @@ typedef sai_status_t (*sai_bulk_object_get_stats_fn)(
  *
  * @return #SAI_STATUS_SUCCESS on success, failure status code on error
  */
-typedef sai_status_t (*sai_bulk_object_clear_stats_fn)(
+sai_status_t sai_bulk_object_clear_stats(
         _In_ sai_object_id_t switch_id,
         _In_ sai_object_type_t object_type,
         _In_ uint32_t object_count,

--- a/inc/saiobject.h
+++ b/inc/saiobject.h
@@ -250,6 +250,30 @@ sai_status_t sai_query_stats_capability(
         _Inout_ sai_stat_capability_list_t *stats_capability);
 
 /**
+ * @brief Bulk objects get statistics.
+ *
+ * @param[in] switch_id SAI Switch object id
+ * @param[in] object_type Object type
+ * @param[in] object_count Number of objects to get the stats
+ * @param[in] object_key List of object keys
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Specifies the array of counter ids
+ * @param[in] mode Statistics mode
+ * @param[out] counters Array of resulting counter values
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_bulk_object_get_stats_fn)(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t object_count,
+        _In_ const sai_object_key_t *object_key,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Out_ uint64_t *counters);
+
+/**
  * @}
  */
 #endif /** __SAIOBJECT_H_ */

--- a/inc/saiobject.h
+++ b/inc/saiobject.h
@@ -261,6 +261,8 @@ sai_status_t sai_query_stats_capability(
  * @param[in] mode Statistics mode
  * @param[inout] object_statuses Array of status for each object. Length of the array should be object_count. Should be looked only if API return is not SAI_STATUS_SUCCESS.
  * @param[out] counters Array of resulting counter values.
+ *    Length of counters array should be object_count*number_of_counters.
+ *    Counter value of I object and J counter_id = counter[I*number_of_counters + J]
  *
  * @return #SAI_STATUS_SUCCESS on success, failure status code on error
  */

--- a/inc/saiobject.h
+++ b/inc/saiobject.h
@@ -259,7 +259,7 @@ sai_status_t sai_query_stats_capability(
  * @param[in] number_of_counters Number of counters in the array
  * @param[in] counter_ids Specifies the array of counter ids
  * @param[in] mode Statistics mode
- * @param[out] status Array of status for each object. Length of the array should be object_count. Should be looked only if API return is not SAI_STATUS_SUCCESS.
+ * @param[inout] object_statuses Array of status for each object. Length of the array should be object_count. Should be looked only if API return is not SAI_STATUS_SUCCESS.
  * @param[out] counters Array of resulting counter values.
  *
  * @return #SAI_STATUS_SUCCESS on success, failure status code on error
@@ -272,7 +272,7 @@ typedef sai_status_t (*sai_bulk_object_get_stats_fn)(
         _In_ uint32_t number_of_counters,
         _In_ const sai_stat_id_t *counter_ids,
         _In_ sai_stats_mode_t mode,
-        _Out_ sai_status_t *status,
+        _Inout_ sai_status_t *object_statuses,
         _Out_ uint64_t *counters);
 
 /**
@@ -285,7 +285,7 @@ typedef sai_status_t (*sai_bulk_object_get_stats_fn)(
  * @param[in] number_of_counters Number of counters in the array
  * @param[in] counter_ids Specifies the array of counter ids
  * @param[in] mode Statistics mode
- * @param[out] status Array of status for each object. Length of the array should be object_count. Should be looked only if API return is not SAI_STATUS_SUCCESS.
+ * @param[inout] object_statuses Array of status for each object. Length of the array should be object_count. Should be looked only if API return is not SAI_STATUS_SUCCESS.
  *
  * @return #SAI_STATUS_SUCCESS on success, failure status code on error
  */
@@ -297,7 +297,7 @@ typedef sai_status_t (*sai_bulk_object_clear_stats_fn)(
         _In_ uint32_t number_of_counters,
         _In_ const sai_stat_id_t *counter_ids,
         _In_ sai_stats_mode_t mode,
-        _Out_ sai_status_t *status);
+        _Inout_ sai_status_t *object_statuses);
 
 /**
  * @}

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1455,6 +1455,26 @@ typedef struct _sai_stat_capability_list_t
 } sai_stat_capability_list_t;
 
 /**
+ * @brief Bulk objects get statistics.
+ *
+ * @param[in] object_count Number of objects to get on attribute
+ * @param[in] object_id List of object ids
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Specifies the array of counter ids
+ * @param[in] mode Statistics mode
+ * @param[out] counters Array of resulting counter values
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_bulk_object_get_stats_fn)(
+        _In_ uint32_t object_count,
+        _In_ const sai_object_id_t *object_id,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Out_ uint64_t *counters);
+
+/**
  * @}
  */
 #endif /** __SAITYPES_H_ */

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1428,6 +1428,21 @@ typedef enum _sai_stats_mode_t
      * @brief Read and clear after reading
      */
     SAI_STATS_MODE_READ_AND_CLEAR = 1 << 1,
+
+    /**
+     * @brief Build read statistics
+     */
+    SAI_STATS_MODE_BULK_READ = 1 << 2,
+
+    /**
+     * @brief Build clear statistics
+     */
+    SAI_STATS_MODE_BULK_CLEAR = 1 << 3,
+
+    /**
+     * @brief Bulk read and clear after reading
+     */
+    SAI_STATS_MODE_BULK_READ_AND_CLEAR = 1 << 4,
 } sai_stats_mode_t;
 
 typedef struct _sai_stat_capability_t

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1455,30 +1455,6 @@ typedef struct _sai_stat_capability_list_t
 } sai_stat_capability_list_t;
 
 /**
- * @brief Bulk objects get statistics.
- *
- * @param[in] switch_id SAI Switch object id
- * @param[in] object_type Object type
- * @param[in] object_count Number of objects to get the stats
- * @param[in] object_id List of object ids
- * @param[in] number_of_counters Number of counters in the array
- * @param[in] counter_ids Specifies the array of counter ids
- * @param[in] mode Statistics mode
- * @param[out] counters Array of resulting counter values
- *
- * @return #SAI_STATUS_SUCCESS on success, failure status code on error
- */
-typedef sai_status_t (*sai_bulk_object_get_stats_fn)(
-        _In_ sai_object_id_t switch_id,
-        _In_ sai_object_type_t object_type,
-        _In_ uint32_t object_count,
-        _In_ const sai_object_id_t *object_id,
-        _In_ uint32_t number_of_counters,
-        _In_ const sai_stat_id_t *counter_ids,
-        _In_ sai_stats_mode_t mode,
-        _Out_ uint64_t *counters);
-
-/**
  * @}
  */
 #endif /** __SAITYPES_H_ */

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1457,7 +1457,9 @@ typedef struct _sai_stat_capability_list_t
 /**
  * @brief Bulk objects get statistics.
  *
- * @param[in] object_count Number of objects to get on attribute
+ * @param[in] switch_id SAI Switch object id
+ * @param[in] object_type Object type
+ * @param[in] object_count Number of objects to get the stats
  * @param[in] object_id List of object ids
  * @param[in] number_of_counters Number of counters in the array
  * @param[in] counter_ids Specifies the array of counter ids
@@ -1467,6 +1469,8 @@ typedef struct _sai_stat_capability_list_t
  * @return #SAI_STATUS_SUCCESS on success, failure status code on error
  */
 typedef sai_status_t (*sai_bulk_object_get_stats_fn)(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
         _In_ uint32_t object_count,
         _In_ const sai_object_id_t *object_id,
         _In_ uint32_t number_of_counters,

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1430,12 +1430,12 @@ typedef enum _sai_stats_mode_t
     SAI_STATS_MODE_READ_AND_CLEAR = 1 << 1,
 
     /**
-     * @brief Build read statistics
+     * @brief Bulk read statistics
      */
     SAI_STATS_MODE_BULK_READ = 1 << 2,
 
     /**
-     * @brief Build clear statistics
+     * @brief Bulk clear statistics
      */
     SAI_STATS_MODE_BULK_CLEAR = 1 << 3,
 

--- a/meta/style.pm
+++ b/meta/style.pm
@@ -206,6 +206,7 @@ sub CheckStatsFunction
     return if $fname eq "sai_clear_port_all_stats_fn"; # exception
     return if $fname eq "sai_get_tam_snapshot_stats_fn"; # exception
     return if $fname eq "sai_bulk_object_get_stats_fn"; # exception
+    return if $fname eq "sai_bulk_object_clear_stats_fn"; # exception
 
     if (not $fname =~ /^sai_((get|clear)_(\w+)_stats|get_\w+_stats_ext)_fn$/)
     {

--- a/meta/style.pm
+++ b/meta/style.pm
@@ -205,6 +205,7 @@ sub CheckStatsFunction
 
     return if $fname eq "sai_clear_port_all_stats_fn"; # exception
     return if $fname eq "sai_get_tam_snapshot_stats_fn"; # exception
+    return if $fname eq "sai_bulk_object_get_stats_fn"; # exception
 
     if (not $fname =~ /^sai_((get|clear)_(\w+)_stats|get_\w+_stats_ext)_fn$/)
     {


### PR DESCRIPTION
This API introduces ability to query bulk stats for an object list.
Return counter buffer is populated in the same order as the counter id for each object in a list.
Since same counter ids are applicable to all objects in the list, objects in the object list need to be of the same type. This is consistent with other bulk APIs.