### PR TITLE
[v1.10] Backport Allow builds with multiple python3 versions (#1441)

### DIFF
--- a/debian/installerFiles/python-saithriftv2.install
+++ b/debian/installerFiles/python-saithriftv2.install
@@ -1,1 +1,1 @@
-debian/usr/local/lib/python3.7/site-packages/* /usr/lib/python3.7/dist-packages/
+debian/usr/local/lib/python3*/site-packages/* /usr/lib/python3/dist-packages/


### PR DESCRIPTION
Currently Python 3.7 is hardcoded into the debian build system here. These code changes allow other versions of python.

This was tested on Python 3.9 on Debian 11.

Signed-off-by: Alexander Allen <arallen@nvidia.com>