### PR TITLE
[Fix]Correct enum check on branch 1.9

### DIFF
--- a/meta/checkenumlock.sh
+++ b/meta/checkenumlock.sh
@@ -29,9 +29,9 @@ rm -rf temp
 
 mkdir temp
 
-git --work-tree=temp/ checkout origin/master inc
+git --work-tree=temp/ checkout origin/v1.9 inc
 
-echo "Checking for possible enum values shift (current branch vs origin/master) ..."
+echo "Checking for possible enum values shift (current branch vs origin/v1.9) ..."
 
 ./checkheaders.pl -s ../inc/ temp/inc/
 

--- a/meta/checkenumlock.sh
+++ b/meta/checkenumlock.sh
@@ -29,9 +29,9 @@ rm -rf temp
 
 mkdir temp
 
-git --work-tree=temp/ checkout origin/v1.9 inc
+git --work-tree=temp/ checkout origin/master inc
 
-echo "Checking for possible enum values shift (current branch vs origin/v1.9) ..."
+echo "Checking for possible enum values shift (current branch vs origin/master) ..."
 
 ./checkheaders.pl -s ../inc/ temp/inc/
 

--- a/meta/checkheaders.pl
+++ b/meta/checkheaders.pl
@@ -194,7 +194,7 @@ sub CheckHash
             next if $key eq "SAI_OBJECT_TYPE_MAX";
             next if $key eq "SAI_API_MAX";
 
-            # ignore the num lock for the diff between 1.9 and master
+            # ignore the enum lock for the diff between 1.9 and master
             next if $key eq "SAI_PORT_INTERFACE_TYPE_MAX";
 
             # NOTE: some other attributes/enum with END range could be added

--- a/meta/checkheaders.pl
+++ b/meta/checkheaders.pl
@@ -194,6 +194,9 @@ sub CheckHash
             next if $key eq "SAI_OBJECT_TYPE_MAX";
             next if $key eq "SAI_API_MAX";
 
+            # ignore the num lock for the diff between 1.9 and master
+            next if $key eq "SAI_PORT_INTERFACE_TYPE_MAX";
+
             # NOTE: some other attributes/enum with END range could be added
         }
 


### PR DESCRIPTION
When checking the enum we should base on the current branch(1.9)
Test done:
local build

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>