### PR TITLE
Allow builds with multiple python3 versions

### DIFF
--- a/debian/installerFiles/python-saithriftv2.install
+++ b/debian/installerFiles/python-saithriftv2.install
@@ -1,1 +1,1 @@
-debian/usr/local/lib/python3.7/site-packages/* /usr/lib/python3.7/dist-packages/
+debian/usr/local/lib/python3*/site-packages/* /usr/lib/python3/dist-packages/


### PR DESCRIPTION
Currently Python 3.7 is hardcoded into the debian build system here. These code changes allow other versions of python.

This was tested on Python 3.9 on Debian 11.