### PR TITLE
[SAI-PTF]Add platform helper for saiswitch test and refactor saiswitch

### DIFF
--- a/ptf/platform_helper/brcm_helper/__init__.py
+++ b/ptf/platform_helper/brcm_helper/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+# @file    __init__.py
+#
+# @brief   init
+#
+
+"""
+Init the platform helper module.
+
+platform_helper module contains classes to distiguish the different behivor on different platforms.
+"""

--- a/ptf/platform_helper/brcm_helper/__init__.py
+++ b/ptf/platform_helper/brcm_helper/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+# Copyright (c) 2022 Microsoft Open Technologies, Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain

--- a/ptf/platform_helper/brcm_helper/brcm_saiswitch_helper.py
+++ b/ptf/platform_helper/brcm_helper/brcm_saiswitch_helper.py
@@ -1,19 +1,38 @@
-THIS_DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.join(THIS_DIR, '..'))
-from common_helper import saiswitch_helper
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+
+
+from platform_helper.common_helper.saiswitch_helper import *
 from sai_base_test import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
-from saiswitch import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
-class BrcmSaiSwitchHelper(saiswitch_helper):
-    def __init__(self):
-        pass
+"""
+Brcm sai switch helper for sai switch tests.
+"""
 
+class BrcmSaiSwitchHelper(SaiSwitchHelper):
     
-    def create_route_entry_from_default_vrf(self):
+    def create_route_entry_from_default_vrf(self, client):
+        print("BrcmSaiSwitchHelper::create_route_entry_from_default_vrf.")
         route_entry = sai_thrift_route_entry_t(
-            switch_id=self.switch_id,
-            vr_id = self.default_vrf,
+            switch_id=client.switch_id,
+            vr_id = client.default_vrf,
             destination=sai_ipprefix('0.0.0.0/0'))
         status = sai_thrift_create_route_entry(
-            self.client, route_entry, next_hop_id=nhop)
-        self.assertEqual(status, SAI_STATUS_SUCCESS)
+            client.client, route_entry, next_hop_id=client.nhop)
+        client.assertEqual(status, SAI_STATUS_SUCCESS)
+        client.route_number += 1

--- a/ptf/platform_helper/brcm_helper/brcm_saiswitch_helper.py
+++ b/ptf/platform_helper/brcm_helper/brcm_saiswitch_helper.py
@@ -1,0 +1,19 @@
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(THIS_DIR, '..'))
+from common_helper import saiswitch_helper
+from sai_base_test import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from saiswitch import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+
+class BrcmSaiSwitchHelper(saiswitch_helper):
+    def __init__(self):
+        pass
+
+    
+    def create_route_entry_from_default_vrf(self):
+        route_entry = sai_thrift_route_entry_t(
+            switch_id=self.switch_id,
+            vr_id = self.default_vrf,
+            destination=sai_ipprefix('0.0.0.0/0'))
+        status = sai_thrift_create_route_entry(
+            self.client, route_entry, next_hop_id=nhop)
+        self.assertEqual(status, SAI_STATUS_SUCCESS)

--- a/ptf/platform_helper/brcm_helper/brcm_saiswitch_helper.py
+++ b/ptf/platform_helper/brcm_helper/brcm_saiswitch_helper.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+# Copyright (c) 2022 Microsoft Open Technologies, Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -35,4 +35,6 @@ class BrcmSaiSwitchHelper(SaiSwitchHelper):
         status = sai_thrift_create_route_entry(
             client.client, route_entry, next_hop_id=client.nhop)
         client.assertEqual(status, SAI_STATUS_SUCCESS)
-        client.route_number += 1
+        # Cause we add a route here, we need to increase the route_number
+        if hasattr(client, 'route_number'):
+            client.route_number += 1

