### PR TITLE
DSCP based marking and queue selection for tunnels and PFC frames

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -570,7 +570,7 @@ typedef enum _sai_switch_tunnel_attr_t
      * @allownull true
      * @default SAI_NULL_OBJECT_ID
      */
-    SAI_SWITCH_TUNNEL_ATTR_DECAP_QOS_PFC_DSCP_TO_TC_MAP,
+    SAI_SWITCH_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_PFC_TC_MAP,
 
     /**
      * @brief Enable TC -> Priority Group MAP

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -515,6 +515,78 @@ typedef enum _sai_switch_tunnel_attr_t
     SAI_SWITCH_TUNNEL_ATTR_VXLAN_UDP_SPORT_MASK,
 
     /**
+     * @brief Enable DSCP -> TC MAP on tunnel object to determine Traffic Class for access-to-network traffic
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_SWITCH_TUNNEL_ATTR_ENCAP_QOS_DSCP_TO_TC_MAP,
+
+    /**
+     * @brief Enable TC AND COLOR -> DSCP MAP on tunnel at encapsulation (access-to-network) node to remark the DSCP in tunnel header
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_SWITCH_TUNNEL_ATTR_ENCAP_QOS_TC_AND_COLOR_TO_DSCP_MAP,
+
+    /**
+     * @brief Enable TC -> Priority Group MAP
+     *
+     * Map id = #SAI_NULL_OBJECT_ID to disable map on port.
+     * Default no map
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_SWITCH_TUNNEL_ATTR_ENCAP_QOS_PFC_TC_TO_PRIORITY_GROUP_MAP,
+
+    /**
+     * @brief Enable DSCP -> TC MAP on tunnel at termination (Network-to-access) node.
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_SWITCH_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_TC_MAP,
+
+    /**
+     * @brief Enable DSCP -> PFC TC MAP on tunnel at termination (Network-to-access) node. Used to flexibly map DSCP to TC for PFC
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_SWITCH_TUNNEL_ATTR_DECAP_QOS_PFC_DSCP_TO_TC_MAP,
+
+    /**
+     * @brief Enable TC -> Priority Group MAP
+     *
+     * Map id = #SAI_NULL_OBJECT_ID to disable map on port.
+     * Default no map
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_SWITCH_TUNNEL_ATTR_DECAP_QOS_PFC_TC_TO_PRIORITY_GROUP_MAP,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_TUNNEL_ATTR_END,

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -687,6 +687,78 @@ typedef enum _sai_tunnel_attr_t
     SAI_TUNNEL_ATTR_IPSEC_SA_PORT_LIST,
 
     /**
+     * @brief Enable DSCP -> TC MAP on tunnel object to determine Traffic Class for access-to-network traffic
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_TUNNEL_ATTR_ENCAP_QOS_DSCP_TO_TC_MAP,
+
+    /**
+     * @brief Enable TC AND COLOR -> DSCP MAP on tunnel at encapsulation (access-to-network) node to remark the DSCP in tunnel header
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_TUNNEL_ATTR_ENCAP_QOS_TC_AND_COLOR_TO_DSCP_MAP,
+
+    /**
+     * @brief Enable TC -> Priority Group MAP
+     *
+     * Map id = #SAI_NULL_OBJECT_ID to disable map on port.
+     * Default no map
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_TUNNEL_ATTR_ENCAP_QOS_PFC_TC_TO_PRIORITY_GROUP_MAP,
+
+    /**
+     * @brief Enable DSCP -> TC MAP on tunnel at termination (Network-to-access) node.
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_TC_MAP,
+
+    /**
+     * @brief Enable DSCP -> PFC TC MAP on tunnel at termination (Network-to-access) node. Used to flexibly map DSCP to TC
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_TUNNEL_ATTR_DECAP_QOS_PFC_DSCP_TO_TC_MAP,
+
+    /**
+     * @brief Enable TC -> Priority Group MAP
+     *
+     * Map id = #SAI_NULL_OBJECT_ID to disable map on port.
+     * Default no map
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_TUNNEL_ATTR_DECAP_QOS_PFC_TC_TO_PRIORITY_GROUP_MAP,
+
+    /**
      * @brief End of attributes
      */
     SAI_TUNNEL_ATTR_END,

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -734,7 +734,7 @@ typedef enum _sai_tunnel_attr_t
     SAI_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_TC_MAP,
 
     /**
-     * @brief Enable DSCP -> PFC TC MAP on tunnel at termination (Network-to-access) node. Used to flexibly map DSCP to TC
+     * @brief Enable DSCP -> PFC TC MAP on tunnel at termination (Network-to-access) node. Used to flexibly map DSCP to TC for PFC
      *
      * @type sai_object_id_t
      * @flags CREATE_AND_SET
@@ -742,7 +742,7 @@ typedef enum _sai_tunnel_attr_t
      * @allownull true
      * @default SAI_NULL_OBJECT_ID
      */
-    SAI_TUNNEL_ATTR_DECAP_QOS_PFC_DSCP_TO_TC_MAP,
+    SAI_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_PFC_TC_MAP,
 
     /**
      * @brief Enable TC -> Priority Group MAP

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -1082,6 +1082,8 @@ typedef struct _sai_tunnel_api_t
     sai_remove_tunnel_map_entry_fn               remove_tunnel_map_entry;
     sai_set_tunnel_map_entry_attribute_fn        set_tunnel_map_entry_attribute;
     sai_get_tunnel_map_entry_attribute_fn        get_tunnel_map_entry_attribute;
+    sai_bulk_object_get_attribute_fn             get_tunnels_attribute;
+    sai_bulk_object_set_attribute_fn             set_tunnels_attribute;
 
 } sai_tunnel_api_t;
 


### PR DESCRIPTION
Following attributes are introduced for fine grain marking and queue selection for tunneled traffic and PFC frames.
Same attributes are also added to saiswitch.

Tunnel Encap:
SAI_TUNNEL_ATTR_ENCAP_QOS_DSCP_TO_TC_MAP: For DSCP based TC MAP for queue
SAI_TUNNEL_ATTR_ENCAP_QOS_TC_AND_COLOR_TO_DSCP_MAP: for Remarking
SAI_TUNNEL_ATTR_ENCAP_QOS_PFC_TC_TO_PRIORITY_GROUP_MAP: Priority group selection for PFC frames

Tunnel Decap:
SAI_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_TC_MAP: For DSCP based TC MAP for queue
SAI_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_PFC_TC_MAP: For DSCP based TC MAP for PFC frames
SAI_TUNNEL_ATTR_DECAP_QOS_PFC_TC_TO_PRIORITY_GROUP_MAP: Priority group selection for PFC frames