### PR TITLE
Add label attribute for counter

### DIFF
--- a/inc/saicounter.h
+++ b/inc/saicounter.h
@@ -70,6 +70,15 @@ typedef enum _sai_counter_attr_t
     SAI_COUNTER_ATTR_TYPE = SAI_COUNTER_ATTR_START,
 
     /**
+     * @brief Label attribute used to unique identify counter.
+     *
+     * @type char
+     * @flags CREATE_AND_SET
+     * @default ""
+     */
+    SAI_COUNTER_ATTR_LABEL,
+
+    /**
      * @brief End of attributes
      */
     SAI_COUNTER_ATTR_END,


### PR DESCRIPTION
Counter does not have any mandatory attribute to identify object uniquely. Adding a label attribute that can be used to uniquely identify object during warmboot scenarios. This is similar to existing label attribute used by LAG and virtual router.
The attribute is considered as user data attached to the object.

Related to:
#1158 

Signed-off-by: Midhun Somasundaran <msomasundaran@fb.com>