### PR TITLE
Support for experimental entries

### DIFF
--- a/inc/saiobject.h
+++ b/inc/saiobject.h
@@ -36,6 +36,9 @@
 #include <sainat.h>
 #include <saisrv6.h>
 
+/* new experimental object type includes */
+#include "../experimental/saiexperimentalbmtor.h"
+
 /**
  * @defgroup SAIOBJECT SAI - Object API definitions.
  *
@@ -80,6 +83,8 @@ typedef union _sai_object_key_entry_t
 
     /** @validonly object_type == SAI_OBJECT_TYPE_MY_SID_ENTRY */
     sai_my_sid_entry_t        my_sid_entry;
+
+    /* Add new experimental entries above this line */
 
 } sai_object_key_entry_t;
 

--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -353,6 +353,8 @@ sub ProcessTagDefault
 
     return $val if $val =~ /^0\.0\.0\.0$/;
 
+    return $val if $val =~ /^0\:0\:0\:0\:0\:0$/;
+
     return $val if $val eq "disabled";
 
     return $val if $val eq "\"\"";
@@ -1561,6 +1563,8 @@ sub ProcessDefaultValueType
 
     return "SAI_DEFAULT_VALUE_TYPE_CONST" if $default =~ /^0\.0\.0\.0$/;
 
+    return "SAI_DEFAULT_VALUE_TYPE_CONST" if $default =~ /^0\:0\:0\:0\:0\:0$/;
+
     return "SAI_DEFAULT_VALUE_TYPE_CONST" if $default eq "disabled";
 
     return "SAI_DEFAULT_VALUE_TYPE_CONST" if $default eq "\"\"";
@@ -1631,6 +1635,10 @@ sub ProcessDefaultValue
     elsif ($default =~ /^0\.0\.0\.0$/ and $type =~ /^(sai_ip4_t)/)
     {
         WriteSource "$val = { 0 };";
+    }
+    elsif ($default =~ /^0\:0\:0\:0\:0\:0$/ and $type =~ /^(sai_mac_t)/)
+    {
+        WriteSource "$val = { .mac = { 0, 0, 0, 0, 0, 0 } };";
     }
     else
     {
@@ -2507,6 +2515,7 @@ sub ProcessStructValueType
     return "SAI_ATTR_VALUE_TYPE_UINT16"         if $type eq "sai_vlan_id_t";
     return "SAI_ATTR_VALUE_TYPE_UINT32"         if $type eq "sai_label_id_t";
     return "SAI_ATTR_VALUE_TYPE_UINT32"         if $type eq "uint32_t";
+    return "SAI_ATTR_VALUE_TYPE_UINT32"         if $type eq "sai_uint32_t";
     return "SAI_ATTR_VALUE_TYPE_INT32"          if $type =~ /^sai_\w+_type_t$/; # enum
     return "SAI_ATTR_VALUE_TYPE_NAT_ENTRY_DATA" if $type eq "sai_nat_entry_data_t";
     return "SAI_ATTR_VALUE_TYPE_ENCRYPT_KEY"    if $type eq "sai_encrypt_key_t";
@@ -3420,7 +3429,7 @@ sub ProcessSingleNonObjectId
 
         # allowed entries on object structs
 
-        if (not $type =~ /^sai_(nat_entry_data|mac|object_id|vlan_id|ip_address|ip_prefix|label_id|ip6|uint8|\w+_type)_t$/)
+        if (not $type =~ /^sai_(nat_entry_data|mac|object_id|vlan_id|ip_address|ip_prefix|label_id|ip6|uint8|uint32|\w+_type)_t$/)
         {
             LogError "struct member $member type '$type' is not allowed on struct $structname";
             next;

--- a/meta/serialize.pm
+++ b/meta/serialize.pm
@@ -606,6 +606,11 @@ sub GetConditionForSerialize
         return "";
     }
 
+    if (defined $refStructInfoEx->{baseName})
+    {
+        $condition = "(sai_int32_t)$condition" if $refStructInfoEx->{baseName} eq "object_key_entry";
+    }
+
     if (defined $refMembersHash->{$1})
     {
         $condition = "$structBase->$1 == $2";

--- a/meta/utils.pm
+++ b/meta/utils.pm
@@ -263,7 +263,7 @@ sub GetNonObjectIdStructNames
 {
     my %structs;
 
-    my @headers = GetHeaderFiles();
+    my @headers = (GetHeaderFiles(), GetExperimentalHeaderFiles());
 
     # TODO must support experimental extensions
 


### PR DESCRIPTION
This commit adds support for non object ID entries
in experimental directory
Test generation will need further improvements to include
experimental entries

Signed-off-by: Marian Pritsak <marianp@mellanox.com>