--- a/ptf/platform_helper/brcm_sai_helper.py
+++ b/ptf/platform_helper/brcm_sai_helper.py
@@ -21,8 +21,13 @@ This file contains class for brcm specified functions.
 """
 
 from platform_helper.common_sai_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from brcm_helper.brcm_saiswitch_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
 class BrcmSaiHelper(CommonSaiHelper):
+    def __init__(self):
+        self.switch_helper = BrcmSaiSwitchHelper()
+
+
     """
     This class contains broadcom(brcm) specified functions for the platform setup and test context configuration.
     """

--- a/ptf/platform_helper/brcm_sai_helper.py
+++ b/ptf/platform_helper/brcm_sai_helper.py
@@ -21,10 +21,11 @@ This file contains class for brcm specified functions.
 """
 
 from platform_helper.common_sai_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
-from brcm_helper.brcm_saiswitch_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from platform_helper.brcm_helper.brcm_saiswitch_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
 class BrcmSaiHelper(CommonSaiHelper):
     def __init__(self):
+        super().__init__()
         self.switch_helper = BrcmSaiSwitchHelper()
 
 

--- a/ptf/platform_helper/common_helper/__init__.py
+++ b/ptf/platform_helper/common_helper/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+# @file    __init__.py
+#
+# @brief   init
+#
+
+"""
+Init the platform helper module.
+
+platform_helper module contains classes to distiguish the different behivor on different platforms.
+"""

--- a/ptf/platform_helper/common_helper/__init__.py
+++ b/ptf/platform_helper/common_helper/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+# Copyright (c) 2022 Microsoft Open Technologies, Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain

--- a/ptf/platform_helper/common_helper/saiswitch_helper.py
+++ b/ptf/platform_helper/common_helper/saiswitch_helper.py
@@ -1,0 +1,8 @@
+
+class SaiSwitchHelper(object):
+    def __init__(self):
+        pass
+
+
+    def create_route_entry_from_default_vrf(self):
+        pass

--- a/ptf/platform_helper/common_helper/saiswitch_helper.py
+++ b/ptf/platform_helper/common_helper/saiswitch_helper.py
@@ -1,8 +1,29 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
 
-class SaiSwitchHelper(object):
-    def __init__(self):
-        pass
+"""
+Common sai switch helper for sai switch tests.
+"""
 
+class SaiSwitchHelper:
+    """
+    Common sai switch helper for sai switch tests.
+    """
 
-    def create_route_entry_from_default_vrf(self):
-        pass
+    def create_route_entry_from_default_vrf(self, client, nhop):
+        print("SaiSwitchHelper::create_route_entry_from_default_vrf.")

--- a/ptf/platform_helper/common_helper/saiswitch_helper.py
+++ b/ptf/platform_helper/common_helper/saiswitch_helper.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+# Copyright (c) 2022 Microsoft Open Technologies, Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain

--- a/ptf/platform_helper/common_sai_helper.py
+++ b/ptf/platform_helper/common_sai_helper.py
@@ -22,8 +22,13 @@ Class contains common functions.
 This file contains base class for other platform classes.
 """
 from  sai_base_test import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from common_helper.saiswitch_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
 class CommonSaiHelper(SaiHelper):
+    def __init__():
+        self.switch_helper = SaiSwitchHelper()
+
+
     """
     This class contains the common functions for the platform setup and test context configuration.
     """

--- a/ptf/platform_helper/common_sai_helper.py
+++ b/ptf/platform_helper/common_sai_helper.py
@@ -21,11 +21,14 @@ Class contains common functions.
 
 This file contains base class for other platform classes.
 """
-from  sai_base_test import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
-from common_helper.saiswitch_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from platform_helper.common_helper.saiswitch_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+
+from sai_base_test import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+
 
 class CommonSaiHelper(SaiHelper):
-    def __init__():
+    def __init__(self):
+        super().__init__()
         self.switch_helper = SaiSwitchHelper()
 
 

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -34,7 +34,7 @@ from thrift.protocol import TBinaryProtocol
 
 from sai_thrift import sai_rpc
 
-from sai_utils import *
+from sai_utils import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 import sai_thrift.sai_adapter as adapter
 
 ROUTER_MAC = '00:77:66:55:44:00'

--- a/ptf/sai_utils.py
+++ b/ptf/sai_utils.py
@@ -22,10 +22,10 @@ import socket
 
 from functools import wraps
 
