### PR TITLE
Add two more API as RPC for warmboot testing (#1421)

### DIFF
--- a/meta/sai_rpc_frontend.cpp
+++ b/meta/sai_rpc_frontend.cpp
@@ -819,6 +819,24 @@ class sai_rpcHandlerFrontend : virtual public sai_rpcHandler {
     return count;
   }
 
+    /**
+   * @brief Thrift wrapper for sai_object_type_query() SAI function
+   */
+  sai_thrift_object_type_t sai_thrift_object_type_query(
+      const sai_thrift_object_id_t object_id) {
+
+    return sai_object_type_query(object_id);
+  }
+
+    /**
+   * @brief Thrift wrapper for sai_switch_id_query() SAI function
+   */
+  sai_thrift_object_id_t sai_thrift_switch_id_query(
+      const sai_thrift_object_id_t object_id) {
+
+    return sai_switch_id_query(object_id);
+  }
+
   /**
    * @brief Thrift wrapper for sai_query_attribute_enum_values_capability()
    *        function

--- a/meta/templates/sai_rpc_server_functions.tt
+++ b/meta/templates/sai_rpc_server_functions.tt
@@ -5,7 +5,7 @@
 [%- create_switch_function = 'create_switch' %]
 [%- remove_switch_function = 'remove_switch' %]
 
-[%- sai_utils_functions = '(query_attribute_enum_values_capability|sai_object_type_get_availability)' -%]
+[%- sai_utils_functions = '(query_attribute_enum_values_capability|sai_object_type_get_availability|sai_object_type_query|sai_switch_id_query)' -%]
 
 [%- ######################################################################## -%]
 
@@ -74,6 +74,8 @@
     [%- indentation = 2 || 2; tab = 2; indent = ' '; indent = indent.repeat(tab*indentation) %]
     [%- IF ret_type == 'int64_t' %]
 [% indent %]return 0ULL;
+    [%- ELSIF ret_type == 'sai_thrift_object_id_t' OR ret_type == 'sai_thrift_object_type_t' %]
+[% indent %]return SAI_NULL_OBJECT_ID;
     [%- ELSE %]
 [% indent %]return;
     [%- END %]

--- a/meta/templates/sai_thrift_utils.tt
+++ b/meta/templates/sai_thrift_utils.tt
@@ -4,6 +4,8 @@
     // sai objects API
     list<i32> sai_thrift_query_attribute_enum_values_capability(1: sai_thrift_object_type_t object_type, 2: sai_thrift_attr_id_t attr_id, 3: i32 caps_count);
     i64 sai_thrift_object_type_get_availability(1 : sai_thrift_object_type_t object_type, 2: sai_thrift_attr_id_t attr_id, 3: i32 attr_type);
+    sai_thrift_object_id_t sai_thrift_switch_id_query(1 : sai_thrift_object_id_t object_id);
+    sai_thrift_object_type_t sai_thrift_object_type_query(1 : sai_thrift_object_id_t object_id);
 
 [%- END -%]
 

--- a/ptf/sai_utils.py
+++ b/ptf/sai_utils.py
@@ -74,6 +74,44 @@ def sai_thrift_object_type_get_availability(client,
     return availability_cnt
 
 
+def sai_thrift_object_type_query(client,
+                                 obj_id=None):
+    """
+    sai_thrift_object_type_query() RPC client function
+    implementation
+
+    Args:
+        client (Client): SAI RPC client
+        obj_id (obj): SAI object id
+
+    Returns:
+        uint: object type
+    """
+    obj_type = client.sai_object_type_query(
+        obj_id)
+
+    return obj_type
+
+
+def sai_thrift_switch_id_query(client,
+                               obj_id=None):
+    """
+    sai_thrift_switch_id_query() RPC client function
+    implementation
+
+    Args:
+        client (Client): SAI RPC client
+        obj_id (obj): SAI object id
+
+    Returns:
+        uint: object type
+    """
+    switch_obj_id = client.sai_switch_id_query(
+        obj_id)
+
+    return switch_obj_id
+
+
 def sai_thrift_get_debug_counter_port_stats(client, port_oid, counter_ids):
     """
     Get port statistics for given debug counters


### PR DESCRIPTION
try to expose the sai api object_type_query and switch_id_query for
warmboot testing
Modify the template file for generate code from meta.

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>