### PR TITLE
[SAI-PTF] Add SAI ptf test structure for T0 test

### DIFF
--- a/test/sai_test/config/__init__.py
+++ b/test/sai_test/config/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+
+
+"""
+Init the config module.
+
+config module contains classes to make the configurations.
+"""

--- a/test/sai_test/config/fdb_configer.py
+++ b/test/sai_test/config/fdb_configer.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+#
+
+from sai_utils import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from sai_thrift.sai_adapter import *
+
+
+def t0_fdb_config_helper(test_obj):
+    """
+    Make t0 FDB configurations base on the configuration in the test plan.
+    Set the configuration in test directly.
+
+    Set the following test_obj attributes:
+        list: local_server_mac_list
+
+    """
+    configer = FdbConfiger(test_obj)
+    local_server_mac_list = []
+    mac_list_temp = []
+
+    mac_list_temp = configer.generate_mac_address_list(FDB_SERVER_NUM, 0, range(0, 1))
+    local_server_mac_list.extend(mac_list_temp)
+    mac_list_temp = configer.generate_mac_address_list(FDB_SERVER_NUM, 1, range(1,9))
+    local_server_mac_list.extend(mac_list_temp)
+    mac_list_temp = configer.generate_mac_address_list(FDB_SERVER_NUM, 2, range(9,17))
+    local_server_mac_list.extend(mac_list_temp)
+    configer.create_fdb_entries(
+        switch_id=test_obj.switch_id, 
+        mac_list=local_server_mac_list,
+        port_oids=test_obj.bridge_port_list[0:len(local_server_mac_list)], 
+        vlan_oid=test_obj.default_vlan_id)
+    test_obj.local_server_mac_list = local_server_mac_list
+
+class FdbConfiger(object):
+    """
+    Class use to make all the fdb configurations.
+    """
+
+    def __init__(self, test_obj) -> None:
+        """
+        Init the Port configer.
+
+        Args:
+            test_obj: the test object
+        """
+        self.test_obj = test_obj
+        self.client = test_obj.client
+
+    def create_fdb_entries(self, 
+                           switch_id, 
+                           mac_list, 
+                           port_oids, 
+                           type=SAI_FDB_ENTRY_TYPE_STATIC, 
+                           vlan_oid=None, 
+                           packet_action=SAI_PACKET_ACTION_FORWARD):
+        """
+        Create FDB entries.
+
+        Args:
+            switch_id: switch id
+            mac_list: mac list
+            port_oids: port oids
+            type: SAI_FDB_ENTRY_ATTR_TYPE
+            vlan_oid: vlan id for the mac
+            packet_action:SAI_FDB_ENTRY_ATTR_PACKET_ACTION
+
+        """
+        print("Add FDBs ...")
+        for index, mac in enumerate(mac_list):
+            fdb_entry = sai_thrift_fdb_entry_t(
+                switch_id=switch_id,
+                mac_address=mac,
+                bv_id=vlan_oid)
+            sai_thrift_create_fdb_entry(
+                self.client,
+                fdb_entry,
+                type=type,
+                bridge_port_id=port_oids[index],
+                packet_action=packet_action)
+
+    def generate_mac_address_list(self, role, group, indexes):
+        """
+        Generate mac addresses.
+
+        Args:
+            role: Role which is represented by the mac address(base on test plan config)
+            group: group number for the mac address(base on test plan config)
+            indexes: mac indexes
+
+        Returns:
+            default_1q_bridge_id
+        """
+        print("Generate MAC ...")
+        mac_list = []
+        for index in indexes:
+            mac = FDB_MAC_PREFIX + ':' + role + ':' + \
+                '{:02d}'.format(group) + ':' + '{:02d}'.format(index)
+            mac_list.append(mac)
+        return mac_list