-from ptf.packet import *
-from ptf.testutils import *
+from ptf.packet import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from ptf.testutils import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
-from sai_thrift.sai_adapter import *
+from sai_thrift.sai_adapter import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
 
 def sai_thrift_query_attribute_enum_values_capability(client,

--- a/ptf/saisanity.py
+++ b/ptf/saisanity.py
@@ -20,8 +20,8 @@
 This file contains some Test classes which are used to the basic functionality of the switch.
 """
 
-from sai_thrift.sai_headers import *
-from sai_base_test import *
+from sai_thrift.sai_headers import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from sai_base_test import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
 mac1 = '00:11:11:11:11:11'
 mac2 = '00:22:22:22:22:22'

--- a/ptf/saiswitch.py
+++ b/ptf/saiswitch.py
@@ -17,12 +17,12 @@ Thrift SAI interface Switch tests
 """
 from ipaddress import ip_address
 
-from sai_thrift.sai_headers import *
+from sai_thrift.sai_headers import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
 from ptf.mask import Mask
 from lpm import LpmDict
 
-from sai_base_test import *
+from sai_base_test import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(THIS_DIR, '..'))
@@ -83,10 +83,100 @@ def generate_mac_list(no_of_addr):
                         return mac_list
     return mac_list
 
+class AvailableIPv4RouteEntryTest(PlatformSaiHelper):
+    def setUp(self):
+        super(AvailableIPv4RouteEntryTest, self).setUp()
+
+        # values required by neighbor entries tests set by route entries test
+        # Note: routes entries tests should be run as first
+        self.available_v4_host_routes = None
+        self.available_v6_host_routes = None
+
+
+    def check_data_creation(self):
+        '''
+        Verifies creation of maximum number of IPv4 route entries.
+        '''
+        print("\navailableIPv4RouteEntryTest()")
+
+        attr = sai_thrift_get_switch_attribute(
+            self.client, available_ipv4_route_entry=True)
+        max_route_entry = attr["available_ipv4_route_entry"]
+        print("Available IPv4 route entries: %d" % max_route_entry)
+
+        self.routes = dict()
+        mask = '/32'
+        ip_add = generate_ip_addr(max_route_entry + 100)
+
+        self.neigh_entry = sai_thrift_neighbor_entry_t(
+                self.switch_id, self.port10_rif, sai_ipaddress('10.10.10.1'))
+        self.neigh = sai_thrift_create_neighbor_entry(
+                self.client, self.neigh_entry, dst_mac_address='00:11:22:33:44:55')
+        self.nhop = sai_thrift_create_next_hop(
+            self.client,
+            ip=sai_ipaddress('10.10.10.1'),
+            router_interface_id=self.port10_rif,
+            type=SAI_NEXT_HOP_TYPE_IP)
+        self.assertNotEqual(self.nhop, SAI_NULL_OBJECT_ID)
+
+        self.route_number = 0
+        max_host_route = 0
+        self.switch_helper.create_route_entry_from_default_vrf(self)
+        while self.route_number < max_route_entry:
+            ip_p_m = sai_ipprefix(next(ip_add) + mask)
+
+            # check if ip repeat, then get next ip
+            if str(ip_p_m) in self.routes:
+                continue
+
+            route_entry = sai_thrift_route_entry_t(
+                vr_id=self.default_vrf,
+                destination=ip_p_m)
+            status = sai_thrift_create_route_entry(
+                self.client, route_entry, next_hop_id=self.nhop)
+
+            if status == SAI_STATUS_SUCCESS:
+                self.routes.update({str(ip_p_m): route_entry})
+                self.route_number += 1
+            elif status == SAI_STATUS_ITEM_ALREADY_EXISTS:
+                continue
+            elif mask == '/32':  # when host table is full change to LPM
+                print("%s host routes have been created" % self.route_number)
+                max_host_route = self.route_number
+                self.available_v4_host_routes = max_host_route
+                mask = '/30'
+                continue
+            else:
+                self.fail("Route creation failed after creating %d "
+                            "entries, status %u" % (self.route_number, status))
+
+            attr = sai_thrift_get_switch_attribute(
+                self.client, available_ipv4_route_entry=True)
+            self.assertEqual(attr["available_ipv4_route_entry"],
+                                max_route_entry - self.route_number)
+        ip_add.close()
+
+
+    def tearDown(self):
+        for ip_p_m in self.routes:
+            sai_thrift_remove_route_entry(self.client, self.routes.get(ip_p_m))
+        sai_thrift_remove_next_hop(self.client, self.nhop)
+
+
+    def check_amount(self):
+        attr = sai_thrift_get_switch_attribute(
+            self.client, available_ipv4_route_entry=True)
+        self.assertEqual(attr["available_ipv4_route_entry"], 0)
+
+
+    def runTest(self):
+        self.check_data_creation()
+        self.check_amount()
+
 
 class AvailableIPv6RouteEntryTest(PlatformSaiHelper):
     def setUp(self):
