### PR TITLE
SAI NAT aging notification

### DIFF
--- a/inc/sainat.h
+++ b/inc/sainat.h
@@ -210,6 +210,17 @@ typedef enum _sai_nat_entry_attr_t
     SAI_NAT_ENTRY_ATTR_HIT_BIT,
 
     /**
+     * @brief NAT entry aging time in seconds
+     *
+     * Zero means aging is disabled.
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_NAT_ENTRY_ATTR_AGING_TIME,
+
+    /**
      * @brief End of NAT Entry attributes
      */
     SAI_NAT_ENTRY_ATTR_END,
@@ -335,6 +346,34 @@ typedef struct _sai_nat_entry_t
 } sai_nat_entry_t;
 
 /**
+ * @brief NAT event type
+ */
+typedef enum _sai_nat_event_t
+{
+    /** NAT entry event none */
+    SAI_NAT_EVENT_NONE,
+
+    /** NAT entry event aged */
+    SAI_NAT_EVENT_AGED,
+
+} sai_nat_event_t;
+
+/**
+ * @brief Notification data format received from SAI NAT callback
+ *
+ * @count attr[attr_count]
+ */
+typedef struct _sai_nat_event_notification_data_t
+{
+    /** Event type */
+    sai_nat_event_t event_type;
+
+    /** NAT entry */
+    sai_nat_entry_t nat_entry;
+
+} sai_nat_event_notification_data_t;
+
+/**
  * @brief Create and return a NAT object
  *
  * @param[in] nat_entry NAT entry
@@ -383,6 +422,18 @@ typedef sai_status_t (*sai_get_nat_entry_attribute_fn)(
         _In_ const sai_nat_entry_t *nat_entry,
         _In_ uint32_t attr_count,
         _Inout_ sai_attribute_t *attr_list);
+
+/**
+ * @brief NAT notifications
+ *
+ * @count data[count]
+ *
+ * @param[in] count Number of notifications
+ * @param[in] data Pointer to NAT event notification data array
+ */
+typedef void (*sai_nat_event_notification_fn)(
+        _In_ uint32_t count,
+        _In_ const sai_nat_event_notification_data_t *data);
 
 /**
  * @brief Bulk create NAT entry

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -2696,6 +2696,17 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_IPSEC_SA_STATUS_CHANGE_NOTIFY,
 
     /**
+     * @brief NAT event notification callback function passed to the adapter.
+     *
+     * Use sai_nat_event_notification_fn as notification function.
+     *
+     * @type sai_pointer_t sai_nat_event_notification_fn
+     * @flags CREATE_AND_SET
+     * @default NULL
+     */
+    SAI_SWITCH_ATTR_NAT_EVENT_NOTIFY,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,

--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -2520,6 +2520,7 @@ sub ProcessStructValueType
     return "SAI_ATTR_VALUE_TYPE_INT32"          if defined $SAI_ENUMS{$type}; # enum
 
     return "-1"                                 if $type eq "sai_fdb_entry_t";
+    return "-1"                                 if $type eq "sai_nat_entry_t";
     return "-1"                                 if $type eq "sai_attribute_t*";
 
     LogError "invalid struct member value type $type";


### PR DESCRIPTION
In the Hit Bit query mechanism described in [https://github.com/opencomputeproject/SAI/blob/master/doc/NAT/SAI-NAT-API.md]( https://github.com/opencomputeproject/SAI/blob/master/doc/NAT/SAI-NAT-API.md), the NOS periodically polls the NAT entries for aging out unused entries. In a highly scaled environment with tens of thousands of NAT entries programmed, the frequent polling for aging out is not performant. An alternative is to use a callback from SAI to notify NOS about the NAT entries that are aged out after a certain time. 

The NOS registers a callback named sai_nat_event_notification_fn through the switch attribute SAI_SWITCH_ATTR_NAT_EVENT_NOTIFY. 

The NOS then create/sets the NAT entry with the optional attribute SAI_NAT_ENTRY_ATTR_AGING_TIME. 

nat_entry_attr[0].id = SAI_NAT_ENTRY_ATTR_AGING_TIME; 
nat_entry_attr[0].value.u32 = aging_time; // in seconds 

If the attribute is not added the NAT entry does not age out. If the aging time is specified as 0, the NAT entry does not age out. The aging time configured can be queried using a GET request of this attribute. 

Once the NAT entry ages out, SAI notifies NOS using sai_nat_event_notification_fn callback. This callback provides events of type sai_nat_event_notification_data_t which has information about the specific NAT entries that got aged out. The NOS uses the NAT entry information to delete these NAT entries. 