### PR TITLE
[v1.7] Tunnel Scoped TC MAP and Remarking

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -326,6 +326,177 @@ typedef enum _sai_switch_failover_config_mode_t
 } sai_switch_failover_config_mode_t;
 
 /**
+ * @brief Defines tunnel attributes at switch level.
+ * SAI_OBJECT_TYPE_SWITCH_TUNNEL object provides
+ * per tunnel type global configuration.
+ * SAI_OBJECT_TYPE_TUNNEL object configuration
+ * overrides the switch scoped global configuration.
+ */
+typedef enum _sai_switch_tunnel_attr_t
+{
+    /**
+     * @brief Start of attributes
+     */
+    SAI_SWITCH_TUNNEL_ATTR_START,
+
+    /**
+     * @brief Tunnel type key
+     *
+     * @type sai_tunnel_type_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY | KEY
+     * @isresourcetype true
+     */
+    SAI_SWITCH_TUNNEL_ATTR_TUNNEL_TYPE = SAI_SWITCH_TUNNEL_ATTR_START,
+
+    /**
+     * @brief Packet action when a packet ingress and gets routed back to same tunnel
+     *
+     * @type sai_packet_action_t
+     * @flags CREATE_AND_SET
+     * @default SAI_PACKET_ACTION_FORWARD
+     */
+    SAI_SWITCH_TUNNEL_ATTR_LOOPBACK_PACKET_ACTION,
+
+    /* Tunnel encap attributes */
+
+    /**
+     * @brief Tunnel encap ECN mode
+     *
+     * @type sai_tunnel_encap_ecn_mode_t
+     * @flags CREATE_ONLY
+     * @default SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD
+     */
+    SAI_SWITCH_TUNNEL_ATTR_TUNNEL_ENCAP_ECN_MODE,
+
+    /**
+     * @brief Tunnel encap ECN mappers only
+     *
+     * @type sai_object_list_t
+     * @flags CREATE_ONLY
+     * @objects SAI_OBJECT_TYPE_TUNNEL_MAP
+     * @default empty
+     */
+    SAI_SWITCH_TUNNEL_ATTR_ENCAP_MAPPERS,
+
+    /* Tunnel decap attributes */
+
+    /**
+     * @brief Tunnel decap ECN mode
+     *
+     * @type sai_tunnel_decap_ecn_mode_t
+     * @flags CREATE_ONLY
+     * @default SAI_TUNNEL_DECAP_ECN_MODE_STANDARD
+     */
+    SAI_SWITCH_TUNNEL_ATTR_TUNNEL_DECAP_ECN_MODE,
+
+    /**
+     * @brief Tunnel decap ECN mappers only
+     *
+     * @type sai_object_list_t
+     * @flags CREATE_ONLY
+     * @objects SAI_OBJECT_TYPE_TUNNEL_MAP
+     * @default empty
+     */
+    SAI_SWITCH_TUNNEL_ATTR_DECAP_MAPPERS,
+
+    /**
+     * @brief Tunnel VXLAN UDP source port mode
+     *
+     * @type sai_tunnel_vxlan_udp_sport_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_TUNNEL_VXLAN_UDP_SPORT_MODE_EPHEMERAL
+     */
+    SAI_SWITCH_TUNNEL_ATTR_TUNNEL_VXLAN_UDP_SPORT_MODE,
+
+    /**
+     * @brief Tunnel UDP source port
+     *
+     * @type sai_uint16_t
+     * @flags CREATE_AND_SET
+     * @isvlan false
+     * @default 0
+     * @validonly SAI_SWITCH_TUNNEL_ATTR_TUNNEL_TYPE == SAI_TUNNEL_TYPE_VXLAN and SAI_SWITCH_TUNNEL_ATTR_TUNNEL_VXLAN_UDP_SPORT_MODE == SAI_TUNNEL_VXLAN_UDP_SPORT_MODE_USER_DEFINED
+     */
+    SAI_SWITCH_TUNNEL_ATTR_VXLAN_UDP_SPORT,
+
+    /**
+     * @brief Tunnel UDP source port mask
+     *
+     * Sport mask defining the number of least significant bits
+     * reserved for the calculated hash value. 0 means a fixed value.
+     *
+     * @type sai_uint8_t
+     * @flags CREATE_AND_SET
+     * @isvlan false
+     * @default 0
+     * @validonly SAI_SWITCH_TUNNEL_ATTR_TUNNEL_TYPE == SAI_TUNNEL_TYPE_VXLAN and SAI_SWITCH_TUNNEL_ATTR_TUNNEL_VXLAN_UDP_SPORT_MODE == SAI_TUNNEL_VXLAN_UDP_SPORT_MODE_USER_DEFINED
+     */
+    SAI_SWITCH_TUNNEL_ATTR_VXLAN_UDP_SPORT_MASK,
+
+    /**
+     * @brief Enable TC AND COLOR -> DSCP MAP on tunnel at encapsulation (access-to-network) node to remark the DSCP in tunnel header
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_SWITCH_TUNNEL_ATTR_ENCAP_QOS_TC_AND_COLOR_TO_DSCP_MAP,
+
+    /**
+     * @brief Enable TC -> Queue MAP on tunnel encap
+     *
+     * Map id = #SAI_NULL_OBJECT_ID to disable map on tunnel.
+     * Default no map, i.e. packets are queued with static mapping.
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_SWITCH_TUNNEL_ATTR_ENCAP_QOS_TC_TO_QUEUE_MAP,
+
+    /**
+     * @brief Enable DSCP -> TC MAP on tunnel at termination (Network-to-access) node.
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_SWITCH_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_TC_MAP,
+
+    /**
+     * @brief Enable TC -> Priority Group MAP
+     *
+     * Map id = #SAI_NULL_OBJECT_ID to disable map on port.
+     * Default no map
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_SWITCH_TUNNEL_ATTR_DECAP_QOS_TC_TO_PRIORITY_GROUP_MAP,
+
+    /**
+     * @brief End of attributes
+     */
+    SAI_SWITCH_TUNNEL_ATTR_END,
+
+    /** Custom range base value */
+    SAI_SWITCH_TUNNEL_ATTR_CUSTOM_RANGE_START = 0x10000000,
+
+    /** End of custom range base */
+    SAI_SWITCH_TUNNEL_ATTR_CUSTOM_RANGE_END
+
+} sai_switch_tunnel_attr_t;
+
+/**
  * @brief Attribute Id in sai_set_switch_attribute() and
  * sai_get_switch_attribute() calls
  */

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -653,6 +653,118 @@ typedef enum _sai_tunnel_attr_t
     SAI_TUNNEL_ATTR_LOOPBACK_PACKET_ACTION,
 
     /**
+     * @brief Tunnel VXLAN UDP source port mode
+     *
+     * @type sai_tunnel_vxlan_udp_sport_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_TUNNEL_VXLAN_UDP_SPORT_MODE_EPHEMERAL
+     */
+    SAI_TUNNEL_ATTR_VXLAN_UDP_SPORT_MODE,
+
+    /**
+     * @brief Tunnel UDP source port
+     *
+     * @type sai_uint16_t
+     * @flags CREATE_AND_SET
+     * @isvlan false
+     * @default 0
+     * @validonly SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_VXLAN and SAI_TUNNEL_ATTR_VXLAN_UDP_SPORT_MODE == SAI_TUNNEL_VXLAN_UDP_SPORT_MODE_USER_DEFINED
+     */
+    SAI_TUNNEL_ATTR_VXLAN_UDP_SPORT,
+
+    /**
+     * @brief Tunnel UDP source port mask
+     *
+     * Sport mask defining the number of least significant bits
+     * reserved for the calculated hash value. 0 means a fixed value.
+     *
+     * @type sai_uint8_t
+     * @flags CREATE_AND_SET
+     * @isvlan false
+     * @default 0
+     * @validonly SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_VXLAN and SAI_TUNNEL_ATTR_VXLAN_UDP_SPORT_MODE == SAI_TUNNEL_VXLAN_UDP_SPORT_MODE_USER_DEFINED
+     */
+    SAI_TUNNEL_ATTR_VXLAN_UDP_SPORT_MASK,
+
+    /**
+     * @brief IPsec encryption SA index
+     *
+     * Index to bind an egress IPsec SA to a tunnel.
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     * @validonly SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_IPINIP_ESP or SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_IPINIP_UDP_ESP or SAI_TUNNEL_ATTR_TYPE == SAI_TUNNEL_TYPE_VXLAN_UDP_ESP
+     */
+    SAI_TUNNEL_ATTR_SA_INDEX,
+
+    /**
+     * @brief List of ports that are programmed with SAs for this IPsec tunnel.
+     * Useful only when IPsec is implemented in a PHY Chip (different sai_switch
+     * object).
+     *
+     * For IPsec hardware in the Switch ASIC, the per-tunnel port list can be
+     * derived from the union of SAI_IPSEC_SA_ATTR_IPSEC_PORT_LIST for all
+     * sai_ipsec_sa objects for that tunnel.
+     *
+     * @type sai_object_list_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_PORT
+     * @default empty
+     */
+    SAI_TUNNEL_ATTR_IPSEC_SA_PORT_LIST,
+
+    /**
+     * @brief Enable TC AND COLOR -> DSCP MAP on tunnel at encapsulation (access-to-network) node to remark the DSCP in tunnel header
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_TUNNEL_ATTR_ENCAP_QOS_TC_AND_COLOR_TO_DSCP_MAP,
+
+    /**
+     * @brief Enable TC -> Queue MAP on tunnel encap
+     *
+     * Map id = #SAI_NULL_OBJECT_ID to disable map on tunnel.
+     * Default no map, i.e. packets are queued with static mapping.
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_TUNNEL_ATTR_ENCAP_QOS_TC_TO_QUEUE_MAP,
+
+    /**
+     * @brief Enable DSCP -> TC MAP on tunnel at termination (Network-to-access) node. This map if configured overrides the port MAP
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_TC_MAP,
+
+    /**
+     * @brief Enable TC -> Priority Group MAP. TC is derived from the tunnel MAP
+     *
+     * Map id = #SAI_NULL_OBJECT_ID to disable map on port.
+     * Default no map
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_TUNNEL_ATTR_DECAP_QOS_TC_TO_PRIORITY_GROUP_MAP,
+
+    /**
      * @brief End of attributes
      */
     SAI_TUNNEL_ATTR_END,
@@ -1037,6 +1149,8 @@ typedef struct _sai_tunnel_api_t
     sai_remove_tunnel_map_entry_fn               remove_tunnel_map_entry;
     sai_set_tunnel_map_entry_attribute_fn        set_tunnel_map_entry_attribute;
     sai_get_tunnel_map_entry_attribute_fn        get_tunnel_map_entry_attribute;
+    sai_bulk_object_get_attribute_fn             get_tunnels_attribute;
+    sai_bulk_object_set_attribute_fn             set_tunnels_attribute;
 
 } sai_tunnel_api_t;
 

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -723,6 +723,7 @@ typedef struct _sai_acl_capability_t
      * @passparam &sai_metadata_enum_sai_acl_action_type_t
      */
     sai_s32_list_t action_list;
+
 } sai_acl_capability_t;
 
 /**


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

This PR is a cherry-pick of PR https://github.com/opencomputeproject/SAI/pull/1413, and resolve cherry-pick conflicts as well.

This PR add following behavior to tunnel encap and decap

**Tunnel Encap:**

 - `SAI_TUNNEL_ATTR_ENCAP_QOS_TC_AND_COLOR_TO_DSCP_MAP` for remarking the packet based on normalized TC as per port TC MAP binding
 - `SAI_TUNNEL_ATTR_ENCAP_QOS_TC_TO_QUEUE_MAP `for queue selection based on normalized TC as per port TC MAP binding

**Tunnel Decap:**

 - `SAI_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_TC_MAP` new TC MAP can be bind'ed to the tunnel for decap. This MAP overrides port MAP if configured.
 - `SAI_TUNNEL_ATTR_DECAP_QOS_TC_TO_PRIORITY_GROUP_MAP` for mapping the normalized TC to priority group mainly for PFC generation.
DSCP mode takes effect as configured for both cases.