### PR TITLE
[Cherry-pick] Add platform support and a sanity test sample (#1390)

### DIFF
--- a/ptf/platform_helper/__init__.py
+++ b/ptf/platform_helper/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+# @file    __init__.py
+#
+# @brief   init
+#
+
+"""
+Init the platform helper module.
+
+platform_helper module contains classes to distiguish the different behivor on different platforms.
+"""

--- a/ptf/platform_helper/bfn_sai_helper.py
+++ b/ptf/platform_helper/bfn_sai_helper.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+
+
+"""
+This file contains class for bfn specified functions.
+"""
+from platform_helper.common_sai_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+
+class BfnSaiHelper(CommonSaiHelper):
+    """
+    This class contains Barefoot(bfn) specified functions for the platform setup and test context configuration.
+    """
+    platform = 'bfn'
+
+    def recreate_ports(self):
+        print("BfnSaiHelper::recreate_ports")
+        if 'port_config_ini' in self.test_params:
+            if 'createPorts_has_been_called' not in config:
+                self.createPorts()
+                # check if ports became UP
+                #self.checkPortsUp()
+                config['createPorts_has_been_called'] = 1
+        wait_sec = 5
+        print("Waiting for ports to get ready, {} seconds ...".format(wait_sec))
+        time.sleep(wait_sec)

--- a/ptf/platform_helper/brcm_sai_helper.py
+++ b/ptf/platform_helper/brcm_sai_helper.py
@@ -1,0 +1,267 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+
+"""
+This file contains class for brcm specified functions.
+"""
+
+from platform_helper.common_sai_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+
+class BrcmSaiHelper(CommonSaiHelper):
+    """
+    This class contains broadcom(brcm) specified functions for the platform setup and test context configuration.
+    """
+    platform = 'brcm'
+
+    def remove_switch(self):
+        '''
+        Method to remove the switch.
+        '''
+        print("BrcmSaiHelperBase::remove_switch does not support. Cannot recreate after remove.")
+
+
+    def recreate_ports(self):
+        """
+        Method to recreate the port.
+        """
+
+        #port recreate not support, error happened.
+        #Port needs to be init and setup at same time.
+        #Make the process happened in turn_up_and_check_ports
+        print("BrcmSaiHelperBase::recreate_ports does not support.")
+
+
+    def sai_thrift_create_fdb_entry_allow_mac_move(self,
+                                client,
+                                fdb_entry,
+                                type=None,
+                                packet_action=None,
+                                user_trap_id=None,
+                                bridge_port_id=None,
+                                meta_data=None,
+                                endpoint_ip=None,
+                                counter_id=None,
+                                allow_mac_move=None):
+        """
+        Override the sai_thrift_create_fdb_entry when check the functionality related to allow_mac_move.
+
+        This method will set the allow_mac_move to True.
+        """
+        #TODO confirm the SPEC. Related to RFC9014 and RFC7432
+        #Context: when set SAI_FDB_ENTRY_TYPE_STATIC, allow_mac_move will be checked, and its default value is false
+        #         then, when a port get different mac (i.e. arp ack from arp req, port used in previous arp req, also means other ports with different session).
+        #         the packet should be dropped.
+        #         but some other ASIC can transfer the packet to other ports not used to transfer the packet.
+
+        print("BrcmSaiHelper::sai_thrift_create_fdb_entry_allow_mac_move")
+        sai_thrift_create_fdb_entry(
+            client=client,
+            fdb_entry=fdb_entry,
+            type=type,
+            packet_action=packet_action,
+            user_trap_id=user_trap_id,
+            bridge_port_id=bridge_port_id,
+            meta_data=meta_data,
+            endpoint_ip=endpoint_ip,
+            counter_id=counter_id,
+            allow_mac_move=True)
+
+
+    def get_bridge_port_all_attribute(self, bridge_port_id):
+        '''
+        Gets all the attrbute from bridge port.
+        '''
+        print("BrcmSaiHelperBase::get_bridge_port_all_attribute")
+
+        #Cannot get those three attributes from sai_thrift_get_bridge_port_attribute
+        #ingress_filtering=True,
+        #egress_filtering=True,
+        #isolation_group=True
+        sai_thrift_get_bridge_port_attribute(self.client,  bridge_port_oid=bridge_port_id, ingress_filtering=True,  egress_filtering=True)
+        attr = sai_thrift_get_bridge_port_attribute(
+            self.client, 
+            bridge_port_oid=bridge_port_id,
+            type=True,
+            port_id=True,
+            tagging_mode=True,
+            vlan_id=True,
+            rif_id=True,
+            tunnel_id=True,
+            bridge_id=True,
+            fdb_learning_mode=True,
+            max_learned_addresses=True,
+            fdb_learning_limit_violation_packet_action=True,
+            admin_state=True
+            #Cannot get those three
+            #ingress_filtering=True,
+            #egress_filtering=True,
+            #isolation_group=True
+            )
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        return attr
+
+
+    def turn_up_and_check_ports(self):
+        '''
+        Method to turn up the ports.
+
+        In case some device not init the port after start the switch.
+
+        Needs the following class attributes:
+
+            self.port_list - list of all active port objects
+        '''
+
+        #For brcm devices, need to init and setup the ports at once after start the switch.
+        #Skip the function :func:`BrcmSaiHelper.recreate_ports`
+        retries = 10
+        for port_id in self.port_list:
+            try:
+                sai_thrift_set_port_attribute(
+                    self.client, port_oid=port_id, admin_state=True)
+            except BaseException as e:
+                print("Cannot setup port admin state, error {}".format(e))
+
+        for num_of_tries in range(retries):
+            all_ports_are_up = True
+            time.sleep(2)
+            for port_id in self.port_list:
+                port_attr = sai_thrift_get_port_attribute(
+                    self.client, port_id, oper_status=True)
+                if port_attr['oper_status'] != SAI_PORT_OPER_STATUS_UP:
+                    all_ports_are_up = False
+                    time.sleep(1)
+                    print("port is down: {}".format(port_attr['oper_status']))
+            if all_ports_are_up:
+                break
+        if not all_ports_are_up:
+            print("Not all the ports are up after {} rounds of retries.".format(retries))
+
+
+    def start_switch(self):
+        """
+        Start switch and wait seconds for a warm up.
+        """
+        switch_init_wait = 5
+
+        self.switch_id = sai_thrift_create_switch(
+            self.client, init_switch=True, src_mac_address=ROUTER_MAC)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+
+        print("Waiting for switch to get ready, {} seconds ...".format(switch_init_wait))
+        time.sleep(switch_init_wait)
+
+
+    def check_cpu_port_hdl(self):
+        """
+        Checks cpu port handler, expect the cpu_port_hdl equals to qos_queue port id
+
+        Needs the following class attributes:
+
+            self.cpu_port_hdl - cpu_port_hdl id
+
+        Sets the following class attributes:
+
+            self.cpu_port - cpu_port id
+
+        """
+        attr = sai_thrift_get_port_attribute(self.client,
+                                             self.cpu_port_hdl,
+                                             qos_number_of_queues=True)
+        num_queues = attr['qos_number_of_queues']
+        q_list = sai_thrift_object_list_t(count=num_queues)
+        attr = sai_thrift_get_port_attribute(self.client,
+                                             self.cpu_port_hdl,
+                                             qos_queue_list=q_list)
+
+        for queue in range(0, num_queues):
+            queue_id = attr['qos_queue_list'].idlist[queue]
+            setattr(self, 'cpu_queue%s' % queue, queue_id)
+            q_attr = sai_thrift_get_queue_attribute(
+                self.client,
+                queue_id,
+                port=True,
+                index=True,
+                parent_scheduler_node=True)
+            self.assertEqual(queue, q_attr['index'])
+            # in broadcom platform, the q_attr["port"] is not equals to cpu_port_hdl
+            # cpu_port_hdl is ahead of the cpu_port list
+            self.cpu_port = q_attr["port"]
+
+
+    def load_default_1q_bridge_ports(self):
+        """
+        Loads default 1q bridge ports and set as class attribute.
+
+        Needs the following class attributes:
+            self.default_1q_bridge - default_1q_bridge oid
+
+            self.active_ports_no - number of active ports
+
+            self.portX objects for all active ports
+
+        Sets the following class attributes:
+
+            self.default_1q_bridge_port_list - list of all 1q bridge port objects
+
+            self.portX_bp - objects for all 1q bridge ports
+        """
+        print("BrcmSaiHelperBase::load_default_1q_bridge_ports")
+        attr = sai_thrift_get_bridge_attribute(
+                    self.client, 
+                    bridge_oid=self.default_1q_bridge,
+                    port_list=sai_thrift_object_list_t(
+                        idlist=[], count=self.active_ports_no))
+        default_1q_bridge_port_list = attr['port_list'].idlist
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+
+        #try to binding the bridge port with the port index here
+        for bp in default_1q_bridge_port_list:
+            attr = self.get_bridge_port_all_attribute(bp)
+            for index in range(0, len(self.port_list)):
+                port_id = getattr(self, 'port%s' % index)
+                if port_id == attr['port_id']:
+                    setattr(self, 'port%s_bp' % index, bp)
+                    break
+        return default_1q_bridge_port_list
+
+
+    def remove_1q_bridge_port(self, default_1q_bridge_port_list):
+        '''
+        Removes all the bridge ports.
+        '''
+
+        for index in range(0, len(default_1q_bridge_port_list)):
+            port_bp = getattr(self, 'port%s_bp' % index)
+            sai_thrift_remove_bridge_port(self.client, port_bp)
+            delattr(self, 'port%s_bp' % index)
+
+
+    def reset_1q_bridge_ports(self):
+        '''
+        Reset all the 1Q bridge ports.
+        Needs the following class attributes:
+            self.default_1q_bridge - default_1q_bridge oid
+
+            self.active_ports_no - number of active ports
+
+            self.portX objects for all active ports
+        '''
+        #In case the bridge port will be initalized by default, clear them
+        default_1q_bridge_port_list = self.load_default_1q_bridge_ports()
+        self.remove_1q_bridge_port(default_1q_bridge_port_list)

--- a/ptf/platform_helper/common_sai_helper.py
+++ b/ptf/platform_helper/common_sai_helper.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+
+"""
+Class contains common functions.
+
+This file contains base class for other platform classes.
+"""
+from  sai_base_test import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+
+class CommonSaiHelper(SaiHelper):
+    """
+    This class contains the common functions for the platform setup and test context configuration.
+    """
+    #TODO move the common methods from the sai_base_test.
+
+    platform = 'common'
+
+    def sai_thrift_create_fdb_entry_allow_mac_move(self,
+                                client,
+                                fdb_entry,
+                                type=None,
+                                packet_action=None,
+                                user_trap_id=None,
+                                bridge_port_id=None,
+                                meta_data=None,
+                                endpoint_ip=None,
+                                counter_id=None,
+                                allow_mac_move=None):
+        """
+        Override the sai_thrift_create_fdb_entry when check the functionality related to allow_mac_move.
+
+        This method will transfer allow_mac_move directly(not override).
+        For the encounter function, please refer to \r
+        \t :func:`BrcmSaiHelper.sai_thrift_create_fdb_entry_allow_mac_move`
+        """
+        #TODO confirm the SPEC. Related to RFC9014 and RFC7432
+        print("CommonSaiHelper::sai_thrift_create_fdb_entry_allow_mac_move")
+        sai_thrift_create_fdb_entry(
+            client=client,
+            fdb_entry=fdb_entry,
+            type=type,
+            packet_action=packet_action,
+            user_trap_id=user_trap_id,
+            bridge_port_id=bridge_port_id,
+            meta_data=meta_data,
+            endpoint_ip=endpoint_ip,
+            counter_id=counter_id,
+            allow_mac_move=allow_mac_move)
+
+
+    def remove_bridge_port(self):
+        """
+        Remove all bridge ports.
+        """
+        for index in range(0, len(self.port_list)):
+            port_bp = getattr(self, 'port%s_bp' % index)
+            sai_thrift_remove_bridge_port(self.client, port_bp)
+
+
+    def create_bridge_ports(self):
+        """
+        Create bridge ports base on port_list.
+        """
+        for index in range(0, len(self.port_list)):
+            port_id = getattr(self, 'port%s' % index)
+            port_bp = sai_thrift_create_bridge_port(
+                self.client,
+                bridge_id=self.default_1q_bridge,
+                port_id=port_id,
+                type=SAI_BRIDGE_PORT_TYPE_PORT,
+                admin_state=True)
+            setattr(self, 'port%s_bp' % index, port_bp)
+            self.assertNotEqual(getattr(self, 'port%s_bp' % index), 0)

--- a/ptf/platform_helper/mlnx_sai_helper.py
+++ b/ptf/platform_helper/mlnx_sai_helper.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+
+"""
+This file contains class for mlnx specified functions.
+"""
+from platform_helper.common_sai_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+
+class MlnxSaiHelper(CommonSaiHelper):
+    """
+    This class contains Mellanox(brcm) specified functions for the platform setup and test context configuration.
+    """
+    platform = 'mlnx'

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -19,8 +19,9 @@ additional useful functions.
 Tests will usually inherit from one of the base classes to have the controller
 and/or dataplane automatically set up.
 """
-
 import os
+import time
+from threading import Thread
 
 from collections import OrderedDict
 
@@ -39,6 +40,8 @@ import sai_adapter as adapter
 ROUTER_MAC = '00:77:66:55:44:00'
 THRIFT_PORT = 9092
 
+PLATFORM = os.environ.get('PLATFORM')
+platform_map = {'broadcom':'brcm', 'barefoot':'bfn', 'mellanox':'mlnx'}
 
 class ThriftInterface(BaseTest):
     """
@@ -146,35 +149,21 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         self.port_list - list of all active port objects
         self.portX objects for all active ports (where X is a port number)
     """
-    def setUp(self):
-        super(SaiHelperBase, self).setUp()
 
-        self.getSwitchPorts()
+    platform = 'common'
 
-        if 'switch_id' in self.test_params:
-            # get switch id initialized before
-            self.switch_id = self.test_params['switch_id']
-        else:
-            # initialize switch
-            self.switch_id = sai_thrift_create_switch(
-                self.client, init_switch=True, src_mac_address=ROUTER_MAC)
-            self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
-            self.test_params['switch_id'] = self.switch_id
+    def get_active_port_list(self):
+        '''
+        Method to get the active port list base on number_of_active_ports
 
-        self.switch_resources = self.saveNumberOfAvaiableResources()
+        Sets the following class attributes:
 
-        # get default vlan
-        attr = sai_thrift_get_switch_attribute(
-            self.client, default_vlan_id=True)
-        self.default_vlan_id = attr['default_vlan_id']
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+            self.active_ports_no - number of active ports 
 
-        if 'port_config_ini' in self.test_params:
-            if 'createPorts_has_been_called' not in config:
-                self.createPorts()
-                config['createPorts_has_been_called'] = 1
-                # check if ports became UP
-                self.checkPortsUp()
+            self.port_list - list of all active port objects
+
+            self.portX objects for all active ports
+        '''
 
         # get number of active ports
         attr = sai_thrift_get_switch_attribute(
@@ -188,27 +177,87 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         self.assertEqual(self.active_ports_no, attr['port_list'].count)
         self.port_list = attr['port_list'].idlist
 
+        #Gets self.portX objects for all active ports
         for i, _ in enumerate(self.port_list):
             setattr(self, 'port%s' % i, self.port_list[i])
 
-        # get default vrf
-        attr = sai_thrift_get_switch_attribute(
-            self.client, default_virtual_router_id=True)
-        self.default_vrf = attr['default_virtual_router_id']
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
-        # get default 1Q bridge OID
+    def turn_up_and_check_ports(self):
+        '''
+        Method to turn up the ports.
+        '''
+        #TODO check if this is common behivor or specified after check on more platform
+        print("For Common platform, Port already setup in recreate_ports.")
+
+
+    def shell(self):
+        '''
+        Method use to start a sai shell in a thread.
+        '''
+        def start_shell():
+            sai_thrift_set_switch_attribute(self.client, switch_shell_enable=True)
+        thread = Thread(target = start_shell)
+        thread.start()
+
+
+    def recreate_ports(self):
+        '''
+        Recreate the port base on file specified in 'port_config_ini' param.
+        '''
+        #TODO check if this is common behivor or specified after check on more platform
+        if 'port_config_ini' in self.test_params:
+            if 'createPorts_has_been_called' not in config:
+                self.createPorts()
+                # check if ports became UP
+                #self.checkPortsUp()
+                config['createPorts_has_been_called'] = 1
+
+
+    def get_default_1q_bridge_id(self):
+        '''
+        Gets default 1q bridge 1d, set it to class attribute 'default_1q_bridge'.
+
+        Sets the following class attributes:
+
+            self.default_1q_bridge - default_1q_bridge_id
+        '''
+
         attr = sai_thrift_get_switch_attribute(
             self.client, default_1q_bridge_id=True)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         self.default_1q_bridge = attr['default_1q_bridge_id']
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
-        # get cpu port
-        attr = sai_thrift_get_switch_attribute(self.client, cpu_port=True)
-        self.cpu_port_hdl = attr['cpu_port']
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
-        # get cpu port queue handles
+    def reset_1q_bridge_ports(self):
+        '''
+        Reset all the 1Q bridge ports.
+        Needs the following class attributes:
+            self.default_1q_bridge - default_1q_bridge oid
+
+            self.active_ports_no - number of active ports
+
+            self.portX objects for all active ports
+        '''
+        #TODO check if this is common behivor or specified after check on more platform
+        #TODO move this function to CommonSaiHelper
+        print("For Common platform, expecting bridge ports not been created by default.")
+
+
+    def check_cpu_port_hdl(self):
+        """
+        Checks cpu port handler.
+        Expect the cpu_port_hdl equals to qos_queue port id, number_of_queues in qos equals to queue index.
+
+        Needs the following class attributes:
+
+            self.cpu_port_hdl - cpu_port_hdl id
+
+        Seds the following class attributes:
+
+            self.cpu_queueX - cpu queue id
+
+        """
+        #TODO move this function to CommonSaiHelper
         attr = sai_thrift_get_port_attribute(self.client,
                                              self.cpu_port_hdl,
                                              qos_number_of_queues=True)
@@ -229,6 +278,61 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
             self.assertEqual(queue, q_attr['index'])
             self.assertEqual(self.cpu_port_hdl, q_attr['port'])
 
+
+    def start_switch(self):
+        """
+        Start switch.
+        """
+        self.switch_id = sai_thrift_create_switch(
+        self.client, init_switch=True, src_mac_address=ROUTER_MAC)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+
+
+    def setUp(self):
+        super(SaiHelperBase, self).setUp()
+
+        self.getSwitchPorts()
+        # initialize switch
+        self.start_switch()
+
+        self.switch_resources = self.saveNumberOfAvaiableResources(debug=True)
+
+        # get default vlan
+        attr = sai_thrift_get_switch_attribute(
+            self.client, default_vlan_id=True)
+        self.default_vlan_id = attr['default_vlan_id']
+        self.assertNotEqual(self.default_vlan_id, 0)
+
+        self.recreate_ports()
+
+        # get number of active ports
+        self.get_active_port_list()
+
+        # get default vrf
+        attr = sai_thrift_get_switch_attribute(
+            self.client, default_virtual_router_id=True)
+        self.default_vrf = attr['default_virtual_router_id']
+        self.assertNotEqual(self.default_vrf, 0)
+
+        self.turn_up_and_check_ports()
+
+        # get default 1Q bridge OID
+        self.get_default_1q_bridge_id()
+
+        #remove all default 1Q bridge port
+        self.reset_1q_bridge_ports()
+
+        # get cpu port
+        attr = sai_thrift_get_switch_attribute(self.client, cpu_port=True)
+        self.cpu_port_hdl = attr['cpu_port']
+        self.assertNotEqual(self.cpu_port_hdl, 0)
+
+        # get cpu port queue handles
+        self.check_cpu_port_hdl()
+
+        print("Finish SaiHelperBase setup")
+
+
     def tearDown(self):
         try:
             for port in self.port_list:
@@ -241,6 +345,7 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
 
         finally:
             super(SaiHelperBase, self).tearDown()
+
 
     def createPorts(self):
         """
@@ -390,7 +495,7 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         """
 
         print("***** Number of available resources *****")
-        for key, value in resources_dict:
+        for key, value in resources_dict.items():
             print(key, ": ", value)
 
     def saveNumberOfAvaiableResources(self, debug=False):
@@ -460,7 +565,7 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         for key, value in available_resources.items():
             if value != init_resources[key]:
                 if debug:
-                    print("Number of %s incorrect!" % key)
+                    print("Number of %s incorrect! Current value: %d, Init value: %d" % (key, value, init_resources[key]))
                 return False
 
         return True
@@ -943,3 +1048,46 @@ class MinimalPortVlanConfig(SaiHelperBase):
             sai_thrift_remove_bridge_port(self.client, bridge_port)
 
         super(MinimalPortVlanConfig, self).tearDown()
+
+
+def get_platform():
+    """
+    Get the platform token.
+    
+    If not any platform specified from the environment variable [PLATFORM], then the default platform will be 'common'.
+    If specified any one, it will try to concert it from standard name to a shorten name (case insentitive). \r
+    \ti.e. Broadcom -> brcm
+    """
+    pl_low = PLATFORM.lower()
+    pl = 'common'
+    if pl_low in platform_map.keys():
+        pl = platform_map[pl_low]
+    elif pl_low in platform_map.values():
+        pl = pl_low
+    return pl
+
+
+from platform_helper.common_sai_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from platform_helper.bfn_sai_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from platform_helper.brcm_sai_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from platform_helper.mlnx_sai_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+
+class PlatformSaiHelper(SaiHelper):
+    """
+    Class uses to extend from SaiHelper, base on the [platform] class attribute,
+    dynamic select a subclass from the platform_helper.
+    """
+    def __new__(cls, *args, **kwargs):
+        sai_helper_subclass_map = {subclass.platform: subclass for subclass in SaiHelper.__subclasses__()}
+        common_sai_helper_subclass_map = {subclass.platform: subclass for subclass in CommonSaiHelper.__subclasses__()}
+        pl = get_platform()
+
+        if pl in common_sai_helper_subclass_map:
+            target_base_class = common_sai_helper_subclass_map[pl]
+        else:
+            target_base_class = sai_helper_subclass_map[pl]
+
+        cls.__bases__ = (target_base_class,)
+
+        instance = target_base_class.__new__(cls, *args, **kwargs)
+        return instance

--- a/ptf/saisanity.py
+++ b/ptf/saisanity.py
@@ -1,0 +1,356 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+
+"""
+This file contains some Test classes which are used to the basic functionality of the switch.
+"""
+
+from sai_thrift.sai_headers import *
+from sai_base_test import *
+
+mac1 = '00:11:11:11:11:11'
+mac2 = '00:22:22:22:22:22'
+mac3 = '00:33:33:33:33:33'
+mac4 = '00:12:12:12:12:13'
+
+
+class L2TrunkToTrunkVlanTest(PlatformSaiHelper):
+    """
+    Test for L2 Vlan Trunk to Trunk transport.
+    """
+
+    def setUp(self):
+        #this process contains the switch_init process
+        SaiHelperBase.setUp(self)
+
+        self.create_bridge_ports()
+
+        print("Sending L2 packet port 1 -> port 2 [access vlan=10])")
+        self.vlan_id = 10
+
+        mac_action = SAI_PACKET_ACTION_FORWARD
+
+        self.vlan_oid = sai_thrift_create_vlan(self.client, vlan_id=self.vlan_id)
+        self.assertNotEqual(self.vlan_oid, 0)
+        self.vlan_member1 = sai_thrift_create_vlan_member(
+            self.client, vlan_id=self.vlan_oid, bridge_port_id=self.port0_bp, vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
+        self.vlan_member2 = sai_thrift_create_vlan_member(
+            self.client, vlan_id=self.vlan_oid, bridge_port_id=self.port1_bp, vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
+
+        sai_thrift_set_port_attribute(self.client, port_oid=self.port0, port_vlan_id=self.vlan_id)
+        sai_thrift_set_port_attribute(self.client, port_oid=self.port1, port_vlan_id=self.vlan_id)
+
+        self.fdb_entry1 = sai_thrift_fdb_entry_t(switch_id=self.switch_id, mac_address=mac1, bv_id=self.vlan_oid)
+        self.fdb_entry2 = sai_thrift_fdb_entry_t(switch_id=self.switch_id, mac_address=mac2, bv_id=self.vlan_oid)
+
+        #need the bridge port inactually
+        sai_thrift_create_fdb_entry(self.client, fdb_entry=self.fdb_entry1, bridge_port_id=self.port0_bp, packet_action=mac_action)
+        sai_thrift_create_fdb_entry(self.client, fdb_entry=self.fdb_entry2, bridge_port_id=self.port1_bp, packet_action=mac_action)
+
+
+    def runTest(self):
+        pkt = simple_tcp_packet(eth_dst='00:22:22:22:22:22',
+                                eth_src=mac4,
+                                ip_dst='10.0.0.1',
+                                ip_id=101,
+                                ip_ttl=64)
+        try:
+            time.sleep(5)
+            send_packet(self, self.dev_port0, pkt)
+            verify_packet(self, pkt, self.dev_port1)
+        finally:
+            pass
+
+
+    def tearDown(self):
+        sai_thrift_remove_fdb_entry(self.client, self.fdb_entry1)
+        sai_thrift_remove_fdb_entry(self.client, self.fdb_entry2)
+
+        sai_thrift_set_port_attribute(self.client, port_oid=self.port0, port_vlan_id=1)
+        sai_thrift_set_port_attribute(self.client, port_oid=self.port1, port_vlan_id=1)
+
+        sai_thrift_remove_vlan_member(self.client,self.vlan_member1)
+        sai_thrift_remove_vlan_member(self.client,self.vlan_member2)
+        sai_thrift_remove_vlan(self.client, self.vlan_oid)
+        self.remove_bridge_port()
+        #TODO resove the error for fdb entry not equals to init one
+        SaiHelperBase.tearDown(self)
+
+
+class L2TrunkToAccessVlanTest(PlatformSaiHelper):
+    """
+    Test for L2 Vlan Trunk to Access transport.
+    """
+
+    def setUp(self):
+        #this process contains the switch_init process
+        SaiHelperBase.setUp(self)
+
+        self.create_bridge_ports()
+
+        print("Sending L2 packet port 1 -> port 2 [trunk vlan=10])")
+        self.vlan_id = 10
+
+        mac_action = SAI_PACKET_ACTION_FORWARD
+
+        self.vlan_oid = sai_thrift_create_vlan(self.client, vlan_id=self.vlan_id)
+        self.assertNotEqual(self.vlan_oid, 0)
+        self.vlan_member1 = sai_thrift_create_vlan_member(
+            self.client, vlan_id=self.vlan_oid, bridge_port_id=self.port0_bp, vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
+        self.vlan_member2 = sai_thrift_create_vlan_member(
+            self.client, vlan_id=self.vlan_oid, bridge_port_id=self.port1_bp, vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
+
+        sai_thrift_set_port_attribute(self.client, port_oid=self.port0, port_vlan_id=self.vlan_id)
+        sai_thrift_set_port_attribute(self.client, port_oid=self.port1, port_vlan_id=self.vlan_id)
+
+        self.fdb_entry1 = sai_thrift_fdb_entry_t(switch_id=self.switch_id, mac_address=mac1, bv_id=self.vlan_oid)
+        self.fdb_entry2 = sai_thrift_fdb_entry_t(switch_id=self.switch_id, mac_address=mac2, bv_id=self.vlan_oid)
+
+        #need the bridge port inactually
+        sai_thrift_create_fdb_entry(self.client, fdb_entry=self.fdb_entry1, bridge_port_id=self.port0_bp, packet_action=mac_action)
+        sai_thrift_create_fdb_entry(self.client, fdb_entry=self.fdb_entry2, bridge_port_id=self.port1_bp, packet_action=mac_action)
+
+
+    def runTest(self):
+        pkt = simple_udp_packet(eth_dst=mac2,
+                                eth_src=mac4,
+                                dl_vlan_enable=True,
+                                vlan_vid=10,
+                                ip_dst='172.16.0.1',
+                                ip_id=102,
+                                ip_ttl=64)
+        exp_pkt = simple_udp_packet(eth_dst=mac2,
+                                    eth_src=mac4,
+                                    ip_dst='172.16.0.1',
+                                    ip_id=102,
+                                    ip_ttl=64,
+                                    pktlen=96)
+        try:
+            time.sleep(5)
+            send_packet(self, self.dev_port0, pkt)
+            verify_packet(self, exp_pkt, self.dev_port1)
+        finally:
+            pass
+
+
+    def tearDown(self):
+        sai_thrift_remove_fdb_entry(self.client, self.fdb_entry1)
+        sai_thrift_remove_fdb_entry(self.client, self.fdb_entry2)
+
+        sai_thrift_set_port_attribute(self.client, port_oid=self.port0, port_vlan_id=1)
+        sai_thrift_set_port_attribute(self.client, port_oid=self.port1, port_vlan_id=1)
+
+        sai_thrift_remove_vlan_member(self.client,self.vlan_member1)
+        sai_thrift_remove_vlan_member(self.client,self.vlan_member2)
+        sai_thrift_remove_vlan(self.client, self.vlan_oid)
+        self.remove_bridge_port()
+        #TODO resove the error for fdb entry not equals to init one
+        SaiHelperBase.tearDown(self)
+
+
+class L2SanityTest(PlatformSaiHelper):
+    """
+    Test for L2 trunk and access port access, all ports scanning.
+    """
+
+    def gen_mac(self):
+         #Gets self.portX objects for all active ports
+        for index in range(0, len(self.port_list)):
+            mac = "00"
+            if index < 9 :
+                section = ":" + "0" + str(index+1)
+            else:
+                section= ":" + str(index+1)
+            mac += (section*5)
+            setattr(self, 'mac%s' % index, mac)
+
+
+    def create_vlan_ports(self, vlanid, vlan_oid):
+        for index in range(0, len(self.port_list)):
+            port_bp = getattr(self, 'port%s_bp' % index)
+            if index%2 == 0:
+                vlan_member = sai_thrift_create_vlan_member(
+                    self.client,
+                    vlan_id=self.vlan_oid,
+                    bridge_port_id=port_bp,
+                    vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
+            else:
+                vlan_member = sai_thrift_create_vlan_member(
+                    self.client,
+                    vlan_id=self.vlan_oid,
+                    bridge_port_id=port_bp,
+                    vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
+
+            setattr(self, 'vlan%s_member%s' % (vlanid, index), vlan_member)
+
+
+    def set_port_vlan(self, vlan_id):
+        for index in range(0, len(self.port_list)):
+            port_id=getattr(self, 'port%s' % index)
+            sai_thrift_set_port_attribute(self.client, port_id, port_vlan_id=vlan_id)
+
+
+    def create_port_fdb(self, vlan_id, vlan_oid, mac_action):
+        for index in range(0, len(self.port_list)):
+            mac=getattr(self, 'mac%s' % index)
+            port_bp = getattr(self, 'port%s_bp' % index)
+            fdb_entry = sai_thrift_fdb_entry_t(
+                switch_id=self.switch_id, mac_address=mac, bv_id=vlan_oid)
+            sai_thrift_create_fdb_entry(
+                self.client,
+                fdb_entry,
+                type=SAI_FDB_ENTRY_TYPE_STATIC,
+                bridge_port_id=port_bp,
+                packet_action=mac_action)
+            setattr(self, 'fdb_entry%s' % index, fdb_entry)
+
+
+    def create_pkt(self, vlan_id):
+        for index in range(0, len(self.port_list)):
+            target_mac = getattr(self, 'mac%s' % index)
+            if index%2 == 0:
+                pkt = simple_tcp_packet(eth_src=self.src_mac,
+                                        eth_dst=target_mac,
+                                        ip_dst='172.16.0.1',
+                                        ip_id=101,
+                                        ip_ttl=64)
+            else:
+                pkt = simple_tcp_packet(eth_dst=target_mac,
+                                        eth_src=self.src_mac,
+                                        dl_vlan_enable=True,
+                                        vlan_vid=vlan_id,
+                                        ip_dst='172.16.0.1',
+                                        ip_id=102,
+                                        ip_ttl=64)
+            setattr(self, 'pkt%s' % index, pkt)
+
+    def create_exp_pkt(self, vlan_id):
+        for index in range(0, len(self.port_list)):
+            target_mac = getattr(self, 'mac%s' % index)
+            if index%2 == 0:
+                exp_pkt = getattr(self, 'pkt%s' % index)
+            else:
+                exp_pkt = simple_tcp_packet(eth_dst=target_mac,
+                                        eth_src=self.src_mac,
+                                        ip_dst='172.16.0.1',
+                                        ip_id=102,
+                                        dl_vlan_enable=True,
+                                        vlan_vid=vlan_id,
+                                        ip_ttl=64)
+            setattr(self, 'exp_pkt%s' % index, exp_pkt)
+
+
+    def setUp(self):
+        #Init switch
+        SaiHelperBase.setUp(self)
+
+        mac4=  '00:12:12:12:12:13'
+
+        self.vlan_id = 10
+        self.gen_mac()
+        self.src_mac=mac4
+        mac_action = SAI_PACKET_ACTION_FORWARD
+
+        self.src_port = self.port0
+        self.dst_port = self.port1
+
+        self.create_bridge_ports()
+
+        # create vlan 10 with ports
+        self.vlan_oid = sai_thrift_create_vlan(self.client, vlan_id=self.vlan_id)
+        self.assertNotEqual(self.vlan_oid, 0)
+        self.create_vlan_ports(self.vlan_id, self.vlan_oid)
+
+        #set port vlan attribute
+        self.set_port_vlan(self.vlan_id)
+
+        #set fdb
+        self.create_port_fdb(self.vlan_id, self.vlan_oid, mac_action)
+
+        #create send pkt and rcv pkt
+        self.create_pkt(self.vlan_id)
+        self.create_exp_pkt(self.vlan_id)
+
+
+    def runTest(self):
+        try:
+            for index in range(1, len(self.port_list)):
+                self.dataplane.flush()
+                print("Check port{} forwarding...".format(index))
+                target_pkt = getattr(self, 'pkt%s' % index)
+                exp_pkt = getattr(self, 'exp_pkt%s' % index)
+                send_packet(self, self.dev_port0, target_pkt)
+                verify_packet(self, exp_pkt, index)
+        finally:
+            pass
+
+
+    def tearDown(self):
+        #reset port vlan id
+        #?reset to 0 or 1?
+        self.reset_port_vlan(1)
+
+        #remove fdb
+        self.remove_fdb()
+
+        #remove vlan member
+        self.remove_vlan_member(self.vlan_id)
+
+        #remove bridge port
+        self.remove_bridge_port()
+
+        sai_thrift_remove_vlan(self.client, self.vlan_oid)
+        SaiHelperBase.tearDown(self)
+
+    def reset_port_vlan(self, reset_vlan_id):
+        for index in range(0, len(self.port_list)):
+            port_id=getattr(self, 'port%s' % index)
+            sai_thrift_set_port_attribute(self.client, port_id, port_vlan_id=reset_vlan_id)
+
+    def remove_fdb(self):
+        for index in range(0, len(self.port_list)):
+            fdb_entry=getattr(self, 'fdb_entry%s' % index)
+            sai_thrift_remove_fdb_entry(self.client, fdb_entry)
+
+
+    def remove_vlan_member(self, vlan_id):
+        for index in range(0, len(self.port_list)):
+            vlan_member=getattr(self, 'vlan%s_member%s' % (vlan_id, index))
+            sai_thrift_remove_vlan_member(self.client, vlan_member)
+
+
+def set_vlan_data(vlan_id=0, ports=None, untagged=None, large_port=0):
+    """
+    Creates dictionary with vlan data
+
+    Args:
+        vlan_id (int): VLAN ID number
+        ports (list): ports numbers
+        untagged (list): list of untagged ports
+        large_port (int): the largest port in vlan
+
+    Return:
+        dictionary: vlan_data_dict
+    """
+    vlan_data_dict = {
+        "vlan_id": vlan_id,
+        "ports": ports,
+        "untagged": untagged,
+        "large_port": large_port
+    }
+    return vlan_data_dict


### PR DESCRIPTION
* Add a middle layer (strategy and factory) under the test cases which can

no more if-else for platform selecting
no more code injection for different platforms, just need to abstract to a method on the differences
auto select the platform by the parameters in the test starter (shell, happed in run_p4_tests, not published here)
easy-distinct structure for the difference from platforms
prepared for future statistic
Add a sanity sample, it can

configure across all the ports (base on port's configuration file)
simple FDB and VLAN naming according to port's number
make a basic check on the status of the devices
use as a sample for how to use the new middle layer

fix and suppress LGTM alters

Signed-off-by: Richard Yu <richard.yu@microsoft.com>

* code refactor part I

- add comments for class and method
- reformat code
- move platform related method to corresponding class

code refactor Part II

optimize the class hirerarchy
simplify the import items
add more docs

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>

* suppress lgtm warnings

fix lgtm warning

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>