-        super(SwitchAttrTest, self).setUp()
+        super(AvailableIPv6RouteEntryTest, self).setUp()
 
         # values required by neighbor entries tests set by route entries test
         # Note: routes entries tests should be run as first
@@ -109,74 +199,72 @@ class AvailableIPv6RouteEntryTest(PlatformSaiHelper):
         routes = dict()
         mask = '/128'
         ip_add = generate_ip_addr(max_route_entry + 100, ipv6=True)
-        try:
-            self.neigh_entry = sai_thrift_neighbor_entry_t(
-                self.switch_id, self.port10_rif, sai_ipaddress('2001:0db8:1::1'))
-            self.neigh = sai_thrift_create_neighbor_entry(
-                self.client, self.neigh_entry, dst_mac_address='00:11:22:33:44:55')
-            nhop = sai_thrift_create_next_hop(
-                self.client,
-                ip=sai_ipaddress('2001:0db8:1::1'),
-                router_interface_id=self.port10_rif,
-                type=SAI_NEXT_HOP_TYPE_IP)
-            self.assertNotEqual(nhop, SAI_NULL_OBJECT_ID)
 
-            route_number = 0
-            max_host_route = 0
-            while route_number < max_route_entry:
-                ip_p_m = sai_ipprefix(next(ip_add) + mask)
+        self.neigh_entry = sai_thrift_neighbor_entry_t(
+            self.switch_id, self.port10_rif, sai_ipaddress('2001:0db8:1::1'))
+        self.neigh = sai_thrift_create_neighbor_entry(
+            self.client, self.neigh_entry, dst_mac_address='00:11:22:33:44:55')
+        nhop = sai_thrift_create_next_hop(
+            self.client,
+            ip=sai_ipaddress('2001:0db8:1::1'),
+            router_interface_id=self.port10_rif,
+            type=SAI_NEXT_HOP_TYPE_IP)
+        self.assertNotEqual(nhop, SAI_NULL_OBJECT_ID)
 
-                #  check if ip repeat, then get next ip
-                if str(ip_p_m) in routes:
-                    continue
+        route_number = 0
+        max_host_route = 0
+        self.switch_helper.create_route_entry_from_default_vrf(self)
+        while route_number < max_route_entry:
+            ip_p_m = sai_ipprefix(next(ip_add) + mask)
 
-                route_entry = sai_thrift_route_entry_t(
-                    switch_id=self.switch_id,
-                    vr_id=self.default_vrf,
-                    destination=ip_p_m)
-                status = sai_thrift_create_route_entry(
-                    self.client, route_entry, next_hop_id=nhop)
+            #  check if ip repeat, then get next ip
+            if str(ip_p_m) in routes:
+                continue
 