--- a/test/sai_test/config/port_configer.py
+++ b/test/sai_test/config/port_configer.py
@@ -1,0 +1,422 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+#
+
+from collections import OrderedDict
+from ptf import config
+from sai_utils import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from sai_thrift.sai_adapter import *
+from config.vlan_configer import VlanConfiger
+
+
+def t0_port_config_helper(test_obj, is_remove_vlan=True, is_remove_bridge=True):
+    """
+    Make t0 Port configurations base on the configuration in the test plan.
+    Set the configuration in test directly.
+
+    Set the following test_obj attributes:
+        list: dev_port_list
+        dict: portConfigs - index:PortConfig
+        int: default_trap_group
+        list: bridge_port_list
+        list: port_list
+        dict: port_to_hostif_map - port_oid:hostIf_oid
+        int: default_1q_bridge_id
+        int: default_vlan_id
+        int: host_intf_table_id
+        list: hostif_list
+
+    """
+    configer = PortConfiger(test_obj)
+    vlan_configer = VlanConfiger(test_obj)
+
+    dev_port_list = configer.get_local_mapped_ports()
+    portConfigs = configer.parse_port_config(test_obj.test_params['port_config_ini'])
+    
+
+    attr = sai_thrift_get_switch_attribute(configer.client, default_trap_group=True)
+    default_trap_group = attr['default_trap_group']
+
+    port_list = configer.get_port_list()
+    configer.turn_up_and_check_ports(port_list)
+    default_1q_bridge_id = configer.get_default_1q_bridge()
+    bridge_port_list = configer.get_bridge_port_list(default_1q_bridge_id)
+    default_vlan_id = configer.get_default_vlan()
+    if is_remove_vlan:
+        members = vlan_configer.get_vlan_member(default_vlan_id)
+        vlan_configer.remove_vlan_members(members)
+    if is_remove_bridge:
+        configer.remove_bridge_port(default_1q_bridge_id)
+        bridge_port_list = configer.create_bridge_ports(default_1q_bridge_id, port_list)
+    host_intf_table_id, hostif_list = configer.create_host_intf(
+        ports_config=portConfigs, trap_group=default_trap_group, port_list=port_list)
+    port_to_hostif_map = configer.generate_port_to_hostif_map(
+        port_list, hostif_list)
+    configer.turn_on_port_admin_state(port_list)
+
+    test_obj.dev_port_list = dev_port_list
+    test_obj.portConfigs = portConfigs
+    test_obj.default_trap_group = default_trap_group
+    test_obj.port_list = port_list
+    test_obj.port_to_hostif_map = port_to_hostif_map
+    test_obj.default_1q_bridge_id = default_1q_bridge_id
+    test_obj.bridge_port_list = bridge_port_list
+    test_obj.default_vlan_id = default_vlan_id
+    test_obj.host_intf_table_id = host_intf_table_id
+    test_obj.hostif_list = hostif_list
+
+
+class PortConfiger(object):
+    """
+    Class use to make all the basic configurations.
+    """
+
+    def __init__(self, test_obj) -> None:
+        """
+        Init the Port configer.
+
+        Args:
+            test_obj: the test object
+        """
+        self.test_obj = test_obj
+        self.client = test_obj.client
+
+    def create_bridge_ports(self, bridge_id, port_list):
+        """
+        Create bridge ports base on port_list.
+
+        Args:
+            bridge_id: bridge object id
+            port_list: port list oid
+        
+        Returns:
+            list: bridge port list
+        """
+        print("Create bridge ports...")
+        bp_list=[]
+        for index in range(0, len(port_list)):
+            port_bp = sai_thrift_create_bridge_port(
+                self.client,
+                bridge_id=bridge_id,
+                port_id=port_list[index],
+                type=SAI_BRIDGE_PORT_TYPE_PORT,
+                admin_state=True)
+            bp_list.append(port_bp)
+        return bp_list
+
+    def create_host_intf(self, ports_config, port_list, trap_group=None):
+        """
+        Create host interface.
+
+        Steps:
+         1. create host table entry
+         2. create host interface trap
+         3. set host interface base on the port_config.int (this file contains the lanes, name and index information.)
+
+        Args:
+            ports_config: port configs, which is got from the local config.
+            trap_group: host interface trap group(optional)
+            port_list: port list 
+
+        Returns:
+            host_intf_table_id
+            hostif_list
+        """
+        print("Create Host intfs...")
+        host_intf_table_id = sai_thrift_create_hostif_table_entry(
+            self.client, type=SAI_HOSTIF_TABLE_ENTRY_TYPE_WILDCARD,
+            channel_type=SAI_HOSTIF_TABLE_ENTRY_CHANNEL_TYPE_NETDEV_PHYSICAL_PORT)
+        sai_thrift_create_hostif_trap(
+            self.client, trap_type=SAI_HOSTIF_TRAP_TYPE_TTL_ERROR, packet_action=SAI_PACKET_ACTION_TRAP,
+            trap_group=trap_group, trap_priority=0)
+
+        hostif_list = []
+        for i, _ in enumerate(port_list):
+            try:
+                hostif = sai_thrift_create_hostif(
+                    self.client,
+                    type=SAI_HOSTIF_TYPE_NETDEV,
+                    obj_id=port_list[i],
+                    name=ports_config[i].name)
+                sai_thrift_set_hostif_attribute(
+                    self.client, hostif_oid=hostif, oper_status=False)
+                hostif_list.append(hostif)
+            except BaseException as e:
+                print("Cannot create hostif, error : {}".format(e))
+        return host_intf_table_id, hostif_list
+
+    def generate_port_to_hostif_map(self, port_list, hostif_list):
+        """
+        Generate the port to hostif map, base on the port list sequence
+
+        Args:
+            port_list: port obj id list
+            hostif_list: host interface obj list
+
+        Returns:
+            dict: port_to_hostif_map - port_oid:hostif_oid
+        """
+        port_to_hostif_map = {}
+        for i, port in enumerate(port_list):
+            port_to_hostif_map[port] = hostif_list[i]
+        return port_to_hostif_map
+
+    def get_bridge_port_all_attribute(self, bridge_port_id):
+        '''
+        Gets all the attrbute from bridge port.
+
+        Args:
+            bridge_port_id: bridge port object id
+        
+        Returns:
+            dict: bridge attributes
+
+        '''
+
+        #Cannot get those three attributes from sai_thrift_get_bridge_port_attribute
+        #ingress_filtering=True,
+        #egress_filtering=True,
+        #isolation_group=True
+        sai_thrift_get_bridge_port_attribute(self.client,  bridge_port_oid=bridge_port_id, ingress_filtering=True,  egress_filtering=True)
+        attr = sai_thrift_get_bridge_port_attribute(
+            self.client, 
+            bridge_port_oid=bridge_port_id,
+            type=True,
+            port_id=True,
+            tagging_mode=True,
+            vlan_id=True,
+            rif_id=True,
+            tunnel_id=True,
+            bridge_id=True,
+            fdb_learning_mode=True,
+            max_learned_addresses=True,
+            fdb_learning_limit_violation_packet_action=True,
+            admin_state=True
+            #Cannot get those three
+            #ingress_filtering=True,
+            #egress_filtering=True,
+            #isolation_group=True
+            )
+        self.test_obj.assertEqual(self.test_obj.status(), SAI_STATUS_SUCCESS)
+        return attr
+
+    def get_bridge_port_list(self, bridge_id):
+        """
+        Get bridge ports.
+        
+        Args:
+            bridge_id: bridge id.
+        
+        Returns:
+            list: bridge_port_list
+
+        """
+        print("Get bridge ports...")
+        bridge_port_list = sai_thrift_object_list_t(count=100)
+        bp_list = sai_thrift_get_bridge_attribute(
+            self.client, bridge_id, port_list=bridge_port_list)
+        return bp_list['port_list'].idlist
+
+    def get_default_1q_bridge(self):
+        """
+        Get defaule 1Q bridge.
+
+        Returns:
+            default_1q_bridge_id
+        """
+        print("Get default 1Q bridge...")
+        def_attr = sai_thrift_get_switch_attribute(
+            self.client, default_1q_bridge_id=True)
+        return def_attr['default_1q_bridge_id']
+
+    def get_default_vlan(self):
+        """
+        Get defaule vlan.
+
+        Returns:
+            default_vlan_id
+        """
+        print("Get default vlan...")
+        def_attr = sai_thrift_get_switch_attribute(
+            self.client, default_vlan_id=True)
+        return def_attr['default_vlan_id']
+
+    def get_local_mapped_ports(self):
+        """
+        Get device port numbers from ptf config.
+        Those port number should map to the remote DUT port base on the configuration file.
+
+        Returns:
+            list: port numbers
+        """
+        dev_port_list = []
+        for _, port, _ in config['interfaces']:
+            dev_port_list.append(port)
+        return dev_port_list
+
+    def get_port_list(self):
+        """
+        Set the class variable port_list.
+
+        Returns:
+            port_list
+        """
+        port_list = sai_thrift_object_list_t(count=100)
+        p_list = sai_thrift_get_switch_attribute(
+            self.client, port_list=port_list)
+        return p_list['port_list'].idlist
+
+    def parse_port_config(self, port_config_file):
+        """
+        Parse port_config.ini file
+
+        Example of supported format for port_config.ini:
+        # name        lanes       alias       index    speed    autoneg   fec
+        Ethernet0       0         Ethernet0     1      25000      off     none
+        Ethernet1       1         Ethernet1     1      25000      off     none
+        Ethernet2       2         Ethernet2     1      25000      off     none
+        Ethernet3       3         Ethernet3     1      25000      off     none
+        Ethernet4       4         Ethernet4     2      25000      off     none
+        Ethernet5       5         Ethernet5     2      25000      off     none
+        Ethernet6       6         Ethernet6     2      25000      off     none
+        Ethernet7       7         Ethernet7     2      25000      off     none
+        Ethernet8       8         Ethernet8     3      25000      off     none
+        Ethernet9       9         Ethernet9     3      25000      off     none
+        Ethernet10      10        Ethernet10    3      25000      off     none
+        Ethernet11      11        Ethernet11    3      25000      off     none
+        etc
+
+        Args:
+            port_config_file (string): path to port config file
+
+        Returns:
+            dict: port configuation from file
+
+        Raises:
+            e: exit if file not found
+        """
+        portConfigs = OrderedDict()
+        try:
+            index = 0
+            with open(port_config_file) as conf:
+                for line in conf:
+                    if line.startswith('#'):
+                        if "name" in line:
+                            titles = line.strip('#').split()
+                        continue
+                    tokens = line.split()
+                    if len(tokens) < 2:
+                        continue
+
+                    name_index = titles.index('name')
+                    name = tokens[name_index]
+                    data = {}
+                    portConfig = PortConfig()
+                    for i, item in enumerate(tokens):
+                        if i == name_index:
+                            continue
+                        data[titles[i]] = item
+                    portConfig.lanes = [int(lane)
+                                        for lane in data['lanes'].split(',')]
+                    portConfig.speed = int(data['speed'])
+                    portConfig.name = name
+                    portConfigs[index] = portConfig
+                    index = index + 1
+            return portConfigs
+        except Exception as e:
+            raise e
+
+    def remove_bridge_port(self, bridge_id):
+        """
+        Remove bridge ports (bridge will not be removed).
+        
+        Args:
+            bridge_id: bridge id.
+
+        """
+        print("Remove bridge ports...")
+        bridge_port_list = sai_thrift_object_list_t(count=100)
+        bp_list = sai_thrift_get_bridge_attribute(
+            self.client, bridge_id, port_list=bridge_port_list)
+        bp_ports = bp_list['port_list'].idlist
+        for port in bp_ports:
+            sai_thrift_remove_bridge_port(self.client, port)
+        self.test_obj.assertEqual(self.test_obj.status(), SAI_STATUS_SUCCESS)
+
+    def turn_on_port_admin_state(self, port_list):
+        """
+        Turn on port admin state
+
+        Args:
+            post_list: post list
+        """
+        print("Set port...")
+        for i, port in enumerate(port_list):
+            sai_thrift_set_port_attribute(
+                self.client, port_oid=port, mtu=PORT_MTU, admin_state=True)
+
+    def turn_up_and_check_ports(self, port_list):
+        '''
+        Method to turn up the ports.
+        In case some device not init the port after start the switch.
+
+        Args:
+            port_list - list of all active port objects
+        '''
+
+        # For brcm devices, need to init and setup the ports at once after start the switch.
+        retries = 10
+        for port_id in port_list:
+            try:
+                sai_thrift_set_port_attribute(
+                    self.client, port_oid=port_id, admin_state=True)
+            except BaseException as e:
+                print("Cannot setup port admin state, error {}".format(e))
+
+        for num_of_tries in range(retries):
+            all_ports_are_up = True
+            time.sleep(1)
+            for port_id in port_list:
+                port_attr = sai_thrift_get_port_attribute(
+                    self.client, port_id, oper_status=True)
+                if port_attr['oper_status'] != SAI_PORT_OPER_STATUS_UP:
+                    all_ports_are_up = False
+                    time.sleep(1)
+                    print("port is down: {}".format(port_attr['oper_status']))
+            if all_ports_are_up:
+                print("Retry {} times turn up port.".format(num_of_tries))
+                break
+        if not all_ports_are_up:
+            print("Not all the ports are up after {} rounds of retries.".format(retries))
+
+
+class PortConfig(object):
+    """
+    Represent the PortConfig Object
+
+    Attrs:
+        vlan_id: vlan id
+        vlan_oid: vlan ojbect id
+        vlan_moids: vlan member object ids
+    """
+
+    def __init__(self, name=None, lanes=None, speed=None):
+        self.name = name
+        self.lanes = lanes
+        self.speed = speed

