### PR TITLE
[Cherry-Pick]SAI PTF 2: sai_base_test infra (#1335)

### DIFF
--- a/meta/acronyms.txt
+++ b/meta/acronyms.txt
@@ -101,6 +101,7 @@ PTP - Precision time protocol
 QOS - Quality of Service
 RARP - Reverse Address Resolution Protocol
 RFC - Request For Comment
+RPC - Remote Procedure Call
 RPF - Reverse Path Forwarding
 RPN - Reverse Polish Notation
 RSPAN - Remote Span

--- a/meta/sai_rpc_frontend.cpp
+++ b/meta/sai_rpc_frontend.cpp
@@ -1,0 +1,925 @@
+/**
+ * Copyright (c) 2021 Microsoft Open Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ *    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ *    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ *
+ *    See the Apache Version 2.0 License for specific language governing
+ *    permissions and limitations under the License.
+ *
+ *    Microsoft would like to thank the following companies for their review and
+ *    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+ *    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+ *
+ * @file    sai_rpc_frontend.cpp
+ *
+ * @brief   This module contains RPC server handler and helper functions
+ */
+
+#include <arpa/inet.h>
+
+#include <iostream>
+#include <cstring>
+#include "sai_rpc.h"
+
+extern "C" {
+#include "sai.h"
+#include "saitypes.h"
+#include "saimetadatatypes.h"
+#include "saimetadatautils.h"
+#include "saimetadata.h"
+}
+
+using namespace ::sai;
+
+/**
+ *  @brief Convert Thrift MAC format to SAI MAC format
+ */
+unsigned int sai_thrift_mac_t_parse(const std::string s, void *data) {
+  unsigned int i, j = 0;
+  unsigned char *m = static_cast<unsigned char *>(data);
+  memset(m, 0, 6);
+  for (i = 0; i < s.size(); i++) {
+    char let = s.c_str()[i];
+    if (let >= '0' && let <= '9') {
+      m[j / 2] = (m[j / 2] << 4) + (let - '0');
+      j++;
+    } else if (let >= 'a' && let <= 'f') {
+      m[j / 2] = (m[j / 2] << 4) + (let - 'a' + 10);
+      j++;
+    } else if (let >= 'A' && let <= 'F') {
+      m[j / 2] = (m[j / 2] << 4) + (let - 'A' + 10);
+      j++;
+    }
+  }
+  return (j == 12);
+}
+
+/**
+ *  @brief Convert Thrift IPv4 format to SAI IPv4 format
+ */
+void sai_thrift_ip4_t_parse(const std::string s, unsigned int *m) {
+  unsigned char r = 0;
+  unsigned int i;
+  *m = 0;
+  for (i = 0; i < s.size(); i++) {
+    char let = s.c_str()[i];
+    if (let >= '0' && let <= '9') {
+      r = (r * 10) + (let - '0');
+    } else {
+      *m = (*m << 8) | r;
+      r = 0;
+    }
+  }
+  *m = (*m << 8) | (r & 0xFF);
+  *m = htonl(*m);
+  return;
+}
+
+/**
+ *  @brief Convert Thrift IPv6 format to SAI IPv6 format
+ */
+void sai_thrift_ip6_t_parse(const std::string s, unsigned char *v6_ip) {
+  const char *v6_str = s.c_str();
+  inet_pton(AF_INET6, v6_str, v6_ip);
+  return;
+}
+
+/**
+ *  @brief Convert Thrift IP address format to SAI IP address format
+ */
+void sai_thrift_ip_address_t_parse(
+    const sai_thrift_ip_address_t &thrift_ip_address,
+    sai_ip_address_t *ip_address) {
+  ip_address->addr_family = (sai_ip_addr_family_t)thrift_ip_address.addr_family;
+  if ((sai_ip_addr_family_t)thrift_ip_address.addr_family ==
+      SAI_IP_ADDR_FAMILY_IPV4) {
+    sai_thrift_ip4_t_parse(thrift_ip_address.addr.ip4, &ip_address->addr.ip4);
+  } else {
+    sai_thrift_ip6_t_parse(thrift_ip_address.addr.ip6, ip_address->addr.ip6);
+  }
+}
+
+/**
+ *  @brief Convert IP address and mask from Thrift to SAI format
+ */
+void sai_thrift_ip_prefix_t_parse(
+    const sai_thrift_ip_prefix_t &thrift_ip_prefix,
+    sai_ip_prefix_t *ip_prefix) {
+  ip_prefix->addr_family = (sai_ip_addr_family_t)thrift_ip_prefix.addr_family;
+  if ((sai_ip_addr_family_t)thrift_ip_prefix.addr_family ==
+      SAI_IP_ADDR_FAMILY_IPV4) {
+    sai_thrift_ip4_t_parse(thrift_ip_prefix.addr.ip4, &ip_prefix->addr.ip4);
+    sai_thrift_ip4_t_parse(thrift_ip_prefix.mask.ip4, &ip_prefix->mask.ip4);
+  } else {
+    sai_thrift_ip6_t_parse(thrift_ip_prefix.addr.ip6, ip_prefix->addr.ip6);
+    sai_thrift_ip6_t_parse(thrift_ip_prefix.mask.ip6, ip_prefix->mask.ip6);
+  }
+}
+
+/**
+ *  @brief Convert attribute from Thrift to SAI format according to the type
+ */
+void convert_attr_thrift_to_sai(const sai_object_type_t sai_ot,
+                                const sai_thrift_attribute_t &thrift_attr,
+                                sai_attribute_t *sai_attr) {
+  const auto attr_md = sai_metadata_get_attr_metadata(sai_ot, thrift_attr.id);
+  sai_attr->id = thrift_attr.id;
+
+  if (attr_md == NULL) {
+    return;
+  }
+
+  switch (attr_md->attrvaluetype) {
+    case SAI_ATTR_VALUE_TYPE_BOOL:
+      sai_attr->value.booldata = thrift_attr.value.booldata;
+      break;
+    case SAI_ATTR_VALUE_TYPE_CHARDATA:
+      // 32 is chardata size in sai types
+      std::memcpy(
+          sai_attr->value.chardata, thrift_attr.value.chardata.c_str(), 32);
+      break;
+    case SAI_ATTR_VALUE_TYPE_UINT8:
+      sai_attr->value.u8 = thrift_attr.value.u8;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT8:
+      sai_attr->value.s8 = thrift_attr.value.s8;
+      break;
+    case SAI_ATTR_VALUE_TYPE_UINT16:
+      sai_attr->value.u16 = thrift_attr.value.u16;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT16:
+      sai_attr->value.s16 = thrift_attr.value.s16;
+      break;
+    case SAI_ATTR_VALUE_TYPE_UINT32:
+      sai_attr->value.u32 = thrift_attr.value.u32;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT32:
+      sai_attr->value.s32 = thrift_attr.value.s32;
+      break;
+    case SAI_ATTR_VALUE_TYPE_UINT64:
+      sai_attr->value.u64 = thrift_attr.value.u64;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT64:
+      sai_attr->value.s64 = thrift_attr.value.s64;
+      break;
+    case SAI_ATTR_VALUE_TYPE_POINTER:
+      // not supported
+      break;
+    case SAI_ATTR_VALUE_TYPE_MAC:
+      sai_thrift_mac_t_parse(thrift_attr.value.mac, &sai_attr->value.mac);
+      break;
+    case SAI_ATTR_VALUE_TYPE_IPV4:
+      sai_thrift_ip4_t_parse(thrift_attr.value.ip4, &sai_attr->value.ip4);
+      break;
+    case SAI_ATTR_VALUE_TYPE_IPV6:
+      sai_thrift_ip6_t_parse(thrift_attr.value.ip6, sai_attr->value.ip6);
+      break;
+    case SAI_ATTR_VALUE_TYPE_IP_ADDRESS:
+      sai_thrift_ip_address_t_parse(thrift_attr.value.ipaddr,
+                                    &sai_attr->value.ipaddr);
+      break;
+    case SAI_ATTR_VALUE_TYPE_IP_PREFIX:
+      sai_thrift_ip_prefix_t_parse(thrift_attr.value.ipprefix,
+                                   &sai_attr->value.ipprefix);
+      break;
+    case SAI_ATTR_VALUE_TYPE_OBJECT_ID:
+      sai_attr->value.oid = thrift_attr.value.oid;
+      break;
+    case SAI_ATTR_VALUE_TYPE_OBJECT_LIST: {
+      sai_attr->value.objlist.list = (sai_object_id_t *)malloc(
+          sizeof(sai_object_id_t) * thrift_attr.value.objlist.count);
+      int i = 0;
+      for (auto obj : thrift_attr.value.objlist.idlist)
+        sai_attr->value.objlist.list[i++] = obj;
+      sai_attr->value.objlist.count = thrift_attr.value.objlist.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_UINT8_LIST: {
+      sai_attr->value.u8list.list =
+          (uint8_t *)malloc(sizeof(uint8_t) * thrift_attr.value.u8list.count);
+      int i = 0;
+      for (auto u8 : thrift_attr.value.u8list.uint8list)
+        sai_attr->value.u8list.list[i++] = u8;
+      sai_attr->value.u8list.count = thrift_attr.value.u8list.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_INT8_LIST: {
+      sai_attr->value.s8list.list =
+          (int8_t *)malloc(sizeof(int8_t) * thrift_attr.value.s8list.count);
+      int i = 0;
+      for (auto s8 : thrift_attr.value.s8list.int8list)
+        sai_attr->value.s8list.list[i++] = s8;
+      sai_attr->value.s8list.count = thrift_attr.value.s8list.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_UINT16_LIST: {
+      sai_attr->value.u16list.list = (uint16_t *)malloc(
+          sizeof(uint16_t) * thrift_attr.value.u16list.count);
+      int i = 0;
+      for (auto u16 : thrift_attr.value.u16list.uint16list)
+        sai_attr->value.u16list.list[i++] = u16;
+      sai_attr->value.u16list.count = thrift_attr.value.u16list.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_INT16_LIST: {
+      sai_attr->value.s16list.list =
+          (int16_t *)malloc(sizeof(int16_t) * thrift_attr.value.s16list.count);
+      int i = 0;
+      for (auto s16 : thrift_attr.value.s16list.int16list)
+        sai_attr->value.s16list.list[i++] = s16;
+      sai_attr->value.s16list.count = thrift_attr.value.s16list.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_UINT32_LIST: {
+      sai_attr->value.u32list.list = (uint32_t *)malloc(
+          sizeof(uint32_t) * thrift_attr.value.u32list.count);
+      int i = 0;
+      for (auto u32 : thrift_attr.value.u32list.uint32list)
+        sai_attr->value.u32list.list[i++] = u32;
+      sai_attr->value.u32list.count = thrift_attr.value.u32list.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_INT32_LIST: {
+      sai_attr->value.s32list.list =
+          (int32_t *)malloc(sizeof(int32_t) * thrift_attr.value.s32list.count);
+      int i = 0;
+      for (auto s32 : thrift_attr.value.s32list.int32list)
+        sai_attr->value.s32list.list[i++] = s32;
+      sai_attr->value.s32list.count = thrift_attr.value.s32list.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_UINT32_RANGE:
+      sai_attr->value.u32range.min = thrift_attr.value.u32range.min;
+      sai_attr->value.u32range.max = thrift_attr.value.u32range.max;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT32_RANGE:
+      sai_attr->value.s32range.min = thrift_attr.value.s32range.min;
+      sai_attr->value.s32range.max = thrift_attr.value.s32range.max;
+      break;
+
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_BOOL:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.booldata =
+          thrift_attr.value.aclfield.data.booldata;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.u8 = thrift_attr.value.aclfield.data.u8;
+      sai_attr->value.aclfield.mask.u8 = thrift_attr.value.aclfield.mask.u8;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_INT8:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.s8 = thrift_attr.value.aclfield.data.s8;
+      sai_attr->value.aclfield.mask.s8 = thrift_attr.value.aclfield.mask.s8;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT16:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.u16 = thrift_attr.value.aclfield.data.u16;
+      sai_attr->value.aclfield.mask.u16 = thrift_attr.value.aclfield.mask.u16;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_INT16:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.s16 = thrift_attr.value.aclfield.data.s16;
+      sai_attr->value.aclfield.mask.s16 = thrift_attr.value.aclfield.mask.s16;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT32:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.u32 = thrift_attr.value.aclfield.data.u32;
+      sai_attr->value.aclfield.mask.u32 = thrift_attr.value.aclfield.mask.u32;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_INT32:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.s32 = thrift_attr.value.aclfield.data.s32;
+      sai_attr->value.aclfield.mask.s32 = thrift_attr.value.aclfield.mask.s32;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_MAC:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_thrift_mac_t_parse(thrift_attr.value.aclfield.data.mac,
+                             &sai_attr->value.aclfield.data.mac);
+      sai_thrift_mac_t_parse(thrift_attr.value.aclfield.mask.mac,
+                             &sai_attr->value.aclfield.mask.mac);
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_IPV4:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_thrift_ip4_t_parse(thrift_attr.value.aclfield.data.ip4,
+                             &sai_attr->value.aclfield.data.ip4);
+      sai_thrift_ip4_t_parse(thrift_attr.value.aclfield.mask.ip4,
+                             &sai_attr->value.aclfield.mask.ip4);
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_IPV6:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_thrift_ip6_t_parse(thrift_attr.value.aclfield.data.ip6,
+                             sai_attr->value.aclfield.data.ip6);
+      sai_thrift_ip6_t_parse(thrift_attr.value.aclfield.mask.ip6,
+                             sai_attr->value.aclfield.mask.ip6);
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_OBJECT_ID:
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.oid = thrift_attr.value.aclfield.data.oid;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_OBJECT_LIST: {
+      int i = 0;
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.objlist.list = (sai_object_id_t *)malloc(
+          sizeof(sai_object_id_t) *
+          thrift_attr.value.aclfield.data.objlist.count);
+      for (auto obj : thrift_attr.value.aclfield.data.objlist.idlist)
+        sai_attr->value.aclfield.data.objlist.list[i++] = obj;
+      sai_attr->value.aclfield.data.objlist.count =
+          thrift_attr.value.aclfield.data.objlist.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST: {
+      int i = 0;
+      sai_attr->value.aclfield.enable = thrift_attr.value.aclfield.enable;
+      sai_attr->value.aclfield.data.u8list.list = (uint8_t *)malloc(
+          sizeof(uint8_t) * thrift_attr.value.aclfield.data.u8list.count);
+      for (auto obj : thrift_attr.value.aclfield.data.u8list.uint8list)
+        sai_attr->value.aclfield.data.u8list.list[i++] = obj;
+      sai_attr->value.aclfield.data.u8list.count =
+          thrift_attr.value.aclfield.data.u8list.count;
+      i = 0;
+      sai_attr->value.aclfield.mask.u8list.list = (uint8_t *)malloc(
+          sizeof(uint8_t) * thrift_attr.value.aclfield.mask.u8list.count);
+      for (auto obj : thrift_attr.value.aclfield.mask.u8list.uint8list)
+        sai_attr->value.aclfield.mask.u8list.list[i++] = obj;
+      sai_attr->value.aclfield.mask.u8list.count =
+          thrift_attr.value.aclfield.mask.u8list.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_BOOL:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.booldata =
+          thrift_attr.value.aclaction.parameter.booldata;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_UINT8:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.u8 =
+          thrift_attr.value.aclaction.parameter.u8;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_INT8:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.s8 =
+          thrift_attr.value.aclaction.parameter.s8;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_UINT16:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.u16 =
+          thrift_attr.value.aclaction.parameter.u16;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_INT16:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.s16 =
+          thrift_attr.value.aclaction.parameter.s16;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_UINT32:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.u32 =
+          thrift_attr.value.aclaction.parameter.u32;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_INT32:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.s32 =
+          thrift_attr.value.aclaction.parameter.s32;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_MAC:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_thrift_mac_t_parse(thrift_attr.value.aclaction.parameter.mac,
+                             &sai_attr->value.aclaction.parameter.mac);
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_IPV4:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_thrift_ip4_t_parse(thrift_attr.value.aclaction.parameter.ip4,
+                             &sai_attr->value.aclaction.parameter.ip4);
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_IPV6:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_thrift_ip6_t_parse(thrift_attr.value.aclaction.parameter.ip6,
+                             sai_attr->value.aclaction.parameter.ip6);
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_IP_ADDRESS:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_thrift_ip_address_t_parse(
+          thrift_attr.value.aclaction.parameter.ipaddr,
+          &sai_attr->value.aclaction.parameter.ipaddr);
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_ID:
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.oid =
+          thrift_attr.value.aclaction.parameter.oid;
+      break;
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_LIST: {
+      int i = 0;
+      sai_attr->value.aclaction.enable = thrift_attr.value.aclaction.enable;
+      sai_attr->value.aclaction.parameter.objlist.list =
+          (sai_object_id_t *)malloc(
+              sizeof(sai_object_id_t) *
+              thrift_attr.value.aclaction.parameter.objlist.count);
+      for (auto obj : thrift_attr.value.aclaction.parameter.objlist.idlist)
+        sai_attr->value.aclaction.parameter.objlist.list[i++] = obj;
+      sai_attr->value.aclaction.parameter.objlist.count =
+          thrift_attr.value.aclaction.parameter.objlist.count;
+    } break;
+
+    case SAI_ATTR_VALUE_TYPE_ACL_CAPABILITY: {
+      sai_attr->value.aclcapability.is_action_list_mandatory =
+          thrift_attr.value.aclcapability.is_action_list_mandatory;
+      sai_attr->value.aclcapability.action_list.list = (int32_t *)malloc(
+          sizeof(int32_t) * thrift_attr.value.aclcapability.action_list.count);
+      int i = 0;
+      for (auto s32 : thrift_attr.value.aclcapability.action_list.int32list)
+        sai_attr->value.aclcapability.action_list.list[i++] = s32;
+      sai_attr->value.aclcapability.action_list.count =
+          thrift_attr.value.aclcapability.action_list.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_ACL_RESOURCE_LIST: {
+      sai_attr->value.aclresource.list = (sai_acl_resource_t *)malloc(
+          sizeof(sai_acl_resource_t) * thrift_attr.value.aclresource.count);
+      int i = 0;
+      for (auto resource : thrift_attr.value.aclresource.resourcelist) {
+        sai_attr->value.aclresource.list[i].stage =
+            static_cast<sai_acl_stage_t>(resource.stage);
+        sai_attr->value.aclresource.list[i].bind_point =
+            static_cast<sai_acl_bind_point_type_t>(resource.bind_point);
+        sai_attr->value.aclresource.list[i++].avail_num = resource.avail_num;
+      }
+      sai_attr->value.aclresource.count = thrift_attr.value.aclresource.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST: {
+      sai_attr->value.ipaddrlist.list = (sai_ip_address_t *)malloc(
+          sizeof(sai_ip_address_t) * thrift_attr.value.ipaddrlist.count);
+      int i = 0;
+      for (auto address : thrift_attr.value.ipaddrlist.addresslist) {
+        sai_thrift_ip_address_t_parse(address,
+                                      &sai_attr->value.ipaddrlist.list[i++]);
+      }
+      sai_attr->value.ipaddrlist.count = thrift_attr.value.ipaddrlist.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_MAP_LIST:
+    case SAI_ATTR_VALUE_TYPE_VLAN_LIST:
+    case SAI_ATTR_VALUE_TYPE_QOS_MAP_LIST: {
+      sai_attr->value.qosmap.list = (sai_qos_map_t *)malloc(
+          sizeof(sai_qos_map_t) * thrift_attr.value.qosmap.count);
+      int i = 0;
+      for (auto qosmap : thrift_attr.value.qosmap.maplist) {
+        // key
+        sai_attr->value.qosmap.list[i].key.tc = qosmap.key.tc;
+        sai_attr->value.qosmap.list[i].key.dscp = qosmap.key.dscp;
+        sai_attr->value.qosmap.list[i].key.dot1p = qosmap.key.dot1p;
+        sai_attr->value.qosmap.list[i].key.prio = qosmap.key.prio;
+        sai_attr->value.qosmap.list[i].key.pg = qosmap.key.pg;
+        sai_attr->value.qosmap.list[i].key.queue_index = qosmap.key.queue_index;
+        sai_attr->value.qosmap.list[i].key.color =
+            static_cast<sai_packet_color_t>(qosmap.key.color);
+        sai_attr->value.qosmap.list[i].key.mpls_exp = qosmap.key.mpls_exp;
+        // value
+        sai_attr->value.qosmap.list[i].value.tc = qosmap.value.tc;
+        sai_attr->value.qosmap.list[i].value.dscp = qosmap.value.dscp;
+        sai_attr->value.qosmap.list[i].value.dot1p = qosmap.value.dot1p;
+        sai_attr->value.qosmap.list[i].value.prio = qosmap.value.prio;
+        sai_attr->value.qosmap.list[i].value.pg = qosmap.value.pg;
+        sai_attr->value.qosmap.list[i].value.queue_index =
+            qosmap.value.queue_index;
+        sai_attr->value.qosmap.list[i].value.color =
+            static_cast<sai_packet_color_t>(qosmap.value.color);
+        sai_attr->value.qosmap.list[i].value.mpls_exp = qosmap.value.mpls_exp;
+        i++;
+      }
+      sai_attr->value.qosmap.count = thrift_attr.value.qosmap.count;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_TLV_LIST:
+    case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
+    case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
+    case SAI_ATTR_VALUE_TYPE_TIMESPEC:
+    case SAI_ATTR_VALUE_TYPE_NAT_ENTRY_DATA:
+      // not supported
+      break;
+    default:
+      break;
+  }
+}
+
+/**
+ *  @brief Convert SAI IPv4 format to Thrift IPv4 format
+ */
+std::string sai_ip4_t_to_thrift(const sai_ip4_t ip4) {
+  char str[INET_ADDRSTRLEN];
+  inet_ntop(AF_INET, &(ip4), str, INET_ADDRSTRLEN);
+  return str;
+}
+
+/**
+ *  @brief Convert SAI IPv6 format to Thrift IPv6 format
+ */
+std::string sai_ip6_t_to_thrift(const sai_ip6_t ip6) {
+  char str[INET6_ADDRSTRLEN];
+  inet_ntop(AF_INET6, ip6, str, INET6_ADDRSTRLEN);
+  return str;
+}
+
+/**
+ *  @brief Convert SAI IP address format to Thrift IP address format
+ */
+void sai_ip_address_t_to_thrift(sai_thrift_ip_address_t &thrift_ip,
+                                const sai_ip_address_t ip) {
+  if (ip.addr_family == SAI_IP_ADDR_FAMILY_IPV4) {
+    thrift_ip.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    thrift_ip.addr.ip4 = sai_ip4_t_to_thrift(ip.addr.ip4);
+  } else if (ip.addr_family == SAI_IP_ADDR_FAMILY_IPV6) {
+    thrift_ip.addr_family = SAI_IP_ADDR_FAMILY_IPV6;
+    thrift_ip.addr.ip6 = sai_ip6_t_to_thrift(ip.addr.ip6);
+  }
+}
+
+/**
+ *  @brief Convert IP address and mask from SAI to Thrift format
+ */
+void sai_ip_prefix_t_to_thrift(sai_thrift_ip_prefix_t &thrift_ip,
+                               const sai_ip_prefix_t ip) {
+  if (ip.addr_family == SAI_IP_ADDR_FAMILY_IPV4) {
+    thrift_ip.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    thrift_ip.addr.ip4 = sai_ip4_t_to_thrift(ip.addr.ip4);
+    thrift_ip.mask.ip4 = sai_ip4_t_to_thrift(ip.mask.ip4);
+  } else if (ip.addr_family == SAI_IP_ADDR_FAMILY_IPV6) {
+    thrift_ip.addr_family = SAI_IP_ADDR_FAMILY_IPV6;
+    thrift_ip.addr.ip6 = sai_ip6_t_to_thrift(ip.addr.ip6);
+    thrift_ip.mask.ip6 = sai_ip6_t_to_thrift(ip.mask.ip6);
+  }
+}
+
+/**
+ *  @brief Convert attribute from SAI to Thrift format according to the type
+ */
+void convert_attr_sai_to_thrift(const sai_object_type_t sai_ot,
+                                const sai_attribute_t &sai_attr,
+                                sai_thrift_attribute_t &thrift_attr) {
+  const auto attr_md = sai_metadata_get_attr_metadata(sai_ot, sai_attr.id);
+  thrift_attr.id = sai_attr.id;
+
+  if (attr_md == NULL) {
+    return;
+  }
+
+  switch (attr_md->attrvaluetype) {
+    case SAI_ATTR_VALUE_TYPE_BOOL:
+      thrift_attr.value.booldata = sai_attr.value.booldata;
+      break;
+    case SAI_ATTR_VALUE_TYPE_CHARDATA:
+      thrift_attr.value.chardata = sai_attr.value.chardata;
+      break;
+    case SAI_ATTR_VALUE_TYPE_UINT8:
+      thrift_attr.value.u8 = sai_attr.value.u8;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT8:
+      thrift_attr.value.s8 = sai_attr.value.s8;
+      break;
+    case SAI_ATTR_VALUE_TYPE_UINT16:
+      thrift_attr.value.u16 = sai_attr.value.u16;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT16:
+      thrift_attr.value.s16 = sai_attr.value.s16;
+      break;
+    case SAI_ATTR_VALUE_TYPE_UINT32:
+      thrift_attr.value.u32 = sai_attr.value.u32;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT32:
+      thrift_attr.value.s32 = sai_attr.value.s32;
+      break;
+    case SAI_ATTR_VALUE_TYPE_UINT64:
+      thrift_attr.value.u64 = sai_attr.value.u64;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT64:
+      thrift_attr.value.s64 = sai_attr.value.s64;
+      break;
+    case SAI_ATTR_VALUE_TYPE_POINTER:
+      // not supported
+      break;
+    case SAI_ATTR_VALUE_TYPE_MAC: {
+      char mac_str[18];
+      snprintf(mac_str,
+               sizeof(mac_str),
+               "%02x:%02x:%02x:%02x:%02x:%02x",
+               sai_attr.value.mac[0],
+               sai_attr.value.mac[1],
+               sai_attr.value.mac[2],
+               sai_attr.value.mac[3],
+               sai_attr.value.mac[4],
+               sai_attr.value.mac[5]);
+      thrift_attr.value.mac = mac_str;
+    } break;
+    case SAI_ATTR_VALUE_TYPE_IPV4:
+      thrift_attr.value.ip4 = sai_ip4_t_to_thrift(sai_attr.value.ip4);
+      break;
+    case SAI_ATTR_VALUE_TYPE_IPV6:
+      thrift_attr.value.ip6 = sai_ip6_t_to_thrift(sai_attr.value.ip6);
+      break;
+    case SAI_ATTR_VALUE_TYPE_IP_ADDRESS:
+      sai_ip_address_t_to_thrift(thrift_attr.value.ipaddr,
+                                 sai_attr.value.ipaddr);
+      break;
+    case SAI_ATTR_VALUE_TYPE_IP_PREFIX:
+      sai_ip_prefix_t_to_thrift(thrift_attr.value.ipprefix,
+                                sai_attr.value.ipprefix);
+      break;
+    case SAI_ATTR_VALUE_TYPE_OBJECT_ID:
+      thrift_attr.value.oid = sai_attr.value.oid;
+      break;
+    case SAI_ATTR_VALUE_TYPE_OBJECT_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.objlist.count; i++) {
+        thrift_attr.value.objlist.idlist.push_back(
+            sai_attr.value.objlist.list[i]);
+      }
+      thrift_attr.value.objlist.count = sai_attr.value.objlist.count;
+      free(sai_attr.value.objlist.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_UINT8_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.u8list.count; i++)
+        thrift_attr.value.u8list.uint8list.push_back(
+            sai_attr.value.u8list.list[i]);
+      thrift_attr.value.u8list.count = sai_attr.value.u8list.count;
+      free(sai_attr.value.u8list.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_INT8_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.s8list.count; i++)
+        thrift_attr.value.s8list.int8list.push_back(
+            sai_attr.value.s8list.list[i]);
+      thrift_attr.value.s8list.count = sai_attr.value.s8list.count;
+      free(sai_attr.value.s8list.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_UINT16_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.u16list.count; i++)
+        thrift_attr.value.u16list.uint16list.push_back(
+            sai_attr.value.u16list.list[i]);
+      thrift_attr.value.u16list.count = sai_attr.value.u16list.count;
+      free(sai_attr.value.u16list.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_INT16_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.s16list.count; i++)
+        thrift_attr.value.s16list.int16list.push_back(
+            sai_attr.value.s16list.list[i]);
+      thrift_attr.value.s16list.count = sai_attr.value.s16list.count;
+      free(sai_attr.value.s16list.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_UINT32_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.u32list.count; i++)
+        thrift_attr.value.u32list.uint32list.push_back(
+            sai_attr.value.u32list.list[i]);
+      thrift_attr.value.u32list.count = sai_attr.value.u32list.count;
+      free(sai_attr.value.u32list.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_INT32_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.s32list.count; i++)
+        thrift_attr.value.s32list.int32list.push_back(
+            sai_attr.value.s32list.list[i]);
+      thrift_attr.value.s32list.count = sai_attr.value.s32list.count;
+      free(sai_attr.value.s32list.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_UINT32_RANGE:
+      thrift_attr.value.u32range.min = sai_attr.value.u32range.min;
+      thrift_attr.value.u32range.max = sai_attr.value.u32range.max;
+      break;
+    case SAI_ATTR_VALUE_TYPE_INT32_RANGE:
+      thrift_attr.value.s32range.min = sai_attr.value.s32range.min;
+      thrift_attr.value.s32range.max = sai_attr.value.s32range.max;
+      break;
+
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_BOOL:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_INT8:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT16:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_INT16:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT32:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_INT32:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_MAC:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_IPV4:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_IPV6:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_OBJECT_ID:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_OBJECT_LIST:
+    case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_BOOL:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_UINT8:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_INT8:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_UINT16:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_INT16:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_UINT32:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_INT32:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_MAC:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_IPV4:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_IPV6:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_IP_ADDRESS:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_ID:
+    case SAI_ATTR_VALUE_TYPE_ACL_ACTION_DATA_OBJECT_LIST:
+      //TODO
+      break;
+
+    case SAI_ATTR_VALUE_TYPE_ACL_CAPABILITY: {
+      for (unsigned int i = 0;
+           i < sai_attr.value.aclcapability.action_list.count;
+           i++) {
+        thrift_attr.value.aclcapability.action_list.int32list.push_back(
+            sai_attr.value.aclcapability.action_list.list[i]);
+      }
+      thrift_attr.value.aclcapability.action_list.count =
+          sai_attr.value.aclcapability.action_list.count;
+      free(sai_attr.value.aclcapability.action_list.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_ACL_RESOURCE_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.aclresource.count; i++) {
+        sai_thrift_acl_resource_t resource = {};
+        resource.stage = sai_attr.value.aclresource.list[i].stage;
+        resource.bind_point = sai_attr.value.aclresource.list[i].bind_point;
+        resource.avail_num = sai_attr.value.aclresource.list[i].avail_num;
+        thrift_attr.value.aclresource.resourcelist.push_back(resource);
+      }
+      thrift_attr.value.aclresource.count = sai_attr.value.aclresource.count;
+      free(sai_attr.value.aclresource.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.ipaddrlist.count; i++) {
+        sai_thrift_ip_address_t thrift_ip;
+        sai_ip_address_t_to_thrift(thrift_ip,
+                                   sai_attr.value.ipaddrlist.list[i]);
+        thrift_attr.value.ipaddrlist.addresslist.push_back(thrift_ip);
+      }
+      thrift_attr.value.ipaddrlist.count = sai_attr.value.ipaddrlist.count;
+      free(sai_attr.value.ipaddrlist.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_MAP_LIST:
+    case SAI_ATTR_VALUE_TYPE_VLAN_LIST:
+    case SAI_ATTR_VALUE_TYPE_QOS_MAP_LIST: {
+      for (unsigned int i = 0; i < sai_attr.value.qosmap.count; i++) {
+        sai_thrift_qos_map_t thrift_qos_map;
+        // key
+        thrift_qos_map.key.tc = sai_attr.value.qosmap.list[i].key.tc;
+        thrift_qos_map.key.dscp = sai_attr.value.qosmap.list[i].key.dscp;
+        thrift_qos_map.key.dot1p = sai_attr.value.qosmap.list[i].key.dot1p;
+        thrift_qos_map.key.prio = sai_attr.value.qosmap.list[i].key.prio;
+        thrift_qos_map.key.pg = sai_attr.value.qosmap.list[i].key.pg;
+        thrift_qos_map.key.queue_index =
+            sai_attr.value.qosmap.list[i].key.queue_index;
+        thrift_qos_map.key.color =
+            static_cast<int32_t>(sai_attr.value.qosmap.list[i].key.color);
+        thrift_qos_map.key.mpls_exp =
+            sai_attr.value.qosmap.list[i].key.mpls_exp;
+        // value
+        thrift_qos_map.value.tc = sai_attr.value.qosmap.list[i].value.tc;
+        thrift_qos_map.value.dscp = sai_attr.value.qosmap.list[i].value.dscp;
+        thrift_qos_map.value.dot1p = sai_attr.value.qosmap.list[i].value.dot1p;
+        thrift_qos_map.value.prio = sai_attr.value.qosmap.list[i].value.prio;
+        thrift_qos_map.value.pg = sai_attr.value.qosmap.list[i].value.pg;
+        thrift_qos_map.value.queue_index =
+            sai_attr.value.qosmap.list[i].value.queue_index;
+        thrift_qos_map.value.color =
+            static_cast<int32_t>(sai_attr.value.qosmap.list[i].value.color);
+        thrift_qos_map.value.mpls_exp =
+            sai_attr.value.qosmap.list[i].value.mpls_exp;
+        thrift_attr.value.qosmap.maplist.push_back(thrift_qos_map);
+      }
+      thrift_attr.value.qosmap.count = sai_attr.value.qosmap.count;
+      free(sai_attr.value.qosmap.list);
+    } break;
+    case SAI_ATTR_VALUE_TYPE_TLV_LIST:
+    case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
+    case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
+    case SAI_ATTR_VALUE_TYPE_TIMESPEC:
+    case SAI_ATTR_VALUE_TYPE_NAT_ENTRY_DATA:
+      // not supported
+      break;
+    default:
+      break;
+  }
+}
+
+/**
+ *  @brief Convert Thrift NAT type to SAI NAT type
+ */
+void sai_thrift_nat_type_t_parse(const sai_thrift_nat_type_t &thrift_nat_type,
+                                 sai_nat_type_t *nat_type) {
+  *nat_type = (sai_nat_type_t)thrift_nat_type;
+}
+
+// including it here we never have to modify the generated file
+#include "sai_rpc_server.cpp"
+
+class sai_rpcHandlerFrontend : virtual public sai_rpcHandler {
+
+  /**
+   * @brief Thrift wrapper for sai_object_type_get_availability() SAI function
+   */
+  int64_t sai_thrift_object_type_get_availability(
+      const sai_thrift_object_type_t object_type,
+      const sai_thrift_attr_id_t attr_id,
+      const int32_t attr_type) {
+    sai_attribute_t attr = {};
+    attr.id = attr_id;
+    attr.value.s32 = attr_type;
+    uint32_t attr_count = 1;
+    uint64_t count = 0;
+
+    sai_object_type_get_availability(
+        switch_id, (sai_object_type_t)object_type, attr_count, &attr, &count);
+    return count;
+  }
+
+  /**
+   * @brief Thrift wrapper for sai_query_attribute_enum_values_capability()
+   *        function
+   */
+  void sai_thrift_query_attribute_enum_values_capability(
+      std::vector<int32_t> &thrift_enum_caps,
+      const sai_thrift_object_type_t object_type,
+      const sai_thrift_attr_id_t attr_id,
+      const int32_t caps_count) {
+    sai_status_t status = SAI_STATUS_SUCCESS;
+    sai_s32_list_t enum_values_capability;
+    int32_t *caps_list = NULL;
+
+    if (!caps_count) {
+      return;
+    }
+    caps_list = (int32_t *)malloc(sizeof(int32_t) * caps_count);
+    if (!caps_list) {
+      return;
+    }
+    enum_values_capability.list = caps_list;
+    enum_values_capability.count = caps_count;
+    status = sai_query_attribute_enum_values_capability(
+        (sai_object_id_t)switch_id,
+        (sai_object_type_t)object_type,
+        (sai_attr_id_t)attr_id,
+        &enum_values_capability);
+    if (SAI_STATUS_SUCCESS != status) {
+      free(caps_list);
+      return;
+    }
+
+    for (uint32_t i = 0; i < enum_values_capability.count; ++i) {
+      thrift_enum_caps.push_back(enum_values_capability.list[i]);
+    }
+    free(caps_list);
+  }
+};
+
+static pthread_mutex_t cookie_mutex;
+static pthread_cond_t cookie_cv;
+static void *cookie;
+
+/**
+ * @brief Create a Thrift RPC server thread
+ */
+static void *sai_thrift_rpc_server_thread(void *arg) {
+  int port = *(int *)arg;
+  std::shared_ptr<sai_rpcHandlerFrontend> handler(new sai_rpcHandlerFrontend());
+  std::shared_ptr<TProcessor> processor(new sai_rpcProcessor(handler));
+  std::shared_ptr<TServerTransport> serverTransport(new TServerSocket(port));
+  std::shared_ptr<TTransportFactory> transportFactory(
+      new TBufferedTransportFactory());
+  std::shared_ptr<TProtocolFactory> protocolFactory(
+      new TBinaryProtocolFactory());
+
+  TSimpleServer server(
+      processor, serverTransport, transportFactory, protocolFactory);
+  pthread_mutex_lock(&cookie_mutex);
+  cookie = (void *)processor.get();
+  pthread_cond_signal(&cookie_cv);
+  pthread_mutex_unlock(&cookie_mutex);
+  server.serve();
+  return 0;
+}
+
+static pthread_t sai_thrift_rpc_thread;
+
+extern "C" {
+
+/**
+ * @brief Start Thrift RPC server
+ */
+int start_p4_sai_thrift_rpc_server(char *port) {
+  static int *param = (int *)malloc(sizeof(int));
+  *param = atoi(port);
+  std::cerr << "Starting SAI RPC server on port " << port << std::endl;
+
+  cookie = NULL;
+  int status = pthread_create(
+      &sai_thrift_rpc_thread, NULL, sai_thrift_rpc_server_thread, param);
+  if (status) return status;
+  pthread_mutex_lock(&cookie_mutex);
+  while (!cookie) {
+    pthread_cond_wait(&cookie_cv, &cookie_mutex);
+  }
+  pthread_mutex_unlock(&cookie_mutex);
+  pthread_mutex_destroy(&cookie_mutex);
+  pthread_cond_destroy(&cookie_cv);
+  return status;
+}
+
+/**
+ * @brief Stop Thrift RPC server
+ */
+int stop_p4_sai_thrift_rpc_server(void) {
+  int status = pthread_cancel(sai_thrift_rpc_thread);
+  if (status == 0) {
+    int s = pthread_join(sai_thrift_rpc_thread, NULL);
+    if (s) return s;
+  }
+  return status;
+}
+}

--- a/meta/style.pm
+++ b/meta/style.pm
@@ -761,6 +761,56 @@ sub CheckDoxygenSpacing
     }
 }
 
+sub GetWordsFromSources
+{
+    my $wordsToCheck = shift;
+
+    my @sources = GetMetaSourceFiles();
+
+    my @acronyms = GetAcronyms();
+
+    my @spellExceptions = qw/ IPv4 IPv6 /;
+
+    my %exceptions = map { $_ => $_ } @spellExceptions;
+
+    my %ac = ();
+
+    $ac{$_} = 1 for @acronyms;
+
+    for my $src (sort @sources)
+    {
+        next if $src =~ /saimetadata.c/;
+        next if $src =~ /saimetadatatest.c/;
+        next if $src =~ /saiswig/;
+
+        my $data = ReadHeaderFile($src);
+
+        my @comments = ExtractComments($data);
+
+        for my $comment(@comments)
+        {
+            my @lines = split/\n/,$comment;
+
+            for my $line (@lines)
+            {
+                while ($line =~ /\b([a-z0-9]+)\b/ig)
+                {
+                    my $pre = $`;
+                    my $post = $';
+                    my $word = $1;
+
+                    next if $word =~ /xFF/;
+                    next if defined $ac{$word};
+                    next if defined $wordsToCheck->{$word};
+                    next if defined $exceptions{$word};
+
+                    $wordsToCheck->{$word} = $src;
+                }
+            }
+        }
+    }
+}
+
 sub CheckHeadersStyle
 {
     #

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -1,0 +1,945 @@
+# Copyright 2021-present Intel Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This file contains base classes for PTF test cases as well as a set of
+additional useful functions.
+
+Tests will usually inherit from one of the base classes to have the controller
+and/or dataplane automatically set up.
+"""
+
+import os
+
+from collections import OrderedDict
+
+from ptf import config
+from ptf.base_tests import BaseTest
+
+from thrift.transport import TSocket
+from thrift.transport import TTransport
+from thrift.protocol import TBinaryProtocol
+
+from sai_thrift import sai_rpc
+
+from sai_utils import *
+import sai_adapter as adapter
+
+ROUTER_MAC = '00:77:66:55:44:00'
+THRIFT_PORT = 9092
+
+
+class ThriftInterface(BaseTest):
+    """
+    Get and format a port map, retrieve test params, and create an RPC client
+    """
+    def setUp(self):
+        super(ThriftInterface, self).setUp()
+
+        self.interface_to_front_mapping = {}
+        self.port_map_loaded = False
+        self.transport = None
+
+        self.test_params = test_params_get()
+        self.loadPortMap()
+        self.createRpcClient()
+
+    def tearDown(self):
+        self.transport.close()
+
+        super(ThriftInterface, self).tearDown()
+
+    def loadPortMap(self):
+        """
+        Get and format port_map
+
+        port_map_file is a port map with following lines format:
+        [test_port_no]@[device_port_name]
+        e.g.:
+             0@Veth1
+             1@Veth2
+             2@Veth3  ...
+        """
+        if self.port_map_loaded:
+            print("port_map already loaded")
+            return
+
+        if "port_map" in self.test_params:
+            user_input = self.test_params['port_map']
+            splitted_map = user_input.split(",")
+            for item in splitted_map:
+                iface_front_pair = item.split("@")
+                self.interface_to_front_mapping[iface_front_pair[0]] =  \
+                    iface_front_pair[1]
+        elif "port_map_file" in self.test_params:
+            user_input = self.test_params['port_map_file']
+            with open(user_input, 'r') as map_file:
+                for line in map_file:
+                    if (line and (line[0] == '#' or
+                                  line[0] == ';' or line[0] == '/')):
+                        continue
+                    iface_front_pair = line.split("@")
+                    self.interface_to_front_mapping[iface_front_pair[0]] =  \
+                        iface_front_pair[1].strip()
+
+        self.port_map_loaded = True
+
+    def createRpcClient(self):
+        """
+        Set up thrift client and contact RPC server
+        """
+
+        if 'thrift_server' in self.test_params:
+            server = self.test_params['thrift_server']
+        else:
+            server = 'localhost'
+
+        self.transport = TSocket.TSocket(server, THRIFT_PORT)
+        self.transport = TTransport.TBufferedTransport(self.transport)
+        self.protocol = TBinaryProtocol.TBinaryProtocol(self.transport)
+
+        self.client = sai_rpc.Client(self.protocol)
+        self.transport.open()
+
+
+class ThriftInterfaceDataPlane(ThriftInterface):
+    """
+    Sets up the thrift interface and dataplane
+    """
+    def setUp(self):
+        super(ThriftInterfaceDataPlane, self).setUp()
+
+        self.dataplane = ptf.dataplane_instance
+        if self.dataplane is not None:
+            self.dataplane.flush()
+            if config['log_dir'] is not None:
+                filename = os.path.join(config['log_dir'], str(self)) + ".pcap"
+                self.dataplane.start_pcap(filename)
+
+    def tearDown(self):
+        if config['log_dir'] is not None:
+            self.dataplane.stop_pcap()
+        super(ThriftInterfaceDataPlane, self).tearDown()
+
+
+class SaiHelperBase(ThriftInterfaceDataPlane):
+    """
+    SAI test helper base class without initial switch ports setup
+
+    Set the following class attributes:
+        self.default_vlan_id
+        self.default_vrf
+        self.default_1q_bridge
+        self.cpu_port_hdl
+        self.active_ports_no - number of active ports
+        self.port_list - list of all active port objects
+        self.portX objects for all active ports (where X is a port number)
+    """
+    def setUp(self):
+        super(SaiHelperBase, self).setUp()
+
+        self.getSwitchPorts()
+
+        if 'switch_id' in self.test_params:
+            # get switch id initialized before
+            self.switch_id = self.test_params['switch_id']
+        else:
+            # initialize switch
+            self.switch_id = sai_thrift_create_switch(
+                self.client, init_switch=True, src_mac_address=ROUTER_MAC)
+            self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+            self.test_params['switch_id'] = self.switch_id
+
+        self.switch_resources = self.saveNumberOfAvaiableResources()
+
+        # get default vlan
+        attr = sai_thrift_get_switch_attribute(
+            self.client, default_vlan_id=True)
+        self.default_vlan_id = attr['default_vlan_id']
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+
+        if 'port_config_ini' in self.test_params:
+            if 'createPorts_has_been_called' not in config:
+                self.createPorts()
+                config['createPorts_has_been_called'] = 1
+                # check if ports became UP
+                self.checkPortsUp()
+
+        # get number of active ports
+        attr = sai_thrift_get_switch_attribute(
+            self.client, number_of_active_ports=True)
+        self.active_ports_no = attr['number_of_active_ports']
+
+        # get port_list and portX objects
+        attr = sai_thrift_get_switch_attribute(
+            self.client, port_list=sai_thrift_object_list_t(
+                idlist=[], count=self.active_ports_no))
+        self.assertEqual(self.active_ports_no, attr['port_list'].count)
+        self.port_list = attr['port_list'].idlist
+
+        for i, _ in enumerate(self.port_list):
+            setattr(self, 'port%s' % i, self.port_list[i])
+
+        # get default vrf
+        attr = sai_thrift_get_switch_attribute(
+            self.client, default_virtual_router_id=True)
+        self.default_vrf = attr['default_virtual_router_id']
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+
+        # get default 1Q bridge OID
+        attr = sai_thrift_get_switch_attribute(
+            self.client, default_1q_bridge_id=True)
+        self.default_1q_bridge = attr['default_1q_bridge_id']
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+
+        # get cpu port
+        attr = sai_thrift_get_switch_attribute(self.client, cpu_port=True)
+        self.cpu_port_hdl = attr['cpu_port']
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+
+        # get cpu port queue handles
+        attr = sai_thrift_get_port_attribute(self.client,
+                                             self.cpu_port_hdl,
+                                             qos_number_of_queues=True)
+        num_queues = attr['qos_number_of_queues']
+        q_list = sai_thrift_object_list_t(count=num_queues)
+        attr = sai_thrift_get_port_attribute(self.client,
+                                             self.cpu_port_hdl,
+                                             qos_queue_list=q_list)
+        for queue in range(0, num_queues):
+            queue_id = attr['qos_queue_list'].idlist[queue]
+            setattr(self, 'cpu_queue%s' % queue, queue_id)
+            q_attr = sai_thrift_get_queue_attribute(
+                self.client,
+                queue_id,
+                port=True,
+                index=True,
+                parent_scheduler_node=True)
+            self.assertEqual(queue, q_attr['index'])
+            self.assertEqual(self.cpu_port_hdl, q_attr['port'])
+
+    def tearDown(self):
+        try:
+            for port in self.port_list:
+                sai_thrift_clear_port_stats(self.client, port)
+                sai_thrift_set_port_attribute(
+                    self.client, port, port_vlan_id=0)
+
+            self.assertTrue(self.verifyNumberOfAvaiableResources(
+                self.switch_resources, debug=False))
+
+        finally:
+            super(SaiHelperBase, self).tearDown()
+
+    def createPorts(self):
+        """
+        Create ports after reading from port config file
+        """
+        def fec_str_to_int(fec):
+            """
+            Convert fec string to SAI enum
+
+            Args:
+                fec (string): fec string from port_config
+
+            Returns:
+                int: SAI enum value
+            """
+            fec_dict = {
+                'rs': SAI_PORT_FEC_MODE_RS,
+                'fc': SAI_PORT_FEC_MODE_FC
+            }
+            return fec_dict.get(fec, SAI_PORT_FEC_MODE_NONE)
+
+        # delete the existing ports
+        attr = sai_thrift_get_switch_attribute(
+            self.client, number_of_active_ports=True)
+        self.active_ports_no = attr['number_of_active_ports']
+        attr = sai_thrift_get_switch_attribute(
+            self.client, port_list=sai_thrift_object_list_t(
+                idlist=[], count=self.active_ports_no))
+        if self.active_ports_no:
+            self.port_list = attr['port_list'].idlist
+            for port in self.port_list:
+                sai_thrift_remove_port(self.client, port)
+
+        # add new ports from port config file
+        self.ports_config = self.parsePortConfig(
+            self.test_params['port_config_ini'])
+        for name, port in self.ports_config.items():
+            print("Creating port: %s" % name)
+            fec_mode = fec_str_to_int(port.get('fec', None))
+            auto_neg_mode = True if port.get(
+                'autoneg', "").lower() == "on" else False
+            sai_list = sai_thrift_u32_list_t(
+                count=len(port['lanes']), uint32list=port['lanes'])
+            sai_thrift_create_port(self.client,
+                                   hw_lane_list=sai_list,
+                                   fec_mode=fec_mode,
+                                   auto_neg_mode=auto_neg_mode,
+                                   speed=port['speed'],
+                                   admin_state=True)
+
+    def parsePortConfig(self, port_config_file):
+        """
+        Parse port_config.ini file
+
+        Example of supported format for port_config.ini:
+        # name        lanes       alias       index    speed    autoneg   fec
+        Ethernet0       0         Ethernet0     1      25000      off     none
+        Ethernet1       1         Ethernet1     1      25000      off     none
+        Ethernet2       2         Ethernet2     1      25000      off     none
+        Ethernet3       3         Ethernet3     1      25000      off     none
+        Ethernet4       4         Ethernet4     2      25000      off     none
+        Ethernet5       5         Ethernet5     2      25000      off     none
+        Ethernet6       6         Ethernet6     2      25000      off     none
+        Ethernet7       7         Ethernet7     2      25000      off     none
+        Ethernet8       8         Ethernet8     3      25000      off     none
+        Ethernet9       9         Ethernet9     3      25000      off     none
+        Ethernet10      10        Ethernet10    3      25000      off     none
+        Ethernet11      11        Ethernet11    3      25000      off     none
+        etc
+
+        Args:
+            port_config_file (string): path to port config file
+
+        Returns:
+            dict: port configuation from file
+
+        Raises:
+            e: exit if file not found
+        """
+        ports = OrderedDict()
+        try:
+            with open(port_config_file) as conf:
+                for line in conf:
+                    if line.startswith('#'):
+                        if "name" in line:
+                            titles = line.strip('#').split()
+                        continue
+                    tokens = line.split()
+                    if len(tokens) < 2:
+                        continue
+                    name_index = titles.index('name')
+                    name = tokens[name_index]
+                    data = {}
+                    for i, item in enumerate(tokens):
+                        if i == name_index:
+                            continue
+                        data[titles[i]] = item
+                    data['lanes'] = [int(lane)
+                                     for lane in data['lanes'].split(',')]
+                    data['speed'] = int(data['speed'])
+                    ports[name] = data
+            return ports
+        except Exception as e:
+            raise e
+
+    def checkPortsUp(self, timeout=30):
+        """
+        Wait for all ports to be UP
+        This may be required while testing on hardware
+        The test fails if all ports are not UP after timeout
+
+        Args:
+            timeout (int): port verification timeout in sec
+        """
+        allup = False
+        timer_start = time.time()
+
+        while allup is False and time.time() - timer_start < timeout:
+            allup = True
+            for port in self.port_list:
+                attr = sai_thrift_get_port_attribute(
+                    self.client, port, oper_status=True)
+                if attr['oper_status'] != SAI_SWITCH_OPER_STATUS_UP:
+                    allup = False
+                    break
+            if allup:
+                break
+            time.sleep(5)
+
+        self.assertTrue(allup)
+
+    def getSwitchPorts(self):
+        """
+        Get device port numbers
+        """
+        dev_no = 0
+        for _, port, _ in config['interfaces']:
+            setattr(self, 'dev_port%d' % dev_no, port)
+            dev_no += 1
+
+    def printNumberOfAvaiableResources(self, resources_dict):
+        """
+        Prints numbers of available resources
+
+        Args:
+            resources_dict (dict): a dictionary with resources numbers
+        """
+
+        print("***** Number of available resources *****")
+        for key, value in resources_dict:
+            print(key, ": ", value)
+
+    def saveNumberOfAvaiableResources(self, debug=False):
+        """
+        Save number of available resources
+        This allows to verify if all the test objects were removed
+
+        Args:
+            debug (bool): enables debug option
+        Return:
+            dict: switch_resources dictionary with available resources
+        """
+
+        switch_resources = sai_thrift_get_switch_attribute(
+            self.client,
+            available_ipv4_route_entry=True,
+            available_ipv6_route_entry=True,
+            available_ipv4_nexthop_entry=True,
+            available_ipv6_nexthop_entry=True,
+            available_ipv4_neighbor_entry=True,
+            available_ipv6_neighbor_entry=True,
+            available_next_hop_group_entry=True,
+            available_next_hop_group_member_entry=True,
+            available_fdb_entry=True,
+            available_ipmc_entry=True,
+            available_snat_entry=True,
+            available_dnat_entry=True,
+            available_double_nat_entry=True,
+            number_of_ecmp_groups=True,
+            ecmp_members=True)
+
+        if debug:
+            self.printNumberOfAvaiableResources(switch_resources)
+
+        return switch_resources
+
+    def verifyNumberOfAvaiableResources(self, init_resources, debug=False):
+        """
+        Verify number of available resources
+
+        Args:
+            init_resources (dict): a dictionary with initial resources numbers
+            debug (bool): enable debug option
+
+        Returns:
+            bool: True if the numbers of resources are the same as before tests
+        """
+
+        available_resources = sai_thrift_get_switch_attribute(
+            self.client,
+            available_ipv4_route_entry=True,
+            available_ipv6_route_entry=True,
+            available_ipv4_nexthop_entry=True,
+            available_ipv6_nexthop_entry=True,
+            available_ipv4_neighbor_entry=True,
+            available_ipv6_neighbor_entry=True,
+            available_next_hop_group_entry=True,
+            available_next_hop_group_member_entry=True,
+            available_fdb_entry=True,
+            available_ipmc_entry=True,
+            available_snat_entry=True,
+            available_dnat_entry=True,
+            available_double_nat_entry=True,
+            number_of_ecmp_groups=True,
+            ecmp_members=True)
+
+        for key, value in available_resources.items():
+            if value != init_resources[key]:
+                if debug:
+                    print("Number of %s incorrect!" % key)
+                return False
+
+        return True
+
+    @staticmethod
+    def status():
+        """
+        Returns the last operation status.
+
+        Returns:
+            int: sai call result
+        """
+        return adapter.status
+
+    @staticmethod
+    def saiWaitFdbAge(timeout):
+        """
+        Wait for fdb entry to ageout
+
+        Args:
+            timeout (int): Timeout value in seconds
+        """
+        print("Waiting for fdb entry to age")
+        aging_interval_buffer = 10
+        time.sleep(timeout + aging_interval_buffer)
+
+
+class SaiHelper(SaiHelperBase):
+    """
+    Set common base ports configuration for tests
+
+Common ports configuration:
+* U/T = untagged/tagged VLAN member
++--------+------+-----------+-------------+--------+------------+------------+
+| Port   | LAG  | _member   | Bridge port | VLAN   | _member    | RIF        |
++========+======|===========+=============+========+============+============+
+| port0  |      |           | port0_bp    | vlan10 | _member0 U |            |
+| port1  |      |           | port1_bp    |        | _member1 T |            |
++--------+------+-----------+-------------+--------+------------+------------+
+| port2  |      |           | port2_bp    | vlan20 | _member0 U |            |
+| port3  |      |           | port3_bp    |        | _member1 T |            |
++--------+------+-----------+-------------+--------+------------+------------+
+| port4  | lag1 | _member4  | lag1_bp     | vlan10 | _member2 U |            |
+| port5  |      | _member5  |             |        |            |            |
+| port6  |      | _member6  |             |        |            |            |
++--------+------+-----------+-------------+--------+------------+------------+
+| port7  | lag2 | _member7  | lag2_bp     | vlan20 | _member2 T |            |
+| port8  |      | _member8  |             |        |            |            |
+| port9  |      | _member9  |             |        |            |            |
++--------+------+-----------+-------------+--------+------------+------------+
+| port10 |      |           |             |        |            | port10_rif |
++--------+------+-----------+-------------+--------+------------+------------+
+| port11 |      |           |             |        |            | port11_rif |
++--------+------+-----------+-------------+--------+------------+------------+
+| port12 |      |           |             |        |            | port12_rif |
++--------+------+-----------+-------------+--------+------------+------------+
+| port13 |      |           |             |        |            | port13_rif |
++--------+------+-----------+-------------+--------+------------+------------+
+| port14 | lag3 | _member14 |             |        |            | lag3_rif   |
+| port15 |      | _member15 |             |        |            |            |
+| port16 |      | _member16 |             |        |            |            |
++--------+------+-----------+-------------+--------+------------+------------+
+| port17 | lag4 | _member17 |             |        |            | lag4_rif   |
+| port18 |      | _member18 |             |        |            |            |
+| port19 |      | _member19 |             |        |            |            |
++--------+------+-----------+-------------+--------+------------+------------+
+| port20 |      |           | port20_bp   | vlan30 | _member0 U | vlan30_rif |
+| port21 |      |           | port21_bp   |        | _member1 T |            |
++--------+------+-----------+-------------+--------+------------+------------+
+| port22 | lag5 | _member22 | lag5_bp     | vlan30 | _member2 T |            |
+| port23 |      | _member23 |             |        |            |            |
++--------+------+-----------+-------------+--------+------------+------------+
+| port24 |                                                                   |
+| port25 |                                                                   |
+| port26 |                                                                   |
+| port27 |                            UNASSIGNED                             |
+| port28 |                                                                   |
+| port29 |                                                                   |
+| port30 |                                                                   |
+| port31 |                                                                   |
++--------+-------------------------------------------------------------------+
+    """
+
+    def setUp(self):
+        super(SaiHelper, self).setUp()
+
+        # lists of default objects
+        self.def_bridge_port_list = []
+        self.def_lag_list = []
+        self.def_lag_member_list = []
+        self.def_vlan_list = []
+        self.def_vlan_member_list = []
+        self.def_rif_list = []
+
+        # create bridge ports
+        self.port0_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.port0,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_bridge_port_list.append(self.port0_bp)
+
+        self.port1_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.port1,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_bridge_port_list.append(self.port1_bp)
+
+        self.port2_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.port2,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_bridge_port_list.append(self.port2_bp)
+
+        self.port3_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.port3,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_bridge_port_list.append(self.port3_bp)
+
+        self.port20_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.port20,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_bridge_port_list.append(self.port20_bp)
+
+        self.port21_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.port21,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_bridge_port_list.append(self.port21_bp)
+
+        # create LAGs
+        self.lag1 = sai_thrift_create_lag(self.client)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_lag_list.append(self.lag1)
+
+        self.lag1_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.lag1,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_bridge_port_list.append(self.lag1_bp)
+
+        self.lag1_member4 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag1, port_id=self.port4)
+        self.def_lag_member_list.append(self.lag1_member4)
+        self.lag1_member5 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag1, port_id=self.port5)
+        self.def_lag_member_list.append(self.lag1_member5)
+        self.lag1_member6 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag1, port_id=self.port6)
+        self.def_lag_member_list.append(self.lag1_member6)
+
+        self.lag2 = sai_thrift_create_lag(self.client)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_lag_list.append(self.lag2)
+
+        self.lag2_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.lag2,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_bridge_port_list.append(self.lag2_bp)
+
+        self.lag2_member7 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag2, port_id=self.port7)
+        self.def_lag_member_list.append(self.lag2_member7)
+        self.lag2_member8 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag2, port_id=self.port8)
+        self.def_lag_member_list.append(self.lag2_member8)
+        self.lag2_member9 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag2, port_id=self.port9)
+        self.def_lag_member_list.append(self.lag2_member9)
+
+        # L3 lags
+        self.lag3 = sai_thrift_create_lag(self.client)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_lag_list.append(self.lag3)
+
+        self.lag3_member14 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag3, port_id=self.port14)
+        self.def_lag_member_list.append(self.lag3_member14)
+        self.lag3_member15 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag3, port_id=self.port15)
+        self.def_lag_member_list.append(self.lag3_member15)
+        self.lag3_member16 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag3, port_id=self.port16)
+        self.def_lag_member_list.append(self.lag3_member16)
+
+        self.lag4 = sai_thrift_create_lag(self.client)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_lag_list.append(self.lag4)
+
+        self.lag4_member17 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag4, port_id=self.port17)
+        self.def_lag_member_list.append(self.lag4_member17)
+        self.lag4_member18 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag4, port_id=self.port18)
+        self.def_lag_member_list.append(self.lag4_member18)
+        self.lag4_member19 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag4, port_id=self.port19)
+        self.def_lag_member_list.append(self.lag4_member19)
+
+        self.lag5 = sai_thrift_create_lag(self.client)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_lag_list.append(self.lag5)
+
+        self.lag5_bp = sai_thrift_create_bridge_port(
+            self.client,
+            bridge_id=self.default_1q_bridge,
+            port_id=self.lag5,
+            type=SAI_BRIDGE_PORT_TYPE_PORT,
+            admin_state=True)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_bridge_port_list.append(self.lag5_bp)
+
+        self.lag5_member22 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag5, port_id=self.port22)
+        self.def_lag_member_list.append(self.lag5_member22)
+        self.lag5_member23 = sai_thrift_create_lag_member(
+            self.client, lag_id=self.lag5, port_id=self.port23)
+        self.def_lag_member_list.append(self.lag5_member23)
+
+        # create vlan 10 with port0, port1 and lag1
+        self.vlan10 = sai_thrift_create_vlan(self.client, vlan_id=10)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_vlan_list.append(self.vlan10)
+
+        self.vlan10_member0 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan10,
+            bridge_port_id=self.port0_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        self.def_vlan_member_list.append(self.vlan10_member0)
+        self.vlan10_member1 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan10,
+            bridge_port_id=self.port1_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
+        self.def_vlan_member_list.append(self.vlan10_member1)
+        self.vlan10_member2 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan10,
+            bridge_port_id=self.lag1_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        self.def_vlan_member_list.append(self.vlan10_member2)
+
+        # create vlan 20 with port2, port3 and lag2
+        self.vlan20 = sai_thrift_create_vlan(self.client, vlan_id=20)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_vlan_list.append(self.vlan20)
+
+        self.vlan20_member0 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan20,
+            bridge_port_id=self.port2_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        self.def_vlan_member_list.append(self.vlan20_member0)
+        self.vlan20_member1 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan20,
+            bridge_port_id=self.port3_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
+        self.def_vlan_member_list.append(self.vlan20_member1)
+        self.vlan20_member2 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan20,
+            bridge_port_id=self.lag2_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
+        self.def_vlan_member_list.append(self.vlan20_member2)
+
+        # create vlan 30 with port20, port21 and lag5
+        self.vlan30 = sai_thrift_create_vlan(self.client, vlan_id=30)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_vlan_list.append(self.vlan30)
+
+        self.vlan30_member0 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan30,
+            bridge_port_id=self.port20_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        self.def_vlan_member_list.append(self.vlan30_member0)
+        self.vlan30_member1 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan30,
+            bridge_port_id=self.port21_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
+        self.def_vlan_member_list.append(self.vlan30_member1)
+        self.vlan30_member2 = sai_thrift_create_vlan_member(
+            self.client,
+            vlan_id=self.vlan30,
+            bridge_port_id=self.lag5_bp,
+            vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
+        self.def_vlan_member_list.append(self.vlan30_member2)
+
+        # setup untagged ports
+        sai_thrift_set_port_attribute(self.client, self.port0, port_vlan_id=10)
+        sai_thrift_set_lag_attribute(self.client, self.lag1, port_vlan_id=10)
+        sai_thrift_set_port_attribute(self.client, self.port2, port_vlan_id=20)
+
+        # create L3 configuration
+        self.vlan30_rif = sai_thrift_create_router_interface(
+            self.client,
+            type=SAI_ROUTER_INTERFACE_TYPE_VLAN,
+            virtual_router_id=self.default_vrf,
+            vlan_id=self.vlan30)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_rif_list.append(self.vlan30_rif)
+
+        self.lag3_rif = sai_thrift_create_router_interface(
+            self.client,
+            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+            virtual_router_id=self.default_vrf,
+            port_id=self.lag3)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_rif_list.append(self.lag3_rif)
+
+        self.lag4_rif = sai_thrift_create_router_interface(
+            self.client,
+            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+            virtual_router_id=self.default_vrf,
+            port_id=self.lag4)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_rif_list.append(self.lag4_rif)
+
+        self.port10_rif = sai_thrift_create_router_interface(
+            self.client,
+            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+            virtual_router_id=self.default_vrf,
+            port_id=self.port10)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_rif_list.append(self.port10_rif)
+
+        self.port11_rif = sai_thrift_create_router_interface(
+            self.client,
+            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+            virtual_router_id=self.default_vrf,
+            port_id=self.port11)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_rif_list.append(self.port11_rif)
+
+        self.port12_rif = sai_thrift_create_router_interface(
+            self.client,
+            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+            virtual_router_id=self.default_vrf,
+            port_id=self.port12)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_rif_list.append(self.port12_rif)
+
+        self.port13_rif = sai_thrift_create_router_interface(
+            self.client,
+            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+            virtual_router_id=self.default_vrf,
+            port_id=self.port13)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.def_rif_list.append(self.port13_rif)
+
+    def tearDown(self):
+        sai_thrift_set_port_attribute(self.client, self.port2, port_vlan_id=0)
+        sai_thrift_set_lag_attribute(self.client, self.lag1, port_vlan_id=0)
+        sai_thrift_set_port_attribute(self.client, self.port0, port_vlan_id=0)
+
+        for rif in self.def_rif_list:
+            sai_thrift_remove_router_interface(self.client, rif)
+
+        for vlan_member in self.def_vlan_member_list:
+            sai_thrift_remove_vlan_member(self.client, vlan_member)
+
+        for bridge_port in self.def_bridge_port_list:
+            sai_thrift_remove_bridge_port(self.client, bridge_port)
+
+        for lag_member in self.def_lag_member_list:
+            sai_thrift_remove_lag_member(self.client, lag_member)
+
+        for lag in self.def_lag_list:
+            sai_thrift_remove_lag(self.client, lag)
+
+        for vlan in self.def_vlan_list:
+            sai_thrift_remove_vlan(self.client, vlan)
+
+        super(SaiHelper, self).tearDown()
+
+
+class MinimalPortVlanConfig(SaiHelperBase):
+    """
+    Minimal port and vlan configuration. Create port_num bridge ports and add
+    them to VLAN with vlan_id. Configure ports as untagged
+    """
+
+    def __init__(self, port_num, vlan_id=100):
+        """
+        Args:
+            port_num (int): Number of ports to configure
+            vlan_id (int): ID of VLAN that will be created
+        """
+        super(MinimalPortVlanConfig, self).__init__()
+
+        self.port_num = port_num
+        self.vlan_id = vlan_id
+
+    def setUp(self):
+        super(MinimalPortVlanConfig, self).setUp()
+
+        if self.port_num > self.active_ports_no:
+            raise ValueError('Number of ports to configure %d is higher '
+                             'than number of active ports %d'
+                             % (self.port_num, self.active_ports_no))
+
+        self.def_bridge_port_list = []
+        self.def_vlan_member_list = []
+
+        # create bridge ports
+        for port in self.port_list:
+            bp = sai_thrift_create_bridge_port(
+                self.client, bridge_id=self.default_1q_bridge,
+                port_id=port, type=SAI_BRIDGE_PORT_TYPE_PORT,
+                admin_state=True)
+
+            self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+            self.def_bridge_port_list.append(bp)
+
+        # create vlan
+        self.vlan = sai_thrift_create_vlan(self.client, vlan_id=self.vlan_id)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+
+        # add ports to vlan
+        for bridge_port in self.def_bridge_port_list:
+            vm = sai_thrift_create_vlan_member(
+                self.client, vlan_id=self.vlan,
+                bridge_port_id=bridge_port,
+                vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
+
+            self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+            self.def_vlan_member_list.append(vm)
+
+        # setup untagged ports
+        for port in self.port_list:
+            status = sai_thrift_set_port_attribute(
+                self.client, port, port_vlan_id=self.vlan_id)
+
+            self.assertEqual(status, SAI_STATUS_SUCCESS)
+
+    def tearDown(self):
+        # revert untagged ports configuration
+        for port in self.port_list:
+            sai_thrift_set_port_attribute(
+                self.client, port, port_vlan_id=0)
+
+        # remove ports from vlan
+        for vlan_member in self.def_vlan_member_list:
+            sai_thrift_remove_vlan_member(self.client, vlan_member)
+
+        # remove vlan
+        sai_thrift_remove_vlan(self.client, self.vlan)
+
+        # remove bridge ports
+        for bridge_port in self.def_bridge_port_list:
+            sai_thrift_remove_bridge_port(self.client, bridge_port)
+
+        super(MinimalPortVlanConfig, self).tearDown()

--- a/ptf/sai_utils.py
+++ b/ptf/sai_utils.py
@@ -1,0 +1,291 @@
+# Copyright 2021-present Intel Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Thrift SAI interface basic utils.
+"""
+
+import time
+import struct
+import socket
+
+from functools import wraps
+
+from ptf.packet import *
+from ptf.testutils import *
+
+from sai_adapter import *
+
+
+def sai_thrift_query_attribute_enum_values_capability(client,
+                                                      obj_type,
+                                                      attr_id=None):
+    """
+    Call the sai_thrift_query_attribute_enum_values_capability() function
+    and return the list of supported aattr_is enum capabilities
+
+    Args:
+        client (Client): SAI RPC client
+        obj_type (enum): SAI object type
+        attr_id (attr): SAI attribute name
+
+    Returns:
+        list: list of switch object type enum capabilities
+    """
+    max_cap_no = 20
+
+    enum_cap_list = client.sai_thrift_query_attribute_enum_values_capability(
+        obj_type, attr_id, max_cap_no)
+
+    return enum_cap_list
+
+
+def sai_thrift_object_type_get_availability(client,
+                                            obj_type,
+                                            attr_id=None,
+                                            attr_type=None):
+    """
+    sai_thrift_object_type_get_availability() RPC client function
+    implementation
+
+    Args:
+        client (Client): SAI RPC client
+        obj_type (enum): SAI object type
+        attr_id (attr): SAI attribute name
+        attr_type (type): SAI attribute type
+
+    Returns:
+        uint: number of available resources with given parameters
+    """
+    availability_cnt = client.sai_thrift_object_type_get_availability(
+        obj_type, attr_id, attr_type)
+
+    return availability_cnt
+
+
+def sai_thrift_get_debug_counter_port_stats(client, port_oid, counter_ids):
+    """
+    Get port statistics for given debug counters
+
+    Args:
+        client (Client): SAI RPC client
+        port_oid (sai_thrift_object_id_t): object_id IN argument
+        counter_ids (sai_stat_id_t): list of requested counters
+
+    Returns:
+        Dict[str, sai_thrift_uint64_t]: stats
+    """
+
+    stats = {}
+    counters = client.sai_thrift_get_port_stats(port_oid, counter_ids)
+
+    for i, counter_id in enumerate(counter_ids):
+        stats[counter_id] = counters[i]
+
+    return stats
+
+
+def sai_thrift_get_debug_counter_switch_stats(client, counter_ids):
+    """
+    Get switch statistics for given debug counters
+
+    Args:
+        client (Client): SAI RPC client
+        counter_ids (sai_stat_id_t): list of requested counters
+
+    Returns:
+        Dict[str, sai_thrift_uint64_t]: stats
+    """
+
+    stats = {}
+    counters = client.sai_thrift_get_switch_stats(counter_ids)
+
+    for i, counter_id in enumerate(counter_ids):
+        stats[counter_id] = counters[i]
+
+    return stats
+
+
+def sai_ipaddress(addr_str):
+    """
+    Set SAI IP address, assign appropriate type and return
+    sai_thrift_ip_address_t object
+
+    Args:
+        addr_str (str): IP address string
+
+    Returns:
+        sai_thrift_ip_address_t: object containing IP address family and number
+    """
+
+    if '.' in addr_str:
+        family = SAI_IP_ADDR_FAMILY_IPV4
+        addr = sai_thrift_ip_addr_t(ip4=addr_str)
+    if ':' in addr_str:
+        family = SAI_IP_ADDR_FAMILY_IPV6
+        addr = sai_thrift_ip_addr_t(ip6=addr_str)
+    ip_addr = sai_thrift_ip_address_t(addr_family=family, addr=addr)
+
+    return ip_addr
+
+
+def sai_ipprefix(prefix_str):
+    """
+    Set IP address prefix and mask and return ip_prefix object
+
+    Args:
+        prefix_str (str): IP address and mask string (with slash notation)
+
+    Return:
+        sai_thrift_ip_prefix_t: IP prefix object
+    """
+    addr_mask = prefix_str.split('/')
+    if len(addr_mask) != 2:
+        print("Invalid IP prefix format")
+        return None
+
+    if '.' in prefix_str:
+        family = SAI_IP_ADDR_FAMILY_IPV4
+        addr = sai_thrift_ip_addr_t(ip4=addr_mask[0])
+        mask = num_to_dotted_quad(addr_mask[1])
+        mask = sai_thrift_ip_addr_t(ip4=mask)
+    if ':' in prefix_str:
+        family = SAI_IP_ADDR_FAMILY_IPV6
+        addr = sai_thrift_ip_addr_t(ip6=addr_mask[0])
+        mask = num_to_dotted_quad(int(addr_mask[1]), ipv4=False)
+        mask = sai_thrift_ip_addr_t(ip6=mask)
+
+    ip_prefix = sai_thrift_ip_prefix_t(
+        addr_family=family, addr=addr, mask=mask)
+    return ip_prefix
+
+
+def num_to_dotted_quad(address, ipv4=True):
+    """
+    Helper function to convert the ip address
+
+    Args:
+        address (str): IP address
+        ipv4 (bool): determines what IP version is handled
+
+    Returns:
+        str: formatted IP address
+    """
+    if ipv4 is True:
+        mask = (1 << 32) - (1 << 32 >> int(address))
+        return socket.inet_ntop(socket.AF_INET, struct.pack('>L', mask))
+
+    mask = (1 << 128) - (1 << 128 >> int(address))
+    i = 0
+    result = ''
+    for sign in str(hex(mask)[2:]):
+        if (i + 1) % 4 == 0:
+            result = result + sign + ':'
+        else:
+            result = result + sign
+        i += 1
+    return result[:-1]
+
+
+def open_packet_socket(hostif_name):
+    """
+    Open a linux socket
+
+    Args:
+        hostif_name (str): socket interface name
+
+    Return:
+        sock: socket ID
+    """
+    eth_p_all = 3
+    sock = socket.socket(socket.AF_PACKET, socket.SOCK_RAW,
+                         socket.htons(eth_p_all))
+    sock.bind((hostif_name, eth_p_all))
+    sock.setblocking(0)
+
+    return sock
+
+
+def socket_verify_packet(pkt, sock, timeout=2):
+    """
+    Verify packet was received on a socket
+
+    Args:
+        pkt (packet): packet to match with
+        sock (int): socket ID
+        timeout (int): timeout
+
+    Return:
+        bool: True if packet matched
+    """
+    max_pkt_size = 9100
+    timeout = time.time() + timeout
+    match = False
+
+    if isinstance(pkt, ptf.mask.Mask):
+        if not pkt.is_valid():
+            return False
+
+    while time.time() < timeout:
+        try:
+            packet_from_tap_device = Ether(sock.recv(max_pkt_size))
+
+            if isinstance(pkt, ptf.mask.Mask):
+                match = pkt.pkt_match(packet_from_tap_device)
+            else:
+                match = (str(packet_from_tap_device) == str(pkt))
+
+            if match:
+                break
+
+        except BaseException:
+            pass
+
+    return match
+
+
+def delay_wrapper(func, delay=2):
+    """
+    A wrapper extending given function by a delay
+
+    Args:
+        func (function): function to be wrapped
+        delay (int): delay period in sec
+
+    Return:
+        wrapped_function: wrapped function
+    """
+    @wraps(func)
+    def wrapped_function(*args, **kwargs):
+        """
+        A wrapper function adding a delay
+
+        Args:
+            args (tuple): function arguments
+            kwargs (dict): keyword function arguments
+
+        Return:
+            status: original function return value
+        """
+        test_params = test_params_get()
+        if test_params['target'] != "hw":
+            time.sleep(delay)
+
+        status = func(*args, **kwargs)
+        return status
+
+    return wrapped_function
+
+
+sai_thrift_flush_fdb_entries = delay_wrapper(sai_thrift_flush_fdb_entries)

--- a/ptf/saitest.py
+++ b/ptf/saitest.py
@@ -1,0 +1,180 @@
+# Copyright 2021-present Intel Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Thrift SAI interface tester
+"""
+
+from sai_thrift.sai_headers import *
+
+from ptf.packet import *
+from ptf.testutils import *
+
+from sai_base_test import *
+
+
+class FrameworkTester(SaiHelper):
+    """
+    Test auto-generated framework itself
+    The intention of this test is to check if basic features works as expected
+    """
+
+    def setUp(self):
+        super(FrameworkTester, self).setUp()
+
+        self.route_entry_list = []
+        self.nhop_list = []
+
+        # test fdb creation
+        self.fdb_entry = sai_thrift_fdb_entry_t(
+            switch_id=self.switch_id,
+            mac_address="00:11:22:33:44:55",
+            bv_id=self.vlan10)
+        status = sai_thrift_create_fdb_entry(
+            self.client,
+            self.fdb_entry,
+            type=SAI_FDB_ENTRY_TYPE_STATIC,
+            bridge_port_id=self.port0_bp)
+        self.assertEqual(status, SAI_STATUS_SUCCESS)
+
+        # test nhop creation
+        self.nhop = sai_thrift_create_next_hop(
+            self.client,
+            type=SAI_NEXT_HOP_TYPE_IP,
+            router_interface_id=self.port10_rif,
+            ip=sai_ipaddress('10.10.10.1'))
+        self.nhop_list.append(self.nhop)
+
+        self.nhop1 = sai_thrift_create_next_hop(
+            self.client,
+            type=SAI_NEXT_HOP_TYPE_IP,
+            router_interface_id=self.port10_rif,
+            ip=sai_ipaddress('4444::1'))
+        self.nhop_list.append(self.nhop1)
+
+        # test neighbor creation
+        self.neigh_entry = sai_thrift_neighbor_entry_t(
+            self.switch_id, self.port10_rif, sai_ipaddress('10.10.10.1'))
+        self.neigh = sai_thrift_create_neighbor_entry(
+            self.client, self.neigh_entry, dst_mac_address='00:11:22:33:44:66')
+
+        # test route creation
+        self.route0 = sai_thrift_route_entry_t(
+            switch_id=self.switch_id,
+            destination=sai_ipprefix('20.20.20.1/16'),
+            vr_id=self.default_vrf)
+        status = sai_thrift_create_route_entry(
+            self.client, self.route0, next_hop_id=self.nhop)
+        self.assertEqual(status, SAI_STATUS_SUCCESS)
+        self.route_entry_list.append(self.route0)
+
+        self.route1 = sai_thrift_route_entry_t(
+            switch_id=self.switch_id,
+            destination=sai_ipprefix('4441::1/64'),
+            vr_id=self.default_vrf)
+        status = sai_thrift_create_route_entry(
+            self.client, self.route1, next_hop_id=self.nhop)
+        self.assertEqual(status, SAI_STATUS_SUCCESS)
+        self.route_entry_list.append(self.route1)
+
+        self.route2 = sai_thrift_route_entry_t(
+            switch_id=self.switch_id,
+            destination=sai_ipprefix('4411::1/63'),
+            vr_id=self.default_vrf)
+        status = sai_thrift_create_route_entry(
+            self.client, self.route2, next_hop_id=self.nhop)
+        self.assertEqual(status, SAI_STATUS_SUCCESS)
+        self.route_entry_list.append(self.route2)
+
+        self.route3 = sai_thrift_route_entry_t(
+            switch_id=self.switch_id,
+            destination=sai_ipprefix('4423::1/65'),
+            vr_id=self.default_vrf)
+        status = sai_thrift_create_route_entry(
+            self.client, self.route3, next_hop_id=self.nhop)
+        self.assertEqual(status, SAI_STATUS_SUCCESS)
+        self.route_entry_list.append(self.route3)
+
+        self.route4 = sai_thrift_route_entry_t(
+            switch_id=self.switch_id,
+            destination=sai_ipprefix('4444::1/127'),
+            vr_id=self.default_vrf)
+        status = sai_thrift_create_route_entry(
+            self.client, self.route4, next_hop_id=self.nhop)
+        self.assertEqual(status, SAI_STATUS_SUCCESS)
+        self.route_entry_list.append(self.route4)
+
+        # test qos map creation
+        dscp_to_tc_1 = sai_thrift_qos_map_t(
+            key=sai_thrift_qos_map_params_t(dscp=2),
+            value=sai_thrift_qos_map_params_t(tc=16))
+        dscp_to_tc_2 = sai_thrift_qos_map_t(
+            key=sai_thrift_qos_map_params_t(dscp=4),
+            value=sai_thrift_qos_map_params_t(tc=24))
+        self.qos_map_list = sai_thrift_qos_map_list_t(
+            count=2, maplist=[dscp_to_tc_1, dscp_to_tc_2])
+        self.qos_map = sai_thrift_create_qos_map(
+            self.client,
+            SAI_QOS_MAP_TYPE_DSCP_TO_TC,
+            map_to_value_list=self.qos_map_list)
+
+    def runTest(self):
+        attr = sai_thrift_get_fdb_entry_attribute(
+            self.client, self.fdb_entry, bridge_port_id=True)
+        self.assertEqual(attr['bridge_port_id'], self.port0_bp)
+
+        for route in [self.route0, self.route1, self.route2,
+                      self.route3, self.route4]:
+            attr = sai_thrift_get_route_entry_attribute(
+                self.client, route, next_hop_id=True)
+            self.assertEqual(attr['next_hop_id'], self.nhop)
+
+        attr = sai_thrift_get_next_hop_attribute(
+            self.client, self.nhop, ip='0.0.0.0')
+        self.assertEqual(attr['ip'].addr.ip4, '10.10.10.1')
+        attr = sai_thrift_get_next_hop_attribute(
+            self.client, self.nhop1, ip='0.0.0.0')
+        self.assertEqual(attr['ip'].addr.ip6, '4444::1')
+
+        attr = sai_thrift_get_neighbor_entry_attribute(
+            self.client, self.neigh_entry, dst_mac_address=True)
+        self.assertEqual(attr['dst_mac_address'], '00:11:22:33:44:66')
+
+        attr = sai_thrift_get_qos_map_attribute(
+            self.client,
+            self.qos_map,
+            map_to_value_list=sai_thrift_qos_map_list_t(
+                count=2, maplist=[]))
+        self.assertEqual(attr['map_to_value_list'].count,
+                            self.qos_map_list.count)
+        for i in range(0, self.qos_map_list.count):
+            self.assertEqual(attr['map_to_value_list'].maplist[i].key.dscp,
+                                self.qos_map_list.maplist[i].key.dscp)
+            self.assertEqual(attr['map_to_value_list'].maplist[i].value.tc,
+                                self.qos_map_list.maplist[i].value.tc)
+
+    def tearDown(self):
+        sai_thrift_remove_qos_map(self.client, self.qos_map)
+
+        for route_entry in self.route_entry_list:
+            sai_thrift_remove_route_entry(self.client, route_entry)
+
+        sai_thrift_remove_neighbor_entry(self.client, self.neigh_entry)
+
+        for nhop in self.nhop_list:
+            sai_thrift_remove_next_hop(self.client, nhop)
+
+        sai_thrift_remove_fdb_entry(self.client, self.fdb_entry)
+
+        super(FrameworkTester, self).tearDown()


### PR DESCRIPTION
Cherry-pick PR #1335

The changes introduce SAI PTF framework base tests infrastructure. 
Following files have been added:

* sai_rpc_frontend.cpp - RPC server frontend file - there is a set of manually written helper functions that converts/parses SAI and thrift attributes and also here we have autogenerated SAI RPC server functions included
* sai_base_test.py - python module with base test classes with common tests configuration
* sai_utils.py - python module with some helper function used in SAI PTF tests
* saitest.py - first test module with simple framework test

Testing done:
BLDENV=buster make -f Makefile.work buster