-                if status == SAI_STATUS_SUCCESS:
-                    routes.update({str(ip_p_m): route_entry})
-                    route_number += 1
-                elif status == SAI_STATUS_ITEM_ALREADY_EXISTS:
-                    continue
-                elif mask == '/128':  # when host table is full change to LPM
-                    print("%s host routes have been created" % route_number)
-                    max_host_route = route_number
-                    self.available_v6_host_routes = max_host_route
-                    mask = '/120'
-                    continue
-                elif mask == '/120':  # when LPM table is full change to LPM64
-                    print("%s host + LPM routes have been created so far"
-                          % route_number)
-                    mask = '/64'
-                    continue
-                else:
-                    self.fail("Route creation failed after creating %d "
-                              "entries, status %u" % (route_number, status))
+            route_entry = sai_thrift_route_entry_t(
+                switch_id=self.switch_id,
+                vr_id=self.default_vrf,
+                destination=ip_p_m)
+            status = sai_thrift_create_route_entry(
+                self.client, route_entry, next_hop_id=nhop)
 
-                attr = sai_thrift_get_switch_attribute(
-                    self.client, available_ipv6_route_entry=True)
-                self.assertEqual(attr["available_ipv6_route_entry"],
-                                 max_route_entry - route_number)
-                ip_add.close()
-        finally:
-            for ip_p_m in routes:
-                sai_thrift_remove_route_entry(self.client, routes.get(ip_p_m))
-            sai_thrift_remove_next_hop(self.client, nhop)
+            if status == SAI_STATUS_SUCCESS:
+                routes.update({str(ip_p_m): route_entry})
+                route_number += 1
+            elif status == SAI_STATUS_ITEM_ALREADY_EXISTS:
+                continue
+            elif mask == '/128':  # when host table is full change to LPM
+                print("%s host routes have been created" % route_number)
+                max_host_route = route_number
+                self.available_v6_host_routes = max_host_route
+                mask = '/120'
+                continue
+            elif mask == '/120':  # when LPM table is full change to LPM64
+                print("%s host + LPM routes have been created so far"
+                        % route_number)
+                mask = '/64'
+                continue
+            else:
+                self.fail("Route creation failed after creating %d "
+                            "entries, status %u" % (route_number, status))
+
+            attr = sai_thrift_get_switch_attribute(
+                self.client, available_ipv6_route_entry=True)
+            self.assertEqual(attr["available_ipv6_route_entry"],
+                                max_route_entry - route_number)
+        ip_add.close()
+
+
+    def tearDown(self):
+        for ip_p_m in self.routes:
+            sai_thrift_remove_route_entry(self.client, self.routes.get(ip_p_m))
+        sai_thrift_remove_next_hop(self.client, self.nhop)
 
 
     def check_amount(self):
         attr = sai_thrift_get_switch_attribute(
-        self.client, available_ipv6_route_entry=True)
-        max_route_entry = attr["available_ipv6_route_entry"]
-        print("Available IPv6 route entries: %d" % max_route_entry)
-
-        print("%s LPM routes have been created"
-                % (max_route_entry - max_host_route))
-        self.assertEqual(attr["available_ipv6_route_entry"], 0)
+            self.client, available_ipv4_route_entry=True)
+        self.assertEqual(attr["available_ipv4_route_entry"], 0)
 
 
     def runTest(self):

--- a/ptf/saitest.py
+++ b/ptf/saitest.py
@@ -16,12 +16,12 @@
 Thrift SAI interface tester
 """
 
-from sai_thrift.sai_headers import *
+from sai_thrift.sai_headers import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
-from ptf.packet import *
-from ptf.testutils import *
+from ptf.packet import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from ptf.testutils import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
-from sai_base_test import *
+from sai_base_test import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
 
 class FrameworkTester(SaiHelper):

--- a/ptf/warm_boot/warm_saisanity.py
+++ b/ptf/warm_boot/warm_saisanity.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+# Copyright (c) 2022 Microsoft Open Technologies, Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain

--- a/ptf/warm_boot/warm_saiswitch.py
+++ b/ptf/warm_boot/warm_saiswitch.py
@@ -15,64 +15,59 @@
 #    Microsoft would like to thank the following companies for their review and
 #    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
 #    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
-#
-# @file    __init__.py
-#
-# @brief   init
-#
 
 from warm_test_utils import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
-class WarmL2SanityTest(L2SanityTest):
+"""
+Thrift SAI interface Switch tests
+"""
+
+class WarmAvailableIPv4RouteEntryTest(AvailableIPv4RouteEntryTest):
     """
