### PR TITLE
Correct the brief of unknown unicast, broadcast and unknown multicast group

### DIFF
--- a/inc/saivlan.h
+++ b/inc/saivlan.h
@@ -307,9 +307,10 @@ typedef enum _sai_vlan_attr_t
      * @brief Unknown unicast flood group.
      *
      * Provides control on the set of vlan members on which unknown unicast
-     * packets need to be flooded. This attribute would be used only when
-     * the SAI_VLAN_ATTR_UNKNOWN_UNICAST_FLOOD_CONTROL_TYPE is set as
-     * SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP. When this attribute's value is
+     * packets need to be flooded. This attribute would be used when the
+     * SAI_VLAN_ATTR_UNKNOWN_UNICAST_FLOOD_CONTROL_TYPE is set as
+     * SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP or
+     * SAI_VLAN_FLOOD_CONTROL_TYPE_COMBINED. When this attribute's value is
      * SAI_NULL_OBJECT_ID, then flooding would be disabled.
      *
      * @type sai_object_id_t
@@ -334,9 +335,10 @@ typedef enum _sai_vlan_attr_t
      * @brief Unknown multicast flood group.
      *
      * Provides control on the set of vlan members on which unknown multicast
-     * packets need to be flooded. This attribute would be used only when
-     * the SAI_VLAN_ATTR_UNKNOWN_MULTICAST_FLOOD_CONTROL_TYPE is set as
-     * SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP.When this attribute's value is
+     * packets need to be flooded. This attribute would be used when the
+     * SAI_VLAN_ATTR_UNKNOWN_MULTICAST_FLOOD_CONTROL_TYPE is set as
+     * SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP or
+     * SAI_VLAN_FLOOD_CONTROL_TYPE_COMBINED. When this attribute's value is
      * SAI_NULL_OBJECT_ID, then flooding would be disabled.
      *
      * @type sai_object_id_t
@@ -361,9 +363,10 @@ typedef enum _sai_vlan_attr_t
      * @brief Broadcast flood group.
      *
      * Provides control on the set of vlan members on which broadcast
-     * packets need to be flooded. This attribute would be used only when
-     * the SAI_VLAN_ATTR_BROADCAST_FLOOD_CONTROL_TYPE is set as
-     * SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP.When this attribute's value is
+     * packets need to be flooded. This attribute would be used when the
+     * SAI_VLAN_ATTR_BROADCAST_FLOOD_CONTROL_TYPE is set as
+     * SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP or
+     * SAI_VLAN_FLOOD_CONTROL_TYPE_COMBINED. When this attribute's value is
      * SAI_NULL_OBJECT_ID, then flooding would be disabled.
      *
      * @type sai_object_id_t


### PR DESCRIPTION
Miss to modify the brief messages, these groups are valid on both
SAI_VLAN_FLOOD_CONTROL_TYPE_L2MC_GROUP and SAI_VLAN_FLOOD_CONTROL_TYPE_COMBINED

Signed-off-by: gord_chen <gord_chen@edge-core.com>