### PR TITLE
saiport: add support for link training ability query

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -2097,6 +2097,14 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_PFC_TC_DLR_INTERVAL,
 
     /**
+     * @brief Query link-training support
+     *
+     * @type bool
+     * @flags READ_ONLY
+     */
+    SAI_PORT_ATTR_SUPPORTED_LINK_TRAINING_MODE,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_ATTR_END,


### PR DESCRIPTION
Signed-off-by: Dante Su <dante.su@broadcom.com>

**Description**
Add  support for link-training ability query to suppress redundant link-training requests those are doomed to fail

**Motivation and Context**
link-training could either be unavailable on certain ports of a switch silicon or totally unsupported on an entire switch silicon
In order to prevent swss and syncd error out from redundant link-training requests, it's better to introduce this port attribute

**Related HLD:**
<table>
<tr>
<th>Repo</th>
<th>PR title</th>
<th>State</th>
</tr>
<tr>
<td>SONiC</td>
<td><a href='https://github.com/Azure/SONiC/pull/925'>[link-training] initial support</a></td>
<td><img src="https://img.shields.io/github/pulls/detail/state/Azure/SONiC/925"></td>
</tr>
</table>