### PR TITLE
Added port SerDes equalization attributes

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -751,6 +751,30 @@ typedef enum _sai_port_attr_t
      */
     SAI_PORT_ATTR_OPER_SPEED,
 
+    /**
+     * @brief List of port's CTLE values
+     *
+     * @type sai_port_ctle_values_list_t
+     * @flags READ_ONLY
+     */
+    SAI_PORT_ATTR_CTLE_VALUES,
+
+    /**
+     * @brief List of port's FFE values
+     *
+     * @type sai_port_ffe_values_list_t
+     * @flags READ_ONLY
+     */
+    SAI_PORT_ATTR_FFE_VALUES,
+
+    /**
+     * @brief Port's DFE value
+     *
+     * @type sai_port_dfe_values_list_t
+     * @flags READ_ONLY
+     */
+    SAI_PORT_ATTR_DFE_VALUES,
+
     /* READ-WRITE */
 
     /**

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1308,6 +1308,15 @@ typedef union _sai_attribute_value_t
 
     /** @validonly meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_PORT_ERR_STATUS_LIST */
     sai_port_err_status_list_t porterror;
+
+    /** @validonly meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_PORT_CTLE_VALUES_LIST */
+    sai_port_ctle_values_list_t portctlevalues;
+
+    /** @validonly meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_PORT_FFE_VALUES_LIST */
+    sai_port_ffe_values_list_t portffevalues;
+
+    /** @validonly meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_PORT_DFE_VALUES_LIST */
+    sai_port_dfe_values_list_t portdfevalues;
 } sai_attribute_value_t;
 
 /**
@@ -1485,6 +1494,128 @@ typedef struct _sai_stat_capability_list_t
     sai_stat_capability_t *list;
 
 } sai_stat_capability_list_t;
+
+/**
+ * @brief Defines a lane with its list of CTLE values.
+ *
+ * Caller must allocate the buffer for the list member and set the count
+ * member to the size of the allocated objects in the list member.
+ *
+ * If the size is large enough to accommodate the list of objects, the
+ * callee must fill the list member and set the count member to the actual
+ * number of objects filled. If the size is not large enough, the callee
+ * must set the count member to the actual number of objects filled in the
+ * list member and return #SAI_STATUS_BUFFER_OVERFLOW. Once the caller
+ * gets such a return code, it may use the returned count member to
+ * re-allocate the list and retry.
+ */
+typedef struct _sai_port_lane_ctle_values_t
+{
+    uint32_t lane;
+    sai_u32_list_t *ctle;
+
+} sai_port_lane_ctle_values_t;
+
+/**
+ * @brief Defines a port's lanes CTLE values list
+ *
+ * In get_port_attribute function call, the count member defines the number
+ * of objects which will be returned to the caller in the list member. The
+ * caller must allocate the buffer for the list member and set the count
+ * member to the size of the allocated objects in the list member.
+ *
+ * If the size is large enough to accommodate the list of objects, the
+ * callee must fill the list member and set the count member to the actual
+ * number of objects filled. If the size is not large enough, the callee
+ * must set the count member to the actual number of objects filled in the
+ * list member and return #SAI_STATUS_BUFFER_OVERFLOW. Once the caller
+ * gets such a return code, it may use the returned count member to
+ * re-allocate the list and retry.
+ */
+typedef struct _sai_port_ctle_values_list_t
+{
+    uint32_t count;
+    sai_port_lane_ctle_values_t *list;
+
+} sai_port_ctle_values_list_t;
+
+/**
+ * @brief Defines a lane with its list of FFE values.
+ *
+ * Caller must allocate the buffer for the list member and set the count
+ * member to the size of the allocated objects in the list member.
+ *
+ * If the size is large enough to accommodate the list of objects, the
+ * callee must fill the list member and set the count member to the actual
+ * number of objects filled. If the size is not large enough, the callee
+ * must set the count member to the actual number of objects filled in the
+ * list member and return #SAI_STATUS_BUFFER_OVERFLOW. Once the caller
+ * gets such a return code, it may use the returned count member to
+ * re-allocate the list and retry.
+ */
+typedef struct _sai_port_lane_ffe_values_t
+{
+    uint32_t lane;
+    sai_s32_list_t *ffe;
+
+} sai_port_lane_ffe_values_t;
+
+/**
+ * @brief Defines a port's lanes FFE values list
+ *
+ * In get_port_attribute function call, the count member defines the number
+ * of objects which will be returned to the caller in the list member. The
+ * caller must allocate the buffer for the list member and set the count
+ * member to the size of the allocated objects in the list member.
+ *
+ * If the size is large enough to accommodate the list of objects, the
+ * callee must fill the list member and set the count member to the actual
+ * number of objects filled. If the size is not large enough, the callee
+ * must set the count member to the actual number of objects filled in the
+ * list member and return #SAI_STATUS_BUFFER_OVERFLOW. Once the caller
+ * gets such a return code, it may use the returned count member to
+ * re-allocate the list and retry.
+ */
+typedef struct _sai_port_ffe_values_list_t
+{
+    uint32_t count;
+    sai_port_lane_ffe_values_t *list;
+
+} sai_port_ffe_values_list_t;
+
+/**
+ * @brief Defines a lane with the DFE value.
+ */
+typedef struct _sai_port_lane_dfe_value_t
+{
+    uint32_t lane;
+    int32_t dfe;
+
+} sai_port_lane_dfe_value_t;
+
+/**
+ * @brief Defines a port's DFE values list
+ *
+ * In get_port_attribute function call, the count member defines the number
+ * of objects which will be returned to the caller in the list member. The
+ * caller must allocate the buffer for the list member and set the count
+ * member to the size of the allocated objects in the list member.
+ *
+ * If the size is large enough to accommodate the list of objects, the
+ * callee must fill the list member and set the count member to the actual
+ * number of objects filled. If the size is not large enough, the callee
+ * must set the count member to the actual number of objects filled in the
+ * list member and return #SAI_STATUS_BUFFER_OVERFLOW. Once the caller
+ * gets such a return code, it may use the returned count member to
+ * re-allocate the list and retry.
+ */
+typedef struct _sai_port_dfe_values_list_t
+{
+    uint32_t count;
+    sai_port_lane_dfe_value_t *list;
+
+} sai_port_dfe_values_list_t;
+
 
 /**
  * @}

--- a/meta/acronyms.txt
+++ b/meta/acronyms.txt
@@ -21,6 +21,8 @@ CIR - Committed Information Rate
 CPLD - Complex programmable logic device
 CPU - Central Processing Unit
 CRC - Cyclic Redundancy Code
+CTLE - Continuous Time Linear Equalization
+DFE - Decision Feedback Equalization
 DHCP - Dynamic Host Configuration Protocol
 DHCPV6 - Dynamic Host Configuration Protocol for IPv6
 DLD - Dead Lock Detection
@@ -44,6 +46,7 @@ FCS - Frame Check Sequence
 FD - File Descriptor
 FDB - Forwarding Data Base
 FEC - Forward Error Correction
+FFE - Feed Forward Equalization
 FPGA - Field Programmable Gate Array
 FW  - Firmware
 GCM - Galois Counter Mode

--- a/meta/sai_rpc_frontend.cpp
+++ b/meta/sai_rpc_frontend.cpp
@@ -490,6 +490,9 @@ void convert_attr_thrift_to_sai(const sai_object_type_t sai_ot,
     case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
     case SAI_ATTR_VALUE_TYPE_TIMESPEC:
     case SAI_ATTR_VALUE_TYPE_NAT_ENTRY_DATA:
+    case SAI_ATTR_VALUE_TYPE_PORT_CTLE_VALUES_LIST:
+    case SAI_ATTR_VALUE_TYPE_PORT_FFE_VALUES_LIST:
+    case SAI_ATTR_VALUE_TYPE_PORT_DFE_VALUES_LIST:
       // not supported
       break;
     default:
@@ -781,6 +784,9 @@ void convert_attr_sai_to_thrift(const sai_object_type_t sai_ot,
     case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
     case SAI_ATTR_VALUE_TYPE_TIMESPEC:
     case SAI_ATTR_VALUE_TYPE_NAT_ENTRY_DATA:
+    case SAI_ATTR_VALUE_TYPE_PORT_CTLE_VALUES_LIST:
+    case SAI_ATTR_VALUE_TYPE_PORT_FFE_VALUES_LIST:
+    case SAI_ATTR_VALUE_TYPE_PORT_DFE_VALUES_LIST:
       // not supported
       break;
     default:

--- a/meta/saimetadatatypes.h
+++ b/meta/saimetadatatypes.h
@@ -451,6 +451,21 @@ typedef enum _sai_attr_value_type_t
      */
     SAI_ATTR_VALUE_TYPE_AUTH_KEY,
 
