### PR TITLE
[cherry-pick]Proposal for init switch and destroy switch from PRC (#1387)

### DIFF
--- a/meta/templates/sai_rpc_server_functions.tt
+++ b/meta/templates/sai_rpc_server_functions.tt
@@ -2,6 +2,9 @@
 
 [%- unsupported_functions = '(bulk|send_hostif|recv_hostif|hostif_packet|mdio|register)' #TODO: all of them should be supported -%]
 
+[%- create_switch_function = 'create_switch' %]
+[%- remove_switch_function = 'remove_switch' %]
+
 [%- sai_utils_functions = '(query_attribute_enum_values_capability|sai_object_type_get_availability)' -%]
 
 [%- ######################################################################## -%]
@@ -45,6 +48,22 @@
    [%- PROCESS return_error indentation = 2 status_variable = '' %]
 [%- END -%]
 
+[%- BLOCK check_switch_id -%]
+
+    // need to check if the switch exist
+    if (switch_id != NULL) {
+        return switch_id;
+    }
+   
+[%- END -%]
+
+[%- BLOCK empty_switch_id -%]
+
+    // reset the switch id
+    switch_id = NULL;
+   
+[%- END -%]
+
 [%- ######################################################################## -%]
 
 [%- ######################################################################## -%]
@@ -75,6 +94,11 @@
         [%- ELSIF arg.is_rpc_return %]
     [% arg.type.name %] [% arg.name %]_out = 0ULL;
         [%- END -%]
+    [%- END %]
+
+    [%- # If the swich already created, then return it directly -%]
+    [%- IF function_name.match(create_switch_function) %]
+        [%- PROCESS check_switch_id %]
     [%- END %]
     sai_[% api %]_api_t *[% api %]_api;
 [% END -%]
@@ -240,6 +264,10 @@
 [%- BLOCK return -%]
     [%- IF NOT function.rpc_return.is_cpp_return -%]
         [%- # Some types are being changed by Thrift to void, and moved into first parameter %]
+        [%- # Empty global switch_id -%]
+        [%- IF function_name.match(remove_switch_function) %]
+            [%- PROCESS empty_switch_id %]
+        [%- END %]
     return;
     [%- ELSIF function.return.is_rpc_return -%]
         [%- # If the value returned by RPC is the same that was returned by SAI method, -%]


### PR DESCRIPTION
keep the switch id in creat_switch and remove it from remove_switch

1. support to create the create_switch only once before the test run and use the same switch id within multi-round of testing
2. support remove the switch id

Signed-off-by: Richard Yu <richard.yu@microsoft.com>