### PR TITLE
add more waiting time for test

### DIFF
--- a/test/sai_test/config/fdb_configer.py
+++ b/test/sai_test/config/fdb_configer.py
@@ -85,7 +85,8 @@ class FdbConfiger(object):
                            port_oids,
                            type=SAI_FDB_ENTRY_TYPE_STATIC,
                            vlan_oid=None,
-                           packet_action=SAI_PACKET_ACTION_FORWARD):
+                           packet_action=SAI_PACKET_ACTION_FORWARD,
+                           wait_sec=1):
         """
         Create FDB entries.
 
@@ -110,6 +111,9 @@ class FdbConfiger(object):
                 type=type,
                 bridge_port_id=port_oids[index],
                 packet_action=packet_action)
+        print("Waiting for FDB to get refreshed, {} seconds ...".format(
+            wait_sec))
+        time.sleep(wait_sec)
 
     def generate_mac_address_list(self, role, group, indexes):
         """

--- a/test/sai_test/config/fdb_configer.py
+++ b/test/sai_test/config/fdb_configer.py
@@ -86,7 +86,7 @@ class FdbConfiger(object):
                            type=SAI_FDB_ENTRY_TYPE_STATIC,
                            vlan_oid=None,
                            packet_action=SAI_PACKET_ACTION_FORWARD,
-                           wait_sec=1):
+                           wait_sec=2):
         """
         Create FDB entries.
 

--- a/test/sai_test/config/switch_configer.py
+++ b/test/sai_test/config/switch_configer.py
@@ -51,7 +51,7 @@ class SwitchConfiger(object):
         self.test_obj = test_obj
         self.client = test_obj.client
 
-    def start_switch(self, switch_init_wait=1, route_mac=ROUTER_MAC):
+    def start_switch(self, switch_init_wait=3, route_mac=ROUTER_MAC):
         """
         Start switch and wait seconds for a warm up.
 

--- a/test/sai_test/sai_sanity_test.py
+++ b/test/sai_test/sai_sanity_test.py
@@ -60,7 +60,6 @@ class SaiSanityTest(T0TestBase):
                                 eth_src=unknown_mac2,
                                 ip_id=101,
                                 ip_ttl=64)
-        time.sleep(5)
         try:
             # Unknown mac, flooding to all the other ports.
             print("Sanity test, check all the ports be flooded.")

--- a/test/sai_test/sai_sanity_test.py
+++ b/test/sai_test/sai_sanity_test.py
@@ -22,6 +22,7 @@ from sai_thrift.sai_headers import *
 from ptf import config
 from ptf.testutils import *
 from ptf.thriftutils import *
+import time
 
 
 class SaiSanityTest(T0TestBase):
@@ -59,6 +60,7 @@ class SaiSanityTest(T0TestBase):
                                 eth_src=unknown_mac2,
                                 ip_id=101,
                                 ip_ttl=64)
+        time.sleep(5)
         try:
             # Unknown mac, flooding to all the other ports.
             print("Sanity test, check all the ports be flooded.")

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -181,7 +181,8 @@ class T0TestBase(ThriftInterfaceDataPlane):
               is_recreate_bridge=True,
               is_reset_default_vlan=True,
               is_create_vlan=True,
-              is_create_fdb=True):
+              is_create_fdb=True,
+              wait_sec=5):
         super(T0TestBase, self).setUp()
         self.port_configer = PortConfiger(self)
         self.switch_configer = SwitchConfiger(self)
@@ -201,6 +202,9 @@ class T0TestBase(ThriftInterfaceDataPlane):
             t0_fdb_config_helper(
                 test_obj=self,
                 is_create_fdb=is_create_fdb)
+        print("Waiting for switch to get ready before test, {} seconds ...".format(
+            wait_sec))
+        time.sleep(wait_sec)
 
     def shell(self):
         '''


### PR DESCRIPTION
add more waiting time for test

In different test bed, there will be different waiting time to make sure the switch get ready after some configuration. Add sleep time for the switch gets ready before test.

Test done:
Tested on DUT for tests
Tested with pipeline