+    /**
+     * @brief Attribute value is port CTLE values list.
+     */
+    SAI_ATTR_VALUE_TYPE_PORT_CTLE_VALUES_LIST,
+
+    /**
+     * @brief Attribute value is port FFE values list.
+     */
+    SAI_ATTR_VALUE_TYPE_PORT_FFE_VALUES_LIST,
+
+    /**
+     * @brief Attribute value is port DFE values list.
+     */
+    SAI_ATTR_VALUE_TYPE_PORT_DFE_VALUES_LIST,
+
 } sai_attr_value_type_t;
 
 /**

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -667,6 +667,9 @@ void check_attr_object_type_provided(
         case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
         case SAI_ATTR_VALUE_TYPE_TIMESPEC:
+        case SAI_ATTR_VALUE_TYPE_PORT_CTLE_VALUES_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_FFE_VALUES_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_DFE_VALUES_LIST:
 
         case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_BOOL:
         case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8:
@@ -965,6 +968,9 @@ void check_attr_default_required(
         case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
         case SAI_ATTR_VALUE_TYPE_SYSTEM_PORT_CONFIG_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_CTLE_VALUES_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_FFE_VALUES_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_DFE_VALUES_LIST:
 
             if (((md->objecttype == SAI_OBJECT_TYPE_PORT) || (md->objecttype == SAI_OBJECT_TYPE_PORT_SERDES))
                  && md->defaultvaluetype == SAI_DEFAULT_VALUE_TYPE_SWITCH_INTERNAL)
@@ -1168,6 +1174,9 @@ void check_attr_default_value_type(
                 case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST:
                 case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
                 case SAI_ATTR_VALUE_TYPE_SYSTEM_PORT_CONFIG_LIST:
+                case SAI_ATTR_VALUE_TYPE_PORT_CTLE_VALUES_LIST:
+                case SAI_ATTR_VALUE_TYPE_PORT_FFE_VALUES_LIST:
+                case SAI_ATTR_VALUE_TYPE_PORT_DFE_VALUES_LIST:
                     break;
 
                 default:
@@ -1769,6 +1778,9 @@ void check_attr_allow_flags(
             case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
             case SAI_ATTR_VALUE_TYPE_SYSTEM_PORT_CONFIG_LIST:
             case SAI_ATTR_VALUE_TYPE_PORT_ERR_STATUS_LIST:
+            case SAI_ATTR_VALUE_TYPE_PORT_CTLE_VALUES_LIST:
+            case SAI_ATTR_VALUE_TYPE_PORT_FFE_VALUES_LIST:
+            case SAI_ATTR_VALUE_TYPE_PORT_DFE_VALUES_LIST:
                 break;
 
             default:
@@ -2610,6 +2622,9 @@ void check_attr_is_primitive(
         case SAI_ATTR_VALUE_TYPE_SYSTEM_PORT_CONFIG_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_ERR_STATUS_LIST:
         case SAI_ATTR_VALUE_TYPE_UINT16_RANGE_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_CTLE_VALUES_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_FFE_VALUES_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_DFE_VALUES_LIST:
 
             if (md->isprimitive)
             {


### PR DESCRIPTION
objectives:
This request adds the set of the port attributes as: 
SAI_PORT_ATTR_CTLE_VALUES,
SAI_PORT_ATTR_FFE_VALUES,
SAI_PORT_ATTR_DFE_VALUES. 
The purpose of these attributes is allowing to get more detailed information about SerDes equalization.
All these attributes are READ_ONLY and return the per lane values. 

Signed-off-by: Oleksandr Rusanov <oleksandr.rusanov@plvision.eu>