-    Warm boot Test for L2 trunk and access port access, all ports scanning.
+    Warm boot Test for available IPv4 Route Entry.
     """
     @warm_setup
     def setUp(self):
-        print("setUp WarmL2SanityTest")
-        L2SanityTest.setUp(self)
+        print("setUp WarmAvailableIPv4RouteEntryTest")
+        AvailableIPv4RouteEntryTest.setUp(self)
 
 
     def setUp_starting(self):
-        print("setUp_starting WarmL2SanityTest")
-        SaiHelperBase.setUp(self)
-        super().param_init()
+        print("Skip setUp_starting WarmAvailableIPv4RouteEntryTest")
 
 
     def setUp_post_start(self):
-        print("setUp_post_start WarmL2SanityTest")
+        print("setUp_post_start WarmAvailableIPv4RouteEntryTest")
         SaiHelperBase.setUp(self)
-        super().param_init()
 
 
     @warm_test
     def runTest(self):
-        print("Run test WarmL2SanityTest")
+        print("Run test WarmAvailableIPv4RouteEntryTest")
         super().runTest()
 
 
     def test_starting(self):
-        print("test_starting WarmL2SanityTest")
-        super().runTest()
+        print("Skip test_starting WarmAvailableIPv4RouteEntryTest")
 
 
     def test_post_start(self):
-        print("test_post_start WarmL2SanityTest")
-        super().runTest()
+        print("test_post_start WarmAvailableIPv4RouteEntryTest")
+        super().check_amount()
 
 
     @warm_teardown
     def tearDown(self):
-        print("tearDown WarmL2SanityTest")
+        print("tearDown WarmAvailableIPv4RouteEntryTest")
         print("Skip the teardown and make a warm shut down for warm boot testing")
         self.warm_shutdown()
 
 
     def tearDown_starting(self):
-        print("tearDown_starting WarmL2SanityTest")
+        print("tearDown_starting WarmAvailableIPv4RouteEntryTest")
         print("Skip the teardown for warm boot testing")
 
 
     def tearDown_post_start(self):
-        print("tearDown_post_start WarmL2SanityTest")
+        print("tearDown_post_start WarmAvailableIPv4RouteEntryTest")
         print("Skip the teardown after warm boot testing")

--- a/ptf/warm_boot/warm_saiswitch.py
+++ b/ptf/warm_boot/warm_saiswitch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+# Copyright (c) 2022 Microsoft Open Technologies, Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain

--- a/ptf/warm_boot/warm_test_utils.py
+++ b/ptf/warm_boot/warm_test_utils.py
@@ -16,18 +16,16 @@
 #    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
 #    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
 #
-# @file    __init__.py
-#
-# @brief   init
-#
+
 
 import os
 import sys
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(THIS_DIR, '..'))
-from sai_base_test import *
-from saisanity import *
+from sai_base_test import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from saisanity import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from saiswitch import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
 def warm_test(f):
     """

--- a/ptf/warm_boot/warm_test_utils.py
+++ b/ptf/warm_boot/warm_test_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+# Copyright (c) 2022 Microsoft Open Technologies, Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain

--- a/test/saithriftv2/src/saiserver.cpp
+++ b/test/saithriftv2/src/saiserver.cpp
@@ -40,7 +40,8 @@ std::map<std::set<int>, std::string> gPortMap;
 
 std::vector<std::pair<sai_fdb_entry_t, sai_object_id_t>> gFdbMap;
 
-sai_object_id_t gSwitchId; ///< SAI switch global object ID.
+extern sai_object_id_t switch_id;
+sai_object_id_t &gSwitchId = switch_id; ///< SAI switch global object ID.
 
 
 // Profile services


### PR DESCRIPTION
Make the sai test on different platforms can use their own helpers for
making some platform related settings.

- Register the helper in the common_sai_helper
- Override the helper in the platfrom helper as needed
- Use the method from the helper for platform related settings
- Platform choice the helper and its helper method from the
corresponding platform
- refactor the test from method to class