--- a/test/sai_test/config/switch_configer.py
+++ b/test/sai_test/config/switch_configer.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+
+
+from sai_thrift.sai_adapter import *
+from sai_utils import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+
+
+def t0_switch_config_helper(test_obj):
+    """
+    Make t0 switch configurations base on the configuration in the test plan.
+    Set the configuration in test directly.
+
+    Set the following test_obj attributes:
+        int: switch_id
+
+    """
+    configer = SwitchConfiger(test_obj)
+    test_obj.switch_id = configer.start_switch()
+
+
+class SwitchConfiger(object):
+    """
+    Class use to make all the Switch configurations.
+    """
+
+    def __init__(self, test_obj) -> None:
+        """
+        Init the Switch configer.
+
+        Args:
+            test_obj: the test object
+        """
+
+        self.test_obj = test_obj
+        self.client = test_obj.client
+
+    def start_switch(self, switch_init_wait=1, route_mac=ROUTER_MAC):
+        """
+        Start switch and wait seconds for a warm up.
+
+        Args:
+            switch_init_wait: switch init wait time (sec)
+            route_mac: route mac (switch mac)
+
+        Returns:
+            Vlan: vlan object
+        """
+        switch_id = sai_thrift_create_switch(
+            self.test_obj.client, init_switch=True, src_mac_address=route_mac)
+        self.test_obj.assertEqual(self.test_obj.status(), SAI_STATUS_SUCCESS)
+
+        print("Waiting for switch to get ready, {} seconds ...".format(
+            switch_init_wait))
+        time.sleep(switch_init_wait)
+        return switch_id

