### PR TITLE
[Port] 8-lanes interface types

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -316,6 +316,18 @@ typedef enum _sai_port_interface_type_t
     /** Interface type XGMII */
     SAI_PORT_INTERFACE_TYPE_XGMII,
 
+    /** Interface type CR8 */
+    SAI_PORT_INTERFACE_TYPE_CR8,
+
+    /** Interface type KR8 */
+    SAI_PORT_INTERFACE_TYPE_KR8,
+
+    /** Interface type SR8 */
+    SAI_PORT_INTERFACE_TYPE_SR8,
+
+    /** Interface type LR8 */
+    SAI_PORT_INTERFACE_TYPE_LR8,
+
     /** Interface type MAX */
     SAI_PORT_INTERFACE_TYPE_MAX,
 

--- a/meta/ancestry.pl
+++ b/meta/ancestry.pl
@@ -168,6 +168,7 @@ sub BuildCommitHistory
 
             next if $enumName eq "SAI_API_MAX";
             next if $enumName eq "SAI_OBJECT_TYPE_MAX";
+            next if $enumName eq "SAI_PORT_INTERFACE_TYPE_MAX";
 
             LogError "wrong initializer on $enumName $enumValue" if not $enumValue =~ /^0x[0-9a-f]{8}$/;
 

--- a/meta/checkheaders.pl
+++ b/meta/checkheaders.pl
@@ -193,6 +193,7 @@ sub CheckHash
             next if $key eq "SAI_ACL_ENTRY_ATTR_ACTION_END";
             next if $key eq "SAI_OBJECT_TYPE_MAX";
             next if $key eq "SAI_API_MAX";
+            next if $key eq "SAI_PORT_INTERFACE_TYPE_MAX";
 
             # NOTE: some other attributes/enum with END range could be added
         }


### PR DESCRIPTION
This commit adds 8-lanes port interface types: CR8, KR8, SR8, LR8.