### PR TITLE
Add Thrift 0.14.1 compatibility (#1403)

### DIFF
--- a/test/saithrift/Makefile
+++ b/test/saithrift/Makefile
@@ -3,9 +3,15 @@ CXX = $(CROSS_COMPILE)g++
 SAI_PREFIX = /usr
 SAI_HEADER_DIR ?= $(SAI_PREFIX)/include/sai
 SAI_HEADERS = $(SAI_HEADER_DIR)/sai*.h
-CFLAGS = -I$(SAI_HEADER_DIR) -I. -std=c++11 -DFORCE_BOOST_SMART_PTR
+CFLAGS = -I$(SAI_HEADER_DIR) -I. -std=c++11
 ifeq ($(DEBUG),1)
 CFLAGS += -O0 -ggdb
+endif
+
+# Detect THRIFT_VERSION
+THRIFT_VERSION = $(shell thrift  -version | cut -d ' ' -f3)
+ifeq ($(shell dpkg --compare-versions $(THRIFT_VERSION) "le" 0.11.0 && echo True), True)
+CFLAGS += -DFORCE_BOOST_SMART_PTR
 endif
 
 ifeq ($(platform),MLNX)
@@ -21,8 +27,8 @@ CDEFS = -DBRCMSAI
 endif
 endif
 endif
-DEPS = switch_sai_constants.h  switch_sai_rpc.h  switch_sai_types.h
-OBJS = switch_sai_constants.o  switch_sai_rpc.o  switch_sai_types.o
+DEPS =  switch_sai_rpc.h  switch_sai_types.h
+OBJS =  switch_sai_rpc.o  switch_sai_types.o
 
 ODIR = ./src/obj
 SAIDIR = ./include
@@ -42,8 +48,6 @@ endif
 SAI_LIBRARY_DIR ?= $(SAI_PREFIX)/lib
 LDFLAGS = -L$(SAI_LIBRARY_DIR) -Wl,-rpath=$(SAI_LIBRARY_DIR)
 CPP_SOURCES = \
-				src/gen-cpp/switch_sai_constants.cpp \
-				src/gen-cpp/switch_sai_constants.h \
 				src/gen-cpp/switch_sai_rpc.cpp \
 				src/gen-cpp/switch_sai_rpc.h \
 				src/gen-cpp/switch_sai_types.cpp \
@@ -62,6 +66,15 @@ SAI_PY_HEADERS = \
 
 MKDIR_P = mkdir -p
 INSTALL := /usr/bin/install
+
+ifeq ($(shell dpkg --compare-versions $(THRIFT_VERSION) "lt" 0.14.1 && echo True), True)
+DEPS += switch_sai_constants.h
+OBJS += switch_sai_constants.o
+CPP_SOURCES += src/gen-cpp/switch_sai_constants.cpp \
+               src/gen-cpp/switch_sai_constants.h
+
+CONSTANS_OBJ = $(ODIR)/switch_sai_constants.o
+endif
 
 all: directories $(ODIR)/librpcserver.a saiserver clientlib
 
@@ -89,8 +102,8 @@ $(ODIR)/switch_sai_rpc_server.o: src/switch_sai_rpc_server.cpp
 $(ODIR)/saiserver.o: src/saiserver.cpp
 	$(CXX) $(CFLAGS) -c $^ -o $@ $(CFLAGS) $(CDEFS) -I$(SRC)/gen-cpp -I$(SRC)
 
-$(ODIR)/librpcserver.a: $(ODIR)/switch_sai_rpc.o $(ODIR)/switch_sai_types.o $(ODIR)/switch_sai_constants.o $(ODIR)/switch_sai_rpc_server.o
-	ar rcs $(ODIR)/librpcserver.a $(ODIR)/switch_sai_rpc.o $(ODIR)/switch_sai_types.o $(ODIR)/switch_sai_constants.o $(ODIR)/switch_sai_rpc_server.o
+$(ODIR)/librpcserver.a: $(ODIR)/switch_sai_rpc.o $(ODIR)/switch_sai_types.o $(ODIR)/switch_sai_rpc_server.o $(CONSTANS_OBJ)
+	ar rcs $(ODIR)/librpcserver.a $(ODIR)/switch_sai_rpc.o $(ODIR)/switch_sai_types.o  $(ODIR)/switch_sai_rpc_server.o $(CONSTANS_OBJ)
 
 saiserver: $(ODIR)/saiserver.o $(ODIR)/librpcserver.a
 	$(CXX) $(LDFLAGS) $(ODIR)/switch_sai_rpc_server.o $(ODIR)/saiserver.o -o $@ \

--- a/test/saithrift/src/saiserver.cpp
+++ b/test/saithrift/src/saiserver.cpp
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <sys/queue.h>
 #include <sys/types.h>
+#include <algorithm>
 #include <fstream>
 #include <sstream>
 #include <set>

--- a/test/saithrift/src/switch_sai.thrift
+++ b/test/saithrift/src/switch_sai.thrift
@@ -48,7 +48,7 @@ struct sai_thrift_vlan_port_t {
     2: sai_thrift_vlan_tagging_mode_t tagging_mode;
 }
 
-union sai_thrift_ip_t {
+struct sai_thrift_ip_t {
     1: sai_thrift_ip4_t ip4;
     2: sai_thrift_ip6_t ip6;
 }
@@ -79,7 +79,7 @@ struct sai_thrift_s32_list_t {
     2: list<i32> s32list;
 }
 
-union sai_thrift_acl_mask_t {
+struct sai_thrift_acl_mask_t {
     1: byte u8;
     2: byte s8;
     3: i16 u16;
@@ -91,7 +91,7 @@ union sai_thrift_acl_mask_t {
     9: sai_thrift_ip6_t ip6;
 }
 
-union sai_thrift_acl_data_t {
+struct sai_thrift_acl_data_t {
     1: byte u8;
     2: byte s8;
     3: i16 u16;
@@ -112,7 +112,7 @@ struct sai_thrift_acl_field_data_t
     3: sai_thrift_acl_data_t data;
 }
 
-union sai_thrift_acl_parameter_t {
+struct sai_thrift_acl_parameter_t {
     1: byte u8;
     2: byte s8;
     3: i16 u16;
@@ -161,7 +161,7 @@ struct sai_thrift_fdb_values_t {
     2: sai_thrift_fdb_entry_t thrift_fdb_entry;
 }
 
-union sai_thrift_attribute_value_t {
+struct sai_thrift_attribute_value_t {
     1:  bool booldata;
     2:  string chardata;
     3:  byte u8;
@@ -207,7 +207,7 @@ struct sai_thrift_attribute_list_t {
     2: i32 attr_count; // redundant
 }
 
-union sai_thrift_result_data_t {
+struct sai_thrift_result_data_t {
     1: sai_thrift_object_list_t objlist;
     2: sai_thrift_object_id_t oid;
     3: i16 u16;

--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -74,7 +74,11 @@ using namespace ::apache::thrift::protocol;
 using namespace ::apache::thrift::transport;
 using namespace ::apache::thrift::server;
 
+#ifdef FORCE_BOOST_SMART_PTR
 using boost::shared_ptr;
+#else
+using std::shared_ptr;
+#endif
 
 using namespace ::switch_sai;
 
@@ -128,7 +132,7 @@ public:
       sprintf(macstr, "%02x:%02x:%02x:%02x:%02x:%02x", m[0], m[1], m[2], m[3], m[4], m[5]);
       return(macstr);
   }
-  
+
   void sai_thrift_string_to_v4_ip(const std::string s, unsigned int *m) {
       unsigned char r=0;
       unsigned int i;
@@ -762,36 +766,36 @@ public:
       free(attr_list);
       return status;
   }
-//listing all the fdb entries from map	
+//listing all the fdb entries from map
   void sai_thrift_get_fdb_entries (sai_thrift_attribute_list_t& thrift_attr_list){
       sai_mac_t mac_address;
-      sai_object_id_t bv_id;	
+      sai_object_id_t bv_id;
       sai_object_id_t bport_id;
-      sai_fdb_entry_t fdb_entry;  
-             
+      sai_fdb_entry_t fdb_entry;
+
       thrift_attr_list.attr_count = gFdbMap.size();
-      
+
       sai_fdb_entry_t fdb_m;
       sai_object_id_t b_id;
-      
+
       for (auto it = gFdbMap.begin(); it != gFdbMap.end(); it++){
           fdb_m = it->first;
-          b_id = it->second; 	
-      	
-          sai_thrift_fdb_values_t fdb_value;		 
+          b_id = it->second;
+
+          sai_thrift_fdb_values_t fdb_value;
           fdb_value.bport_id=b_id;
           fdb_value.thrift_fdb_entry.bv_id=fdb_m.bv_id;
           fdb_value.thrift_fdb_entry.mac_address=mac_to_sai_thrift_string(fdb_m.mac_address);
-          
-          sai_thrift_attribute_t thrift_fdb_attributes;		
+
+          sai_thrift_attribute_t thrift_fdb_attributes;
           thrift_fdb_attributes.id = SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID;
           thrift_fdb_attributes.value.fdb_values = fdb_value;
-	  	
+
           thrift_attr_list.attr_list.push_back(thrift_fdb_attributes);
-      }			
+      }
       return;
   }
-  
+
   void sai_thrift_parse_vlan_attributes(const std_sai_thrift_attr_vctr_t &thrift_attr_list, sai_attribute_t *attr_list) {
       SAI_THRIFT_LOG_DBG("Called.");
 
@@ -1131,7 +1135,7 @@ public:
       return status;
   }
 
-  sai_thrift_status_t sai_thrift_create_route(const sai_thrift_route_entry_t &thrift_route_entry, const std::vector<sai_thrift_attribute_t> & thrift_attr_list) 
+  sai_thrift_status_t sai_thrift_create_route(const sai_thrift_route_entry_t &thrift_route_entry, const std::vector<sai_thrift_attribute_t> & thrift_attr_list)
   {
       printf("sai_thrift_create_route\n");
       sai_status_t status = SAI_STATUS_SUCCESS;
@@ -1626,15 +1630,15 @@ public:
           case SAI_SWITCH_ATTR_FDB_AGING_TIME:
               attr->value.u32 = thrift_attr.value.u32;
               break;
-  
+
           case SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_SEED:
-              attr->value.u32 = thrift_attr.value.u32;	
+              attr->value.u32 = thrift_attr.value.u32;
 	            break;
-   
+
           case SAI_SWITCH_ATTR_LAG_DEFAULT_HASH_SEED:
               attr->value.u32 = thrift_attr.value.u32;
               break;
-          
+
           default:
               printf("unknown thrift_attr id: %d\n", thrift_attr.id);
       }
@@ -3252,7 +3256,7 @@ public:
           lane_list.push_back((uint32_t) lane_list_num->list[index]);
       }
       attr_list.push_back(thrift_port_hw_lane);
-      free(port_hw_lane.value.u32list.list); 
+      free(port_hw_lane.value.u32list.list);
 
       sai_attribute_t port_oper_status_attribute;
       sai_thrift_attribute_t thrift_port_status;


### PR DESCRIPTION
Cherry-pick "Add Thrift 0.14.1 compatibility #1403" from master

Make saithrift compatible with thrift 0.14.1
#### How I did it:
- Replace `union` by `struct` in *.thrift files as saithrift code relays on an old [thrift bug](https://jira.apache.org/jira/browse/THRIFT-3650) which was fixed in thrift 0.11.0. Due to that BUG  `unios` behaves as `struct`. In SONiC there is [patch ](https://github.com/Azure/sonic-buildimage/blob/master/src/thrift/Makefile#L28)to revert the fix in 0.11.0 .  
- Use different `shared_ptr` based on thrift version. In Thrift 0.11.0 the `boost::shared_ptr` is usually used. But star from 0.13.0 the boost dependency was dropped in Thrift.
- Starting from 0.14.1 the *constants* files are not generated for CPP language, so added them conditionally.

Verified these changes in SONIC build env with different thrift version:
```
msosyak@b3c1a8d88f02:/sonic/src/sonic-sairedis/SAI$ dpkg -l | grep thrift
ii  libthrift-0.11.0                       0.11.0-4                                amd64        Thrift C++ library
ii  libthrift-dev                          0.11.0-4                                amd64        Thrift C++ library (development headers)
ii  python-thrift                          0.11.0-4                                amd64        Python library for Thrift
ii  thrift-compiler                        0.11.0-4                                amd64        code generator/compiler for Thrift definitions
msosyak@b3c1a8d88f02:/sonic/src/sonic-sairedis/SAI$ dpkg-buildpackage -rfakeroot -b -us -uc -tc -j6
dpkg-buildpackage: info: source package saithrift
dpkg-buildpackage: info: source version 0.9.4
dpkg-buildpackage: info: source distribution stable
dpkg-buildpackage: info: source changed by Pavel Shirshov <pavelsh@microsoft.com>
dpkg-buildpackage: info: host architecture amd64
 dpkg-source --before-build .
 fakeroot debian/rules clean
dh clean
dh: warning: Compatibility levels before 10 are deprecated (level 9 in use)
   debian/rules override_dh_auto_clean
make[1]: Entering directory '/sonic/src/sonic-sairedis/SAI'
dh_auto_clean
* * * 
 dpkg-source --after-build .
dpkg-buildpackage: info: binary-only upload (no source included)
msosyak@b3c1a8d88f02:/sonic/src/sonic-sairedis/SAI$ echo $?
0
```

```
msosyak@b3c1a8d88f02:/sonic/src/sonic-sairedis/SAI$ dpkg -l | grep thrift
ii  libthrift-0.11.0                       0.11.0-4                                amd64        Thrift C++ library
ii  libthrift-dev                          0.14.1                                  amd64        Thrift C++ library (development headers)
ii  libthrift0                             0.14.1                                  amd64        Thrift C++ library
ii  python-thrift                          0.14.1                                  amd64        Python bindings for Thrift (Python 2)
ii  thrift-compiler                        0.14.1                                  amd64        Compiler for Thrift definition files
(reverse-i-search)`d': ^Ckg -l | grep thrift
msosyak@b3c1a8d88f02:/sonic/src/sonic-sairedis/SAI$ dpkg-buildpackage -rfakeroot -b -us -uc -tc -j100 
dpkg-buildpackage: info: source package saithrift
dpkg-buildpackage: info: source version 0.9.4
dpkg-buildpackage: info: source distribution stable
dpkg-buildpackage: info: source changed by Pavel Shirshov <pavelsh@microsoft.com>
dpkg-buildpackage: info: host architecture amd64
 dpkg-source --before-build .
 fakeroot debian/rules clean
dh clean
* * * * *
 dpkg-source --after-build .
dpkg-buildpackage: info: binary-only upload (no source included)
msosyak@b3c1a8d88f02:/sonic/src/sonic-sairedis/SAI$ echo $?
0
```