--- a/test/sai_test/config/vlan_configer.py
+++ b/test/sai_test/config/vlan_configer.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+#
+
+from sai_thrift.sai_adapter import *
+from sai_utils import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+
+
+def t0_vlan_config_helper(test_obj):
+    """
+    Make t0 Vlan configurations base on the configuration in the test plan.
+    Set the configuration in test directly.
+
+    Set the following test_obj attributes:
+        dict: vlans - vid_id: vlan_object
+
+    """
+    configer = VlanConfiger(test_obj)
+    vlans = {}
+
+    # Todo add port to vlan member map and vise versa
+
+    vlan = configer.create_vlan(10, [1, 2, 3, 4, 5, 6, 7, 8])
+    vlans.update({vlan.vlan_id, vlan})
+    vlan = configer.create_vlan(20, [9, 10, 11, 12, 13, 14, 15, 16])
+    vlans.update({vlan.vlan_id, vlan})
+
+    if not hasattr(test_obj, 'vlans'):
+        test_obj.vlans = {}
+    for vlan in vlans:
+        test_obj.vlans.update(vlan.vlan_id, vlan)
+
+
+class VlanConfiger(object):
+    """
+    Class use to make all the vlan configurations.
+    """
+
+    def __init__(self, test_obj) -> None:
+        """
+        Init the Vlan configer.
+
+        Args:
+            test_obj: the test object
+        """
+
+        self.test_obj = test_obj
+        self.client = test_obj.client
+
+    def create_vlan(self, vlan_id, vlan_port_idxs, vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED):
+        """
+        Create vlan and its members.
+
+        Args:
+            vlan_id: vlan id
+            vlan_port_idxs: vlan member ports index
+            vlan_tagging_mode: vlan tagging mode
+
+        Returns:
+            Vlan: vlan object
+        """
+
+        vlan = Vlan()
+        print("Create vlan {} and it memmber port at {} ...".format(
+            vlan_id, vlan_port_idxs))
+        vlan_oid = sai_thrift_create_vlan(self.client, vlan_id=vlan_id)
+        members = self.create_vlan_member(
+            vlan_oid, vlan_port_idxs, vlan_tagging_mode)
+        vlan.vlan_id = vlan_id
+        vlan.vlan_mport_oids = members
+        vlan.vlan_oid = vlan_oid
+        return vlan
+
+    def create_vlan_member(self, vlan_oid, vlan_ports, vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED):
+        """
+        Create vlan members for a vlan.
+
+        Args:
+            vlan_oid:   vlan oid
+            vlan_ports: vlan member ports index 
+            vlan_tagging_mode: vlan tagging mode
+
+        Returns:
+            list: vlan members oid
+        """
+        vlan_members = []
+        attr = sai_thrift_get_vlan_attribute(
+            self.client, vlan_oid, vlan_id=True)
+        vlan_id = attr['vlan_id']
+        for port_index in vlan_ports:
+            vlan_member = sai_thrift_create_vlan_member(self.client,
+                                                        vlan_id=vlan_oid,
+                                                        bridge_port_id=self.test_obj.bridge_port_list[port_index],
+                                                        vlan_tagging_mode=vlan_tagging_mode)
+            vlan_members.append(vlan_member)
+            sai_thrift_set_port_attribute(
+                self.client, self.test_obj.port_list[port_index], port_vlan_id=vlan_id)
+        return vlan_members
+
+    def get_vlan_member(self, vlan_id):
+        """
+        Get vlan member by vlan_id.
+
+        Args:
+            vlan_id: vlan id
+
+        Returns:
+            list: vlan member oid list
+        """
+        vlan_member_list = sai_thrift_object_list_t(count=100)
+        mbr_list = sai_thrift_get_vlan_attribute(
+            self.client, vlan_id, member_list=vlan_member_list)
+        return mbr_list['SAI_VLAN_ATTR_MEMBER_LIST'].idlist
+
+    def remove_vlan(self, vlan_id, vlan_oid):
+        """
+        Remove vlan and its members.
+
+        Args:
+            vlan_id: vlan id
+            vlan_ports: vlan member ports index
+
+        Returns:
+            dict: vlan_list[vlan_id][vlan_members]
+        """
+        print("Remove vlan {} and its members ...".format(vlan_oid))
+        sai_thrift_remove_vlan(self.client, vlan_oid)
+        self.test_obj.assertEqual(self.test_obj.status(), SAI_STATUS_SUCCESS)
+
+    def remove_vlan_members(self, vlan_members):
+        """
+        Remove vlan members.
+        Args:
+            vlan_members: vlan member oids
+        """
+
+        for vlan_member in vlan_members:
+            sai_thrift_remove_vlan_member(self.client, vlan_member)
+            self.test_obj.assertEqual(self.test_obj.status(), SAI_STATUS_SUCCESS)
+
+class Vlan(object):
+    """
+    Represent the vlan object
+
+    Attrs:
+        vlan_id: vlan id
+        vlan_oid: vlan ojbect id
+        vlan_moids: vlan member object ids
+    """
+
+    def __init__(self, vlan_id=None, vlan_oid=None, vlan_moids=None):
+        self.vlan_id = vlan_id
+        self.vlan_oid = vlan_oid
+        self.vlan_mport_oids = vlan_moids

--- a/test/sai_test/constant.py
+++ b/test/sai_test/constant.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+#
+
+DEFAULT_IP_V4_PREFIX = '0.0.0.0/0'
+DEFAULT_IP_V6_PREFIX = '0000:0000:0000:0000:0000:0000:0000:0000'
+FDB_MAC_PREFIX = '00:01:01'
+FDB_SERVER_NUM = '99'
+LOCAL_IP_128V6_PREFIX = 'fe80::f68e:38ff:fe16:bc75/128'
+LOCAL_IP_10V6_PREFIX = 'fe80::/10'
+PORT_MTU = 9122
+ROUTER_MAC = '00:77:66:55:44:00'
+THRIFT_PORT = 9092
+

--- a/test/sai_test/sai_fdb_test.py
+++ b/test/sai_test/sai_fdb_test.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+#
+
+from sai_test_base import T0TestBase
+from sai_thrift.sai_headers import *
+from ptf import config
+from ptf.testutils import *
+from ptf.thriftutils import *
+from sai_utils import *
+
+class Common_Forwarding_Test(T0TestBase):
+    """
+    Verify the basic fdb forwarding.
+    """
+
+    def setUp(self):
+        """
+        Test the basic setup process
+        """
+        # this process contains the switch_init process
+        T0TestBase.setUp(self, is_remove_vlan=False)
+
+    def runTest(self):
+        """
+        Test fdb forwarding
+        """
+        try:
+            print("FDB basic forwarding test.")
+            for index in range(2, len(self.local_server_mac_list)):
+                print("L2 Forwarding from {} to port: {}".format(
+                    self.dev_port_list[1], 
+                    self.dev_port_list[index]))
+                pkt = simple_udp_packet(eth_dst=self.local_server_mac_list[index],
+                                        eth_src=self.local_server_mac_list[1],
+                                        ip_id=101,
+                                        ip_ttl=64)
+                    
+                send_packet(self, self.dev_port_list[1], pkt)
+                verify_packet(self, pkt, self.dev_port_list[index])
+        finally:
+            pass
+
+    def tearDown(self):
+        """
+        Test the basic tearDown process
+        """
+        sai_thrift_flush_fdb_entries(
+            self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)

--- a/test/sai_test/sai_sanity_test.py
+++ b/test/sai_test/sai_sanity_test.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+
+from sai_test_base import T0TestBase
+from sai_thrift.sai_headers import *
+from ptf import config
+from ptf.testutils import *
+from ptf.thriftutils import *
+
+class SaiSanityTest(T0TestBase):
+    """
+    This is a test class use to trigger some basic verification when set up the basic t0 data configuration.
+    """
+    # Todo remove this class when T0 data is ready, this class should not be checked into repo
+
+    def setUp(self):
+        """
+        Test the basic setup proecss
+        """
+        # this process contains the switch_init process
+        T0TestBase.setUp(self, is_remove_vlan=False, is_remove_bridge=False)
+
+    def runTest(self):
+        """
+        Test the basic runTest proecss
+        """
+        self.test_flooding_to_ports()
+
+    def tearDown(self):
+        """
+        Test the basic tearDown proecss
+        """
+        pass
+
+    def test_flooding_to_ports(self):
+        """
+        Test fdb forwarding
+        """
+        unknown_mac1 = "00:01:01:99:99:99"
+        unknown_mac2 = "00:01:02:99:99:99"
+        pkt = simple_udp_packet(eth_dst=unknown_mac1, eth_src=unknown_mac2,ip_id=101,ip_ttl=64)
+        try:
+            # Unknown mac, flooding to all the other ports.
+            print("Sanity test, check all the ports be flooded.")
+            send_packet(self, 1, pkt)
+            verify_each_packet_on_multiple_port_lists(self, [pkt], [self.dev_port_list[2:]])
+        finally:
+            pass

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+#
+
+import os
+from threading import Thread
+
+from ptf import config
+from ptf.base_tests import BaseTest
+
+from thrift.transport import TSocket
+from thrift.transport import TTransport
+from thrift.protocol import TBinaryProtocol
+
+from sai_thrift import sai_rpc
+
+import sai_thrift.sai_adapter as adapter
+from sai_thrift.sai_adapter import *
+from sai_utils import *
+
+THRIFT_PORT = 9092
+is_configured = False
+
+
+class ThriftInterface(BaseTest):
+    """
+    Get and format a port map, retrieve test params, and create an RPC client
+    """
+
+    def setUp(self):
+        super(ThriftInterface, self).setUp()
+
+        self.interface_to_front_mapping = {}
+        self.port_map_loaded = False
+
+        self.transport = None
+        self.test_reboot_mode = None
+        self.test_reboot_stage = None
+
+        self.test_params = test_params_get()
+        self.loadTestRebootMode()
+        self.loadPortMap()
+        self.createRpcClient()
+
+    def tearDown(self):
+        self.transport.close()
+
+        super(ThriftInterface, self).tearDown()
+
+    def loadTestRebootMode(self):
+        """
+        Get if test the reboot mode and what's the reboot mode need to be tested
+
+        In reboot mode, test will run many times in different reboot stage.
+        Tests in different stage might be different.
+
+        Set the following class attributes:
+        self.test_reboot_loaded - if the reboot mode already loaded
+        self.test_reboot_mode - reboot mode
+        self.test_reboot_stage - reboot stage, can be [setup|starting|post]
+        """
+
+        if "test_reboot_mode" in self.test_params:
+            self.test_reboot_mode = self.test_params['test_reboot_mode']
+            if "test_reboot_stage" in self.test_params:
+                self.test_reboot_stage = self.test_params['test_reboot_stage']
+            else:
+                raise ValueError('test_reboot_stage is Null!')
+        else:
+            self.test_reboot_mode = 'cold'
+
+        print("Reboot mode is: {}".format(self.test_reboot_mode))
+
+    def loadPortMap(self):
+        """
+        Get and format port_map
+
+        port_map_file is a port map with following lines format:
+        [test_port_no]@[device_port_name]
+        e.g.:
+             0@Veth1
+             1@Veth2
+             2@Veth3  ...
+        """
+        if self.port_map_loaded:
+            print("port_map already loaded")
+            return
+
+        if "port_map" in self.test_params:
+            user_input = self.test_params['port_map']
+            splitted_map = user_input.split(",")
+            for item in splitted_map:
+                iface_front_pair = item.split("@")
+                self.interface_to_front_mapping[iface_front_pair[0]] =  \
+                    iface_front_pair[1]
+        elif "port_map_file" in self.test_params:
+            user_input = self.test_params['port_map_file']
+            with open(user_input, 'r') as map_file:
+                for line in map_file:
+                    if (line and (line[0] == '#' or
+                                  line[0] == ';' or line[0] == '/')):
+                        continue
+                    iface_front_pair = line.split("@")
+                    self.interface_to_front_mapping[iface_front_pair[0]] =  \
+                        iface_front_pair[1].strip()
+        self.port_map_loaded = True
+
+    def createRpcClient(self):
+        """
+        Set up thrift client and contact RPC server
+        """
+
+        if 'thrift_server' in self.test_params:
+            server = self.test_params['thrift_server']
+        else:
+            server = 'localhost'
+
+        self.transport = TSocket.TSocket(server, THRIFT_PORT)
+        self.transport = TTransport.TBufferedTransport(self.transport)
+        self.protocol = TBinaryProtocol.TBinaryProtocol(self.transport)
+        if self.test_reboot_stage == 'starting':
+            return
+        self.client = sai_rpc.Client(self.protocol)
+        self.transport.open()
+
+
+class ThriftInterfaceDataPlane(ThriftInterface):
+    """
+    Sets up the thrift interface and dataplane
+    """
+
+    def setUp(self):
+        super(ThriftInterfaceDataPlane, self).setUp()
+
+        self.dataplane = ptf.dataplane_instance
+        if self.dataplane is not None:
+            self.dataplane.flush()
+            if config['log_dir'] is not None:
+                filename = os.path.join(config['log_dir'], str(self)) + ".pcap"
+                self.dataplane.start_pcap(filename)
+
+    def tearDown(self):
+        if config['log_dir'] is not None:
+            self.dataplane.stop_pcap()
+        super(ThriftInterfaceDataPlane, self).tearDown()
+
+
+class T0TestBase(ThriftInterfaceDataPlane):
+    """
+    SAI test helper base class without initial switch ports setup
+
+    Set the following class attributes:
+        self.default_vlan_id
+        self.default_vrf
+        self.default_1q_bridge
+        self.cpu_port_hdl
+        self.active_ports_no - number of active ports
+        self.port_list - list of all active port objects
+        self.portX objects for all active ports (where X is a port number)
+    """
+
+    def setUp(self, force_config=False, is_remove_vlan=True, is_remove_bridge=True):
+        super(T0TestBase, self).setUp()
+        self.port_configer = PortConfiger(self)
+        self.switch_configer = SwitchConfiger(self)
+        self.fdb_configer = FdbConfiger(self)
+        self.vlan_configer = VlanConfiger(self)        
+
+        if force_config or not is_configured:
+            t0_switch_config_helper(self)
+            t0_port_config_helper(
+                test_obj=self,
+                is_remove_vlan=is_remove_vlan,
+                is_remove_bridge=is_remove_bridge)
+            t0_fdb_config_helper(self)
+
+    def shell(self):
+        '''
+        Method use to start a sai shell in a thread.
+        '''
+        def start_shell():
+            sai_thrift_set_switch_attribute(
+                self.client, switch_shell_enable=True)
+        thread = Thread(target=start_shell)
+        thread.start()
+
+    @staticmethod
+    def status():
+        """
+        Returns the last operation status.
+
+        Returns:
+            int: sai call result
+        """
+        return adapter.status

--- a/test/sai_test/sai_utils.py
+++ b/test/sai_test/sai_utils.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+#
+
+"""
+Thrift SAI interface basic utils.
+"""
+
+import time
+import struct
+import socket
+
+from functools import wraps
+
+from ptf.packet import *
+from ptf.testutils import *
+
+from sai_thrift.sai_adapter import *
+from constant import *
+from config.port_configer import t0_port_config_helper
+from config.port_configer import PortConfiger
+from config.switch_configer import t0_switch_config_helper
+from config.switch_configer import SwitchConfiger
+from config.vlan_configer import t0_vlan_config_helper
+from config.vlan_configer import VlanConfiger
+from config.fdb_configer import t0_fdb_config_helper
+from config.fdb_configer import FdbConfiger
+
+
+def sai_ipprefix(prefix_str):
+    """
+    Set IP address prefix and mask and return ip_prefix object
+
+    Args:
+        prefix_str (str): IP address and mask string (with slash notation)
+
+    Return:
+        sai_thrift_ip_prefix_t: IP prefix object
+    """
+    addr_mask = prefix_str.split('/')
+    if len(addr_mask) != 2:
+        print("Invalid IP prefix format")
+        return None
+
+    if '.' in prefix_str:
+        family = SAI_IP_ADDR_FAMILY_IPV4
+        addr = sai_thrift_ip_addr_t(ip4=addr_mask[0])
+        mask = num_to_dotted_quad(addr_mask[1])
+        mask = sai_thrift_ip_addr_t(ip4=mask)
+    if ':' in prefix_str:
+        family = SAI_IP_ADDR_FAMILY_IPV6
+        addr = sai_thrift_ip_addr_t(ip6=addr_mask[0])
+        mask = num_to_dotted_quad(int(addr_mask[1]), ipv4=False)
+        mask = sai_thrift_ip_addr_t(ip6=mask)
+
+    ip_prefix = sai_thrift_ip_prefix_t(
+        addr_family=family, addr=addr, mask=mask)
+    return ip_prefix
+
+
+def num_to_dotted_quad(address, ipv4=True):
+    """
+    Helper function to convert the ip address
+
+    Args:
+        address (str): IP address
+        ipv4 (bool): determines what IP version is handled
+
+    Returns:
+        str: formatted IP address
+    """
+    if ipv4 is True:
+        mask = (1 << 32) - (1 << 32 >> int(address))
+        return socket.inet_ntop(socket.AF_INET, struct.pack('>L', mask))
+
+    mask = (1 << 128) - (1 << 128 >> int(address))
+    i = 0
+    result = ''
+    for sign in str(hex(mask)[2:]):
+        if (i + 1) % 4 == 0:
+            result = result + sign + ':'
+        else:
+            result = result + sign
+        i += 1
+    return result[:-1]


### PR DESCRIPTION
Create SAI PTF test structure for T0
1. Create configuration structure for different components config
2. Add FDB, PORT, switch, and VLAN configurations
3. Create a Test structure base on PTF
4. Add T0 test case samples for FDB

Test Done:
Checked the functionality of the port with port flooding
Checked port forwarding based on FDB configurations

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>