### PR TITLE
Tunnel Scoped TC MAP and Remarking

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -513,6 +513,55 @@ typedef enum _sai_switch_tunnel_attr_t
      * @validonly SAI_SWITCH_TUNNEL_ATTR_TUNNEL_TYPE == SAI_TUNNEL_TYPE_VXLAN and SAI_SWITCH_TUNNEL_ATTR_TUNNEL_VXLAN_UDP_SPORT_MODE == SAI_TUNNEL_VXLAN_UDP_SPORT_MODE_USER_DEFINED
      */
     SAI_SWITCH_TUNNEL_ATTR_VXLAN_UDP_SPORT_MASK,
+    /**
+     * @brief Enable TC AND COLOR -> DSCP MAP on tunnel at encapsulation (access-to-network) node to remark the DSCP in tunnel header
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_SWITCH_TUNNEL_ATTR_ENCAP_QOS_TC_AND_COLOR_TO_DSCP_MAP,
+
+    /**
+     * @brief Enable TC -> Queue MAP on tunnel encap
+     *
+     * Map id = #SAI_NULL_OBJECT_ID to disable map on tunnel.
+     * Default no map, i.e. packets are queued with static mapping.
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_SWITCH_TUNNEL_ATTR_ENCAP_QOS_TC_TO_QUEUE_MAP,
+
+    /**
+     * @brief Enable DSCP -> TC MAP on tunnel at termination (Network-to-access) node.
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_SWITCH_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_TC_MAP,
+
+    /**
+     * @brief Enable TC -> Priority Group MAP
+     *
+     * Map id = #SAI_NULL_OBJECT_ID to disable map on port.
+     * Default no map
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_SWITCH_TUNNEL_ATTR_DECAP_QOS_TC_TO_PRIORITY_GROUP_MAP,
 
     /**
      * @brief End of attributes

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -513,6 +513,7 @@ typedef enum _sai_switch_tunnel_attr_t
      * @validonly SAI_SWITCH_TUNNEL_ATTR_TUNNEL_TYPE == SAI_TUNNEL_TYPE_VXLAN and SAI_SWITCH_TUNNEL_ATTR_TUNNEL_VXLAN_UDP_SPORT_MODE == SAI_TUNNEL_VXLAN_UDP_SPORT_MODE_USER_DEFINED
      */
     SAI_SWITCH_TUNNEL_ATTR_VXLAN_UDP_SPORT_MASK,
+
     /**
      * @brief Enable TC AND COLOR -> DSCP MAP on tunnel at encapsulation (access-to-network) node to remark the DSCP in tunnel header
      *

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -687,6 +687,56 @@ typedef enum _sai_tunnel_attr_t
     SAI_TUNNEL_ATTR_IPSEC_SA_PORT_LIST,
 
     /**
+     * @brief Enable TC AND COLOR -> DSCP MAP on tunnel at encapsulation (access-to-network) node to remark the DSCP in tunnel header
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_TUNNEL_ATTR_ENCAP_QOS_TC_AND_COLOR_TO_DSCP_MAP,
+
+    /**
+     * @brief Enable TC -> Queue MAP on tunnel encap
+     *
+     * Map id = #SAI_NULL_OBJECT_ID to disable map on tunnel.
+     * Default no map, i.e. packets are queued with static mapping.
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_TUNNEL_ATTR_ENCAP_QOS_TC_TO_QUEUE_MAP,
+
+    /**
+     * @brief Enable DSCP -> TC MAP on tunnel at termination (Network-to-access) node. This map if configured overrides the port MAP
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_TC_MAP,
+
+    /**
+     * @brief Enable TC -> Priority Group MAP. TC is derived from the tunnel MAP
+     *
+     * Map id = #SAI_NULL_OBJECT_ID to disable map on port.
+     * Default no map
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_TUNNEL_ATTR_DECAP_QOS_TC_TO_PRIORITY_GROUP_MAP,
+
+    /**
      * @brief End of attributes
      */
     SAI_TUNNEL_ATTR_END,
@@ -1082,6 +1132,8 @@ typedef struct _sai_tunnel_api_t
     sai_remove_tunnel_map_entry_fn               remove_tunnel_map_entry;
     sai_set_tunnel_map_entry_attribute_fn        set_tunnel_map_entry_attribute;
     sai_get_tunnel_map_entry_attribute_fn        get_tunnel_map_entry_attribute;
+    sai_bulk_object_get_attribute_fn             get_tunnels_attribute;
+    sai_bulk_object_set_attribute_fn             set_tunnels_attribute;
 
 } sai_tunnel_api_t;
 

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -764,6 +764,13 @@ typedef struct _sai_acl_capability_t
      * @passparam &sai_metadata_enum_sai_acl_action_type_t
      */
     sai_s32_list_t action_list;
+
+    /**
+     * @brief Output from get function
+     * Flag indicating whether overlay of match field is supported or not
+     * For example, IPv6 DIP and IPv4 DIP can be overlayed on a 128 bit wide field
+     */
+     bool is_field_overlay_supported;
 } sai_acl_capability_t;
 
 /**

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -765,12 +765,6 @@ typedef struct _sai_acl_capability_t
      */
     sai_s32_list_t action_list;
 
-    /**
-     * @brief Output from get function
-     * Flag indicating whether overlay of match field is supported or not
-     * For example, IPv6 DIP and IPv4 DIP can be overlayed on a 128 bit wide field
-     */
-     bool is_field_overlay_supported;
 } sai_acl_capability_t;
 
 /**


### PR DESCRIPTION
This PR add following behavior to tunnel encap and decap

Tunnel Encap:
1.      SAI_TUNNEL_ATTR_ENCAP_QOS_TC_AND_COLOR_TO_DSCP_MAP for remarking the packet based on normalized TC as per port TC MAP binding
2.      SAI_TUNNEL_ATTR_ENCAP_QOS_TC_TO_QUEUE_MAP for queue selection based on normalized TC as per port TC MAP binding

Tunnel Decap:
1.      SAI_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_TC_MAP new TC MAP can be bind'ed to the tunnel for decap. This MAP overrides port MAP if configured.
2.      SAI_TUNNEL_ATTR_DECAP_QOS_TC_TO_PRIORITY_GROUP_MAP for mapping the normalized TC to priority group mainly for PFC generation.

DSCP mode takes effect as configured for both cases.


