### PR TITLE
Ecmp member 

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -2696,6 +2696,23 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_IPSEC_SA_STATUS_CHANGE_NOTIFY,
 
     /**
+     * @brief Number of ECMP members supported by My MAC entries installed on the switch
+     *
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_SWITCH_ATTR_MAX_ECMP_MEMBER_COUNT,
+
+    /**
+     * @brief Number of  ECMP Members configured on the switch
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 64
+     */
+    SAI_SWITCH_ATTR_ECMP_MEMBER_COUNT,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -764,6 +764,13 @@ typedef struct _sai_acl_capability_t
      * @passparam &sai_metadata_enum_sai_acl_action_type_t
      */
     sai_s32_list_t action_list;
+
+    /**
+     * @brief Output from get function
+     * Flag indicating whether overlay of match field is supported or not
+     * For example, IPv6 DIP and IPv4 DIP can be overlayed on a 128 bit wide field
+     */
+     bool is_field_overlay_supported;
 } sai_acl_capability_t;
 
 /**

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -765,12 +765,6 @@ typedef struct _sai_acl_capability_t
      */
     sai_s32_list_t action_list;
 
-    /**
-     * @brief Output from get function
-     * Flag indicating whether overlay of match field is supported or not
-     * For example, IPv6 DIP and IPv4 DIP can be overlayed on a 128 bit wide field
-     */
-     bool is_field_overlay_supported;
 } sai_acl_capability_t;
 
 /**


### PR DESCRIPTION
Two new Switch attributes are introduced.
Read Only:
SAI_SWITCH_ATTR_MAX_ECMP_MEMBER_COUNT
This attribute is queried during switch init to find out device specific max number of ecmp members supported.

CREATE_AND_SET (read/write):
SAI_SWITCH_ATTR_ECMP_MEMBER_COUNT
This attribute is set based on the query for MAX_ECMP_MEMBER_COUNT and can be changed dynamically.
If the SAI adapter doesn't support dynamic change of this attribute based on certain conditions like if ECMP groups are already configured then MUST return error.

Typical Workflow:

Switch object create
Switch get SAI_SWITCH_ATTR_MAX_ECMP_MEMBER_COUNT: say SAI adapter returns 2k
Switch set SAI_SWITCH_ATTR_ECMP_MEMBER_COUNT
If step 3 is invoked after the system is fully configured and forwarding traffic
SAI adapter MAY return error if HW is not capable of dynamically adjusting the ECMP group size