### PR TITLE
[SAI-PTF]Align the sai rpc front name with swss and syncd

### DIFF
--- a/meta/gensairpc.pl
+++ b/meta/gensairpc.pl
@@ -281,7 +281,7 @@ sub generate_server_template_from_skeleton {
 
                 # Define global variable before "class"
                 print {$server_template}
-"\nextern sai_object_id_t switch_id;\nsai_object_id_t switch_id;\n\n\n";
+"\nextern sai_object_id_t switch_id;\nsai_object_id_t switch_id;\nextern sai_object_id_t gSwitchId;\n\n\n";
 
                 # Define helper functions
                 print {$server_template} "[% PROCESS helper_functions %]\n\n\n";

--- a/meta/sai_rpc_frontend.cpp
+++ b/meta/sai_rpc_frontend.cpp
@@ -892,7 +892,7 @@ static void *cookie;
 /**
  * @brief Create a Thrift RPC server thread
  */
-static void *sai_thrift_rpc_server_thread(void *arg) {
+static void *switch_sai_thrift_rpc_server_thread(void *arg) {
   int port = *(int *)arg;
   std::shared_ptr<sai_rpcHandlerFrontend> handler(new sai_rpcHandlerFrontend());
   std::shared_ptr<TProcessor> processor(new sai_rpcProcessor(handler));
@@ -926,7 +926,7 @@ int start_p4_sai_thrift_rpc_server(char *port) {
 
   cookie = NULL;
   int status = pthread_create(
-      &sai_thrift_rpc_thread, NULL, sai_thrift_rpc_server_thread, param);
+      &sai_thrift_rpc_thread, NULL, switch_sai_thrift_rpc_server_thread, param);
   if (status) return status;
   pthread_mutex_lock(&cookie_mutex);
   while (!cookie) {
@@ -936,6 +936,13 @@ int start_p4_sai_thrift_rpc_server(char *port) {
   pthread_mutex_destroy(&cookie_mutex);
   pthread_cond_destroy(&cookie_cv);
   return status;
+}
+
+int start_sai_thrift_rpc_server(int port)
+{
+    static char port_str[10];
+    snprintf(port_str, sizeof(port_str), "%d", port);
+    return start_p4_sai_thrift_rpc_server(port_str);
 }
 
 /**

--- a/meta/templates/sai_rpc_server_functions.tt
+++ b/meta/templates/sai_rpc_server_functions.tt
@@ -54,6 +54,12 @@
     if (switch_id != NULL) {
         return switch_id;
     }
+
+    //check if the switch created in syncd
+    if (gSwitchId != NULL) {
+      switch_id = gSwitchId;
+      return switch_id;
+    }
    
 [%- END -%]
 

--- a/test/saithriftv2/src/saiserver.cpp
+++ b/test/saithriftv2/src/saiserver.cpp
@@ -266,13 +266,6 @@ void handleInitScript(const std::string& initScript)
     system(initScript.c_str());
 }
 
-int start_sai_thrift_rpc_server(int port)
-{
-    static char port_str[10];
-    snprintf(port_str, sizeof(port_str), "%d", port);
-    return start_p4_sai_thrift_rpc_server(port_str);
-}
-
 int
 main(int argc, char* argv[])
 {

--- a/test/saithriftv2/src/switch_sai_rpc_server.h
+++ b/test/saithriftv2/src/switch_sai_rpc_server.h
@@ -1,3 +1,4 @@
 extern "C" {
 int start_p4_sai_thrift_rpc_server(char *port);
+int start_sai_thrift_rpc_server(int port);
 }


### PR DESCRIPTION
In order to make the comparison with SONiC default config environment, we need to init the saiserver within a complete sonic environment.
In order to do that, we need to
- Combine new saiserver with syncd
- saiserver can be initalized by syncd
- SAI-PTF can operate on the saiserver instance from syncd

In order to make the new saiserver integrate with syncd use the existing variable gSwitchId.

Test done:
Test the syncd-rpc container within DUT.

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>