### PR TITLE
[v1.10] [meta] Backport Disable doxygen TCL_SUBST and COLS_IN_ALPHA_INDEX (#1457)

### DIFF
--- a/meta/Doxyfile
+++ b/meta/Doxyfile
@@ -240,7 +240,7 @@ ALIASES                += "deprecated     =@par Deprecated:^^             @xmlon
 # A mapping has the form "name=value". For example adding "class=itcl::class"
 # will allow you to use the command class in the itcl::class meaning.
 
-TCL_SUBST              =
+#TCL_SUBST              =
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -995,7 +995,7 @@ ALPHABETICAL_INDEX     = YES
 # Minimum value: 1, maximum value: 20, default value: 5.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
 
-COLS_IN_ALPHA_INDEX    = 5
+#COLS_IN_ALPHA_INDEX    = 5
 
 # In case all classes in a project start with a common prefix, all classes will
 # be put under the same header in the alphabetical index. The IGNORE_PREFIX tag

--- a/meta/Doxyfile.compat
+++ b/meta/Doxyfile.compat
@@ -240,7 +240,7 @@ ALIASES                += "deprecated     =@par Deprecated:\n             @xmlon
 # A mapping has the form "name=value". For example adding "class=itcl::class"
 # will allow you to use the command class in the itcl::class meaning.
 
-TCL_SUBST              =
+#TCL_SUBST              =
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -995,7 +995,7 @@ ALPHABETICAL_INDEX     = YES
 # Minimum value: 1, maximum value: 20, default value: 5.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
 
-COLS_IN_ALPHA_INDEX    = 5
+#COLS_IN_ALPHA_INDEX    = 5
 
 # In case all classes in a project start with a common prefix, all classes will
 # be put under the same header in the alphabetical index. The IGNORE_PREFIX tag


### PR DESCRIPTION
Those features are no longer present on new doxygen versions and are not used by metadata parser

Signed-off-by: Alexander Allen <arallen@nvidia.com>