### PR TITLE
Add label attribute for ACL counter

### DIFF
--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -3017,6 +3017,15 @@ typedef enum _sai_acl_counter_attr_t
     SAI_ACL_COUNTER_ATTR_BYTES,
 
     /**
+     * @brief Attribute used to uniquely identify ACL counter.
+     *
+     * @type char
+     * @flags CREATE_AND_SET
+     * @default ""
+     */
+    SAI_ACL_COUNTER_ATTR_LABEL,
+
+    /**
      * @brief End of attributes
      */
     SAI_ACL_COUNTER_ATTR_END,


### PR DESCRIPTION
Summary:

This is similar to #1158 and #1407.

Those PRs added label attribute for LAG/virtual router and counter. This
PR adds similar label attribute for ACL counter.

ACL counter does not have any mandatory attribute to identify object
uniquely. Adding a label attribute that can be used to uniquely identify
ACL counter object during warmboot. The attribute is considered as user
data attached to the object.

Signed-off-by: Shrikrishna Khare <skhare@fb.com>