### PR TITLE
[Test]Add Fdb test plan

### DIFF
--- a/doc/sai-ptf/config_data/config_t0.md
+++ b/doc/sai-ptf/config_data/config_t0.md
@@ -7,6 +7,7 @@
 - [1. L2 Configurations](#1-l2-configurations)
   - [1.1 FDB Configuration](#11-fdb-configuration)
   - [1.2 VLAN configuration](#12-vlan-configuration)
+    - [1.3 Host Interface](#13-host-interface)
 - [2. L3 configuration](#2-l3-configuration)
   - [2.1 VLAN Interfaces](#21-vlan-interfaces)
   - [2.2 Route Interfaces](#22-route-interfaces)
@@ -125,6 +126,12 @@ The MAC Table for VLAN L2 forwarding as below
 |-|-|-|-|
 |Ethernet4-32|10|Port1-8|Untag|
 |Ethernet36-72|20|Port9-16|Untag|
+
+### 1.3 Host Interface
+
+|HostIf_Trap_Group|Queue|Policer|
+|-|-|-|
+|DEFAULT|0||
 
 
 # 2. L3 configuration

--- a/doc/sai-ptf/config_data/config_t0.md
+++ b/doc/sai-ptf/config_data/config_t0.md
@@ -7,7 +7,6 @@
 - [1. L2 Configurations](#1-l2-configurations)
   - [1.1 FDB Configuration](#11-fdb-configuration)
   - [1.2 VLAN configuration](#12-vlan-configuration)
-    - [1.3 Host Interface](#13-host-interface)
 - [2. L3 configuration](#2-l3-configuration)
   - [2.1 VLAN Interfaces](#21-vlan-interfaces)
   - [2.2 Route Interfaces](#22-route-interfaces)
@@ -126,12 +125,6 @@ The MAC Table for VLAN L2 forwarding as below
 |-|-|-|-|
 |Ethernet4-32|10|Port1-8|Untag|
 |Ethernet36-72|20|Port9-16|Untag|
-
-### 1.3 Host Interface
-
-|HostIf_Trap_Group|Queue|Policer|
-|-|-|-|
-|DEFAULT|0||
 
 
 # 2. L3 configuration

--- a/doc/sai-ptf/fdb_test_plan.md
+++ b/doc/sai-ptf/fdb_test_plan.md
@@ -1,0 +1,262 @@
+# SAI FDB Test plan <!-- omit in toc --> 
+
+- [Test Configuration](#test-configuration)
+- [Test Execution](#test-execution)
+- [Test Execution](#test-execution-1)
+  - [Common Test Data/Packet](#common-test-datapacket)
+  - [Test Group1: MAC learning](#test-group1-mac-learning)
+    - [Case1: test_vlan_port_learn_disable](#case1-test_vlan_port_learn_disable)
+    - [Case2: test_bg_port_learn_disable](#case2-test_bg_port_learn_disable)
+    - [Case3: test_non_bgPort_no_learn](#case3-test_non_bgport_no_learn)
+    - [Case4: test_new_vlan_member_learn](#case4-test_new_vlan_member_learn)
+    - [Case5: test_remove_vlan_member_no_learn](#case5-test_remove_vlan_member_no_learn)
+    - [Case6: test_no_learn_invalidate_vlan](#case6-test_no_learn_invalidate_vlan)
+    - [Case7: test_no_learn_broadcast_src](#case7-test_no_learn_broadcast_src)
+    - [Case8: test_no_learn_multicast_src](#case8-test_no_learn_multicast_src)
+  - [Test Group2: MAC move](#test-group2-mac-move)
+    - [Case9:  test_disable_move_drop](#case9--test_disable_move_drop)
+    - [Case10: test_dynamic_mac_move](#case10-test_dynamic_mac_move)
+    - [Case11: test_static_mac_move](#case11-test_static_mac_move)
+  - [Test Group3: FDB age](#test-group3-fdb-age)
+    - [Case12: test_port_age](#case12-test_port_age)
+    - [Case13: test_aging_after_move](#case13-test_aging_after_move)
+  - [Test Group4: FDB flush](#test-group4-fdb-flush)
+    - [Case14: test_flush_vlan_static](#case14-test_flush_vlan_static)
+    - [Case15: test_flush_vlan_dynamic](#case15-test_flush_vlan_dynamic)
+    - [Case16: test_flush_port_static](#case16-test_flush_port_static)
+    - [Case17: test_flush_port_dynamic](#case17-test_flush_port_dynamic)
+    - [Case18: test_flush_all_static](#case18-test_flush_all_static)
+    - [Case19: test_flush_all_dynamic](#case19-test_flush_all_dynamic)
+    - [Case20: test_flush_all](#case20-test_flush_all)
+  - [Test Group5: FDB miss](#test-group5-fdb-miss)
+    - [Case21: test_unicast_action_copy](#case21-test_unicast_action_copy)
+    - [Case22: test_unicast_action_trap](#case22-test_unicast_action_trap)
+    - [Case23: test_unicast_action_drop](#case23-test_unicast_action_drop)
+    - [Case24: test_multicast_action_copy](#case24-test_multicast_action_copy)
+    - [Case25: test_multicast_action_trap](#case25-test_multicast_action_trap)
+    - [Case26: test_multicast_action_drop](#case26-test_multicast_action_drop)
+    - [Case27: test_broadcast_action_copy](#case27-test_broadcast_action_copy)
+    - [Case28: test_broadcast_action_trap](#case28-test_broadcast_action_trap)
+    - [Case29: test_broadcast_action_drop](#case29-test_broadcast_action_drop)
+
+# Test Configuration
+
+For the test configuration, please refer to the file 
+  - [Config_t0](./config_data/config_t0.md)
+  
+**Note. All the tests will be based on the configuration above, if any additional configuration is required, it will be specified in the Test case.**
+
+# Test Execution
+
+# Test Execution
+
+## Common Test Data/Packet
+In this FDB test, the example packet structure is below.
+- Simple L2 packet
+   ```python
+    simple_udp_packet(eth_dst=dmac,
+                      eth_src=smac)
+   ```
+- VLAN
+  ```Python
+    simple_udp_packet(eth_dst=dmsc,
+                      eth_src=smac,
+                      vlan_vid=lvlan_id)
+  ```
+
+  **Note. If need other kinds of packets, they will be added to the test case/group respectively.**
+
+## Test Group1: MAC learning 
+### Case1: test_vlan_port_learn_disable
+### Case2: test_bg_port_learn_disable
+### Case3: test_non_bgPort_no_learn
+### Case4: test_new_vlan_member_learn
+### Case5: test_remove_vlan_member_no_learn
+### Case6: test_no_learn_invalidate_vlan
+### Case7: test_no_learn_broadcast_src
+### Case8: test_no_learn_multicast_src
+
+### Testing Objective <!-- omit in toc --> 
+Verify if MAC addresses are not learned on the port when VLAN port or bridge port learning is disabled.
+Verify if MAC addresses are not learned on the port when the port is not a bridge port.
+Verify newly added VLAN members can learn.
+
+
+### Test steps: <!-- omit in toc --> 
+
+- test_vlan_port_learn_disable
+- test_bg_port_learn_disable
+- test_non_bgPort_no_learn
+
+1. Flush all MAC
+2. Disable MAC learn on VLAN10/Port1(Bridge Port1) and Removed Port1 from Bridge Port1 for each case
+3. Create a packet with SMAC ``MacX``
+4. send packet from port1
+5. Verify the packet flood to other VLAN10 ports
+6. Create a packet with DMAC ``MacX``
+7. send the packet on port2
+8. Verify the packet flood to other VLAN10 ports, including port1
+
+- test_new_vlan_member_learn
+
+1. Add Port24 to VLAN10
+2. Create Packet with SMAC=``MacX`` DMAC=``Port1 MAC``
+3. Send packet on port24
+4. verify only receive a packet on port1
+5. Create a packet with DMAC=``MacX``
+6. Send packet on port1
+7. Verify only receive a packet on port24
+
+- test_remove_vlan_member_learn
+
+1. Remove Port2 from VLAN10
+2. Create a flood Packet with SMAC=``MacX`` and VLAN10 tag
+3. Send packet on port2
+4. Verify no packet was received on any port
+5. Create a packet with DMAC=``MacX`` and VLAN10 tag
+6. Send packet on port1
+7. Verify flooding to VLAN10 ports, no packet on port2
+
+- test_no_learn_invalidate_vlan
+- test_no_learn_broadcast_src
+- test_no_learn_multicast_src
+
+1. Create a packet with vlan_id=``VLAN11`` SMAC=``MacX``/SMAC=``broadcast address``/SMAC=``multicast address``
+2. Send packet on port2
+3. Verify no packet was received on any port
+4. Create a packet with vlan_id=``VLAN11`` DMAC=``MacX``/DMAC=``broadcast address``/DMAC=``multicast address``
+5. Send packet on port1
+6. Flooding on all vlan10 ports, except port1
+
+
+## Test Group2: MAC move
+### Case9:  test_disable_move_drop
+### Case10: test_dynamic_mac_move
+### Case11: test_static_mac_move
+### Testing Objective <!-- omit in toc --> 
+Verify if disable MAC move, drop packet with known SMAC, the SMAC was learned previously on other port.
+Verify when enabling MAC move, if after receiving a packet with known SMAC, but from another port that on which, it was learned previously, next packets with such DMACs are forwarded to the new port.
+
+### Test steps: <!-- omit in toc --> 
+- test_disable_move_drop
+
+1. Disable mac move for ``Port1 MAC`` on Port1
+2. Create a packet with SMAC=``Port1 MAC`` DMAC=``Port2 MAC``
+3. Send packet on port1
+4. Verify packet received on port2
+5. Send packet in step2 on port3
+6. Verify the packet gets dropped
+
+- test_dynamic_mac_move
+- test_static_mac_move
+  
+1. Flush All MAC
+2. Install dynamic/static ``Port1 MAC`` address for port1
+3. Enable mac move for ``Port1 MAC`` on Port1
+4. Create packet with SMAC=``Port1 MAC`` DMAC=``Port2 MAC``
+5. Send packet on port1
+6. Verify packet received on port2
+7. Send packet in step2 on port3
+8. Verify packet received on port2
+
+## Test Group3: FDB age
+### Case12: test_port_age
+### Case13: test_aging_after_move
+### Testing Objective <!-- omit in toc -->
+Verifying if the dynamic FDB entry associated with the port is removed after the aging interval.
+Verifying the aging time refreshed if dynamic FDB entry associated with one port and then moved to another port (not the initial learning time)
+
+
+### Test steps: <!-- omit in toc --> 
+- test_port_age
+
+1. Set FDB aging time=10
+2. Create Packet with SMAC=``MacX`` DMAC=``Port1 MAC`` 
+3. Send packet on port2
+4. verify only receive a packet on port1
+5. Create a packet with DMAC=``MacX``
+6. Send packet on port1
+7. Verify only receive a packet on port2
+8. Wait for the ``aging`` time
+9. Send packet on port1
+10. Verify flooding packet to VLAN10 ports, except port1
+
+- test_aging_after_move
+
+1. Set FDB aging time=10
+2. Create Packet with SMAC=``MacX`` DMAC=``Port1 MAC`` 
+3. Send packet on port2
+4. verify only receive a packet on port1
+5. Create a packet with DMAC=``MacX``
+6. Send packet on port1
+7. Verify only receive a packet on port2
+8. Wait for the ``aging`` time
+9. Send packet on port1
+10. Verify flooding packet to VLAN10 ports, except port1
+
+## Test Group4: FDB flush
+### Case14: test_flush_vlan_static
+### Case15: test_flush_vlan_dynamic
+### Case16: test_flush_port_static
+### Case17: test_flush_port_dynamic
+### Case18: test_flush_all_static
+### Case19: test_flush_all_dynamic
+### Case20: test_flush_all
+
+### Testing Objective <!-- omit in toc -->
+Verify flushing of static/dynamic entries on VLAN/Port/All.
+### Test steps: <!-- omit in toc --> 
+
+1. Flush with conditions for each case in sequence: ``Static`` on ``VLAN10``; ``Dynamic`` on ``VLAN20``; ``Static`` on ``Port1``;  ``Dynamic`` on ``Port9``; ``Static``; ``Dynamic``; ``All``
+2. Send packets for each case in sequence: ``port1`` DMAC=``Port2 MAC``; ``Port9`` DMAC=``Port10 MAC``; ``Port2`` DMAC=``Port1 MAC``; ``Port10`` DMAC=``Port9 MAC``; ``port1`` DMAC=``Port2 MAC``; ``Port9`` DMAC=``Port10 MAC``
+3. Verify flooding happened, packets received in related VLAN, except the ingress port.
+4. Send packets for each case in sequence:  ``Port9`` DMAC=``Port10 MAC``; ``port1`` DMAC=``Port2 MAC``;``Port10`` DMAC=``Port9 MAC``; ``Port2`` DMAC=``Port1 MAC``;  ``Port9`` DMAC=``Port10 MAC``;``port1`` DMAC=``Port2 MAC``;
+5. Verify unicast to the corresponding port.
+
+
+
+## Test Group5: FDB miss
+### Case21: test_unicast_action_copy
+### Case22: test_unicast_action_trap
+### Case23: test_unicast_action_drop
+### Case24: test_multicast_action_copy
+### Case25: test_multicast_action_trap
+### Case26: test_multicast_action_drop
+### Case27: test_broadcast_action_copy
+### Case28: test_broadcast_action_trap
+### Case29: test_broadcast_action_drop
+
+### Testing Objective <!-- omit in toc --> 
+Verify if unicast/multicast/broadcast packets are dropped or redirected/copy to the CPU after setting miss packet action to drop, trap or copy.
+
+### Test steps: <!-- omit in toc --> 
+- test_unicast_action_drop
+- test_multicast_action_drop
+- test_broadcast_action_drop
+
+1. Set the FDB unicast/multicast/broadcast missing action to SAI_PACKET_ACTION_DROP 
+2. Create a packet with DMAC as unknown ``MacX``, ``Multicase MAC`` or ``Broadcast MAC`` for each case
+3. Send the packet to port1
+4. Verify the packet gets dropped
+
+- test_unicast_action_trap
+- test_multicast_action_trap
+- test_broadcast_action_trap
+
+1. Set the FDB unicast/multicast/broadcast missing action to SAI_PACKET_ACTION_TRAP 
+2. Create a packet with DMAC as unknown ``MacX``, ``Multicase MAC`` or ``Broadcast MAC`` for each case
+3. Get the queue status SAI_QUEUE_STAT_PACKETS
+4. Send the packet on port1
+5. Verify the packet gets dropped
+6. Check the SAI_QUEUE_STAT_PACKETS increased by 1
+
+- test_unicast_action_copy
+- test_multicast_action_copy
+- test_broadcast_action_copy
+
+1. Set the FDB unicast/multicast/broadcast missing action to SAI_PACKET_ACTION_TRAP 
+2. Create a packet with DMAC as unknown ``MacX``, ``Multicase MAC`` or ``Broadcast MAC`` for each case
+3. Get the queue status SAI_QUEUE_STAT_PACKETS
+4. Send the packet on port1
+5. Verify the packet flooding to vlan10 ports, except port1
+6. Check the SAI_QUEUE_STAT_PACKETS increased by 1

--- a/doc/sai-ptf/fdb_test_plan.md
+++ b/doc/sai-ptf/fdb_test_plan.md
@@ -206,14 +206,31 @@ Verifying the aging time refreshed if dynamic FDB entry associated with one port
 ### Testing Objective <!-- omit in toc -->
 Verify flushing of static/dynamic entries on VLAN/Port/All.
 ### Test steps: <!-- omit in toc --> 
+- test_flush_vlan_static
+- test_flush_port_static
+- test_flush_all_static
 
-1. Flush with conditions for each case in sequence: ``Static`` on ``VLAN10``; ``Dynamic`` on ``VLAN20``; ``Static`` on ``Port1``;  ``Dynamic`` on ``Port9``; ``Static``; ``Dynamic``; ``All``
-2. Send packets for each case in sequence: ``port1`` DMAC=``Port2 MAC``; ``Port9`` DMAC=``Port10 MAC``; ``Port2`` DMAC=``Port1 MAC``; ``Port10`` DMAC=``Port9 MAC``; ``port1`` DMAC=``Port2 MAC``; ``Port9`` DMAC=``Port10 MAC``
+1. Flush with conditions for each case: ``Static`` flush on ``VLAN10``; ``Static`` flush on ``Port1``; flush for all ``Static`` 
+2. Send packets for each case in sequence: ``port1`` DMAC=``Port2 MAC``; ``Port2`` DMAC=``Port1 MAC``; ``port1`` DMAC=``Port2 MAC``
 3. Verify flooding happened, packets received in related VLAN, except the ingress port.
-4. Send packets for each case in sequence:  ``Port9`` DMAC=``Port10 MAC``; ``port1`` DMAC=``Port2 MAC``;``Port10`` DMAC=``Port9 MAC``; ``Port2`` DMAC=``Port1 MAC``;  ``Port9`` DMAC=``Port10 MAC``;``port1`` DMAC=``Port2 MAC``;
-5. Verify unicast to the corresponding port.
+4. Send packets for each case in sequence:  ``Port9`` DMAC=``Port10 MAC``; ``Port10`` DMAC=``Port9 MAC``; `  ``Port9`` DMAC=``Port10 MAC``
+5. Verify flush happens in a certain domain, unicast to the corresponding port.
 
+- test_flush_vlan_dynamic
+- test_flush_port_dynamic
+- test_flush_all_dynamic
+  
+1. Flush with conditions for each case in sequence: ``Dynamic`` flush on ``VLAN20``;  ``Dynamic`` flush on ``Port9``; flush for all ``Dynamic`` 
+2. Send packets for each case in sequence: ``Port9`` DMAC=``Port10 MAC``;  ``Port10`` DMAC=``Port9 MAC``; ``Port9`` DMAC=``Port10 MAC``
+3. Verify flooding happened, packets received in related VLAN, except the ingress port.
+4. Send packets for each case in sequence:  ``port1`` DMAC=``Port2 MAC``;``Port2`` DMAC=``Port1 MAC``; ``port1`` DMAC=``Port2 MAC``;
+5.  Verify flush happens in a certain domain, unicast to the corresponding port.
 
+- test_flush_all
+
+1. Flush with conditions: flush for ``All``
+2. Send packets : ``port1`` DMAC=``Port2 MAC``; ``Port9`` DMAC=``Port10 MAC``; 
+3. Verify flooding happened, packets received in related VLAN, except the ingress port.
 
 ## Test Group5: FDB miss
 ### Case21: test_unicast_action_copy

--- a/doc/sai-ptf/fdb_test_plan.md
+++ b/doc/sai-ptf/fdb_test_plan.md
@@ -74,8 +74,8 @@ In this FDB test, the example packet structure is below.
 - test_new_vlan_member_learn: Verify newly added VLAN members can learn.
 - test_remove_vlan_member_no_learn: Verify no MAC addresses are learned on the removed vlan member.
 - test_no_learn_invalidate_vlan: Verify no MAC addresses are learned on invalidate vlan ID.
-- test_no_learn_broadcast_src: Verify broadcast mac address is learned.
-- test_no_learn_multicast_src: Verify multicast mac address is learned.
+- test_no_learn_broadcast_src: Verify broadcast mac address is not learned.
+- test_no_learn_multicast_src: Verify multicast mac address is not learned.
 
 ### Test steps: <!-- omit in toc --> 
 
@@ -187,7 +187,7 @@ In this FDB test, the example packet structure is below.
 7. Verify only receive a packet on port2
 9. Wait for the ``aging`` time
 10. Send packet on port3
-11. Verify flooding packet to VLAN10 ports, except port1
+11. Verify flooding packet to VLAN10 ports, except port3
 
 - test_mac_moving_after_aging
 
@@ -218,24 +218,54 @@ In this FDB test, the example packet structure is below.
 Verify flushing of static/dynamic entries on VLAN/Port/All.
 ### Test steps: <!-- omit in toc --> 
 - test_flush_vlan_static
+
+1. Flush with condition for each case: ``Static`` flush on ``VLAN10`` 
+2. Send packets: ``port1`` DMAC=``Port2 MAC``
+3. Verify flooding happened, packets received in related VLAN, except the ingress port.
+4. Send packets:  ``Port9`` DMAC=``Port10 MAC``
+5. Verify unicast to the corresponding port
+
 - test_flush_port_static
+
+1. Flush with condition: ``Static`` flush on ``Port1``
+2. Send packets: ``Port2`` DMAC=``Port1 MAC``
+3. Verify flooding happened, packets received in related VLAN, except the ingress port.
+4. Send packets:  ``Port10`` DMAC=``Port9 MAC``
+5. Verify unicast to the corresponding port
+
 - test_flush_all_static
 
-1. Flush with conditions for each case: ``Static`` flush on ``VLAN10``; ``Static`` flush on ``Port1``; flush for all ``Static`` 
-2. Send packets for each case in sequence: ``port1`` DMAC=``Port2 MAC``; ``Port2`` DMAC=``Port1 MAC``; ``port1`` DMAC=``Port2 MAC``
+1. Flush with condition: flush for all ``Static`` 
+2. Send packets for each case in sequence:``port1`` DMAC=``Port2 MAC``
 3. Verify flooding happened, packets received in related VLAN, except the ingress port.
-4. Send packets for each case in sequence:  ``Port9`` DMAC=``Port10 MAC``; ``Port10`` DMAC=``Port9 MAC``; `  ``Port9`` DMAC=``Port10 MAC``
-5. Verify flush happens in a certain domain, unicast to the corresponding port.
+4. Send packets:``Port9`` DMAC=``Port10 MAC``
+5. Verify flush happens in a certain domain
 
 - test_flush_vlan_dynamic
+
+1. Flush with condition: ``Dynamic`` flush on ``VLAN20``
+2. Send packets for each case in sequence: ``Port9`` DMAC=``Port10 MAC``
+3. Verify flooding happened, packets received in related VLAN, except the ingress port.
+4. Send packets for each case in sequence:  ``port1`` DMAC=``Port2 MAC``
+5. Verify unicast to the corresponding port
+
+
 - test_flush_port_dynamic
+
+1. Flush with condition: ``Dynamic`` flush on ``Port9``
+2. Send packets: ``Port10`` DMAC=``Port9 MAC``
+3. Verify flooding happened, packets received in related VLAN, except the ingress port.
+4. Send packets:  ``Port2`` DMAC=``Port1 MAC``
+5. Verify unicast to the corresponding port
+
+
 - test_flush_all_dynamic
   
-1. Flush with conditions for each case in sequence: ``Dynamic`` flush on ``VLAN20``;  ``Dynamic`` flush on ``Port9``; flush for all ``Dynamic`` 
-2. Send packets for each case in sequence: ``Port9`` DMAC=``Port10 MAC``;  ``Port10`` DMAC=``Port9 MAC``; ``Port9`` DMAC=``Port10 MAC``
+1. Flush with condition: flush for all ``Dynamic`` 
+2. Send packets for each case in sequence: ``Port9`` DMAC=``Port10 MAC``
 3. Verify flooding happened, packets received in related VLAN, except the ingress port.
-4. Send packets for each case in sequence:  ``port1`` DMAC=``Port2 MAC``;``Port2`` DMAC=``Port1 MAC``; ``port1`` DMAC=``Port2 MAC``;
-5.  Verify flush happens in a certain domain, unicast to the corresponding port.
+4. Send packets for each case in sequence: ``port1`` DMAC=``Port2 MAC``
+5. Verify flush happens in a certain domain
 
 - test_flush_all
 

--- a/doc/sai-ptf/fdb_test_plan.md
+++ b/doc/sai-ptf/fdb_test_plan.md
@@ -154,9 +154,11 @@ Verifying the aging time refreshed if dynamic FDB entry associated with one port
 5. Create a packet with DMAC=``MacX``
 6. Send packet on port1
 7. Verify only receive a packet on port2
-8. Wait for the ``aging`` time
-9. Send packet on port1
-10. Verify flooding packet to VLAN10 ports, except port1
+8. Send packet on port3
+7. Verify only receive a packet on port2
+9. Wait for the ``aging`` time
+10. Send packet on port3
+11. Verify flooding packet to VLAN10 ports, except port1
 
 ## Test Group3: FDB flush
 ### Case1: test_flush_vlan_static

--- a/doc/sai-ptf/fdb_test_plan.md
+++ b/doc/sai-ptf/fdb_test_plan.md
@@ -80,11 +80,33 @@ In this FDB test, the example packet structure is below.
 ### Test steps: <!-- omit in toc --> 
 
 - test_vlan_port_learn_disable
+
+1. Flush all MAC
+2. Disable MAC learn on VLAN10
+3. Create a packet with SMAC ``MacX``
+4. send packet from port1
+5. Verify the packet flood to other VLAN10 ports
+6. Create a packet with DMAC ``MacX``
+7. send the packet on port2
+8. Verify the packet flood to other VLAN10 ports, including port1
+9. check FDB entries, no new entry
+
 - test_bg_port_learn_disable
+
+1. Flush all MAC
+2. Disable MAC learn on Port1(Bridge Port1)
+3. Create a packet with SMAC ``MacX``
+4. send packet from port1
+5. Verify the packet flood to other VLAN10 ports
+6. Create a packet with DMAC ``MacX``
+7. send the packet on port2
+8. Verify the packet flood to other VLAN10 ports, including port1
+9. check FDB entries, no new entry
+
 - test_non_bgPort_no_learn
 
 1. Flush all MAC
-2. Disable MAC learn on VLAN10/Port1(Bridge Port1) and Removed Port1 from Bridge Port1 for each case
+2. Removed Port1 from Bridge Port1 for each case
 3. Create a packet with SMAC ``MacX``
 4. send packet from port1
 5. Verify the packet flood to other VLAN10 ports
@@ -107,7 +129,7 @@ In this FDB test, the example packet structure is below.
 - test_remove_vlan_member_learn
 
 1. Remove Port2 from VLAN10
-2. Create a flood Packet with SMAC=``MacX`` and VLAN10 tag
+2. Create a Packet with SMAC=``MacX`` and VLAN10 tag
 3. Send packet on port2
 4. Verify no packet was received on any port
 5. Create a packet with DMAC=``MacX`` and VLAN10 tag
@@ -177,8 +199,11 @@ In this FDB test, the example packet structure is below.
 6. Send packet on port1
 7. Verify only receive a packet on port2
 8. Wait for the ``aging`` time
-9. Send packet on port3
-10. Verify only receive a packet on port2
+9. Create Packet with SMAC=``MacX`` DMAC=``Port1 MAC`` 
+10. Send packet on port3(mac moved from Port2 to Port3)
+11. verify only receive a packet on port1
+12. Create and send a packet with DMAC=``MacX``
+13. Verify only receive a packet on port3
 
 ## Test Group3: FDB flush
 ### Case1: test_flush_vlan_static
@@ -241,14 +266,13 @@ Verify flushing of static/dynamic entries on VLAN/Port/All.
 - test_dynamic_mac_move
   
 1. Flush All MAC
-2. Install static FDB entry for port2 with ``Port2 MAC``
+2. Install static FDB entry for port2 with ``Port2 MAC``(with allow_mac_move as true)
 3. Send Packet on Port1 with SMAC=``Port1 MAC`` DMAC=``Port2 MAC``
-4. Create packet with SMAC=``Port1 MAC`` DMAC=``Port2 MAC``
-5. Send packet on port1
-6. Install static mac move for ``Port1 MAC`` on Port1 and enable mac move
-7. Verify packet received on port2
-8. Send packet in step2 on port3
-9. Verify packet received on port2
+4. Verify packet received on port2
+5. Send packet in step2 on port3
+8. Verify packet received on port2
+9. Send packet with DMAC=``Port1 MAC`` SMAC=``Port2 MAC`` on Port2
+10. Verify packet received on port3
 
 - test_static_mac_move
   

--- a/doc/sai-ptf/fdb_test_plan.md
+++ b/doc/sai-ptf/fdb_test_plan.md
@@ -16,6 +16,7 @@
   - [Test Group2: FDB age](#test-group2-fdb-age)
     - [Case1: test_port_age](#case1-test_port_age)
     - [Case2: test_aging_after_move](#case2-test_aging_after_move)
+    - [Case3: test_mac_moving_after_aging](#case3-test_mac_moving_after_aging)
   - [Test Group3: FDB flush](#test-group3-fdb-flush)
     - [Case1: test_flush_vlan_static](#case1-test_flush_vlan_static)
     - [Case2: test_flush_vlan_dynamic](#case2-test_flush_vlan_dynamic)
@@ -25,7 +26,7 @@
     - [Case6: test_flush_all_dynamic](#case6-test_flush_all_dynamic)
     - [Case7: test_flush_all](#case7-test_flush_all)
   - [Test Group4: MAC move](#test-group4-mac-move)
-    - [Case1:  test_disable_move_drop](#case1--test_disable_move_drop)
+    - [Case1: test_disable_move_drop](#case1-test_disable_move_drop)
     - [Case2: test_dynamic_mac_move](#case2-test_dynamic_mac_move)
     - [Case3: test_static_mac_move](#case3-test_static_mac_move)
 
@@ -67,10 +68,14 @@ In this FDB test, the example packet structure is below.
 ### Case8: test_no_learn_multicast_src
 
 ### Testing Objective <!-- omit in toc --> 
-Verify if MAC addresses are not learned on the port when VLAN port or bridge port learning is disabled.
-Verify if MAC addresses are not learned on the port when the port is not a bridge port.
-Verify newly added VLAN members can learn.
-
+- test_vlan_port_learn_disable: Verify if MAC addresses are not learned on the port when VLAN port is disabled.
+- test_bg_port_learn_disable: Verify if MAC addresses are not learned on the port whenbridge port learning is disabled.
+- test_non_bgPort_no_learn: Verify if MAC addresses are not learned on the port when the port is not a bridge port.
+- test_new_vlan_member_learn: Verify newly added VLAN members can learn.
+- test_remove_vlan_member_no_learn: Verify no MAC addresses are learned on the removed vlan member.
+- test_no_learn_invalidate_vlan: Verify no MAC addresses are learned on invalidate vlan member.
+- test_no_learn_broadcast_src: Verify broadcast mac address is learned.
+- test_no_learn_multicast_src: Verify multicast mac address is learned.
 
 ### Test steps: <!-- omit in toc --> 
 
@@ -126,9 +131,11 @@ Verify newly added VLAN members can learn.
 ## Test Group2: FDB age
 ### Case1: test_port_age
 ### Case2: test_aging_after_move
+### Case3: test_mac_moving_after_aging
 ### Testing Objective <!-- omit in toc -->
-Verifying if the dynamic FDB entry associated with the port is removed after the aging interval.
-Verifying the aging time refreshed if dynamic FDB entry associated with one port and then moved to another port (not the initial learning time)
+- test_port_age: Verifying if the dynamic FDB entry associated with the port is removed after the aging interval.
+- test_aging_after_move: Verifying the aging time refreshed if dynamic FDB entry associated with one port and then moved to another port (not the initial learning time)
+- test_mac_moving_after_aging: Verifying the mac can be learnt if the mac aging reached.
 
 
 ### Test steps: <!-- omit in toc --> 
@@ -159,6 +166,19 @@ Verifying the aging time refreshed if dynamic FDB entry associated with one port
 9. Wait for the ``aging`` time
 10. Send packet on port3
 11. Verify flooding packet to VLAN10 ports, except port1
+
+- test_mac_moving_after_aging
+
+1. Set FDB aging time=10
+2. Create Packet with SMAC=``MacX`` DMAC=``Port1 MAC`` 
+3. Send packet on port2
+4. verify only receive a packet on port1
+5. Create a packet with DMAC=``MacX``
+6. Send packet on port1
+7. Verify only receive a packet on port2
+8. Wait for the ``aging`` time
+9. Send packet on port3
+10. Verify only receive a packet on port2
 
 ## Test Group3: FDB flush
 ### Case1: test_flush_vlan_static
@@ -200,12 +220,13 @@ Verify flushing of static/dynamic entries on VLAN/Port/All.
 
 
 ## Test Group4: MAC move
-### Case1:  test_disable_move_drop
+### Case1: test_disable_move_drop
 ### Case2: test_dynamic_mac_move
 ### Case3: test_static_mac_move
 ### Testing Objective <!-- omit in toc --> 
-Verify if disable MAC move, drop packet with known SMAC, the SMAC was learned previously on other port.
-Verify when enabling MAC move, if after receiving a packet with known SMAC, but from another port that on which, it was learned previously, next packets with such DMACs are forwarded to the new port.
+- test_disable_move_drop: Verify if disable MAC move, drop packet with known SMAC if the SMAC was already learnt on other port.
+- test_dynamic_mac_move: Verify when enabling MAC move, previous learnt mac(SMAC) on a port can be learnt on other port
+- test_static_mac_move: Verify when enabling MAC move, previous installed mac(static SMAC) on a port can be set to other port
 
 ### Test steps: <!-- omit in toc --> 
 - test_disable_move_drop

--- a/doc/sai-ptf/fdb_test_plan.md
+++ b/doc/sai-ptf/fdb_test_plan.md
@@ -96,6 +96,7 @@ Verify newly added VLAN members can learn.
 6. Create a packet with DMAC ``MacX``
 7. send the packet on port2
 8. Verify the packet flood to other VLAN10 ports, including port1
+9. check FDB entries, no new entry
 
 - test_new_vlan_member_learn
 
@@ -106,6 +107,7 @@ Verify newly added VLAN members can learn.
 5. Create a packet with DMAC=``MacX``
 6. Send packet on port1
 7. Verify only receive a packet on port24
+8. check FDB entries, new entry ``MacX`` on Port24 learned
 
 - test_remove_vlan_member_learn
 
@@ -116,6 +118,7 @@ Verify newly added VLAN members can learn.
 5. Create a packet with DMAC=``MacX`` and VLAN10 tag
 6. Send packet on port1
 7. Verify flooding to VLAN10 ports, no packet on port2
+8. check FDB entries, no new entry
 
 - test_no_learn_invalidate_vlan
 - test_no_learn_broadcast_src
@@ -126,7 +129,8 @@ Verify newly added VLAN members can learn.
 3. Verify no packet was received on any port
 4. Create a packet with vlan_id=``VLAN11`` DMAC=``MacX``/DMAC=``broadcast address``/DMAC=``multicast address``
 5. Send packet on port1
-6. Flooding on all vlan10 ports, except port1
+6. Dropped for ``VLAN11``, For broadcast and multicast address, flooding on all vlan10 ports, except port1
+7. check FDB entries, no new entry
 
 
 ## Test Group2: MAC move
@@ -148,16 +152,29 @@ Verify when enabling MAC move, if after receiving a packet with known SMAC, but 
 6. Verify the packet gets dropped
 
 - test_dynamic_mac_move
+  
+1. Flush All MAC
+2. Install static FDB entry for port2 with ``Port2 MAC``
+3. Send Packet on Port1 with SMAC=``Port1 MAC`` DMAC=``Port2 MAC``
+4. Create packet with SMAC=``Port1 MAC`` DMAC=``Port2 MAC``
+5. Send packet on port1
+6. Install static mac move for ``Port1 MAC`` on Port1 and enable mac move
+7. Verify packet received on port2
+8. Send packet in step2 on port3
+9. Verify packet received on port2
+
 - test_static_mac_move
   
 1. Flush All MAC
-2. Install dynamic/static ``Port1 MAC`` address for port1
-3. Enable mac move for ``Port1 MAC`` on Port1
-4. Create packet with SMAC=``Port1 MAC`` DMAC=``Port2 MAC``
-5. Send packet on port1
-6. Verify packet received on port2
-7. Send packet in step2 on port3
-8. Verify packet received on port2
+2. Install static FDB entry for port2 with ``Port2 MAC``
+3. Install static FDB entry for port1 with ``Port1 MAC``  
+4. Enable mac move for ``Port1 MAC`` on Port1
+5. Create packet with SMAC=``Port1 MAC`` DMAC=``Port2 MAC``
+6. Send packet on port1
+7. Verify packet received on port2
+8. Install static FDB entry for port3 with ``Port1 MAC``  
+9. Send packet in step2 on port3
+10. Verify packet received on port2
 
 ## Test Group3: FDB age
 ### Case12: test_port_age

--- a/doc/sai-ptf/fdb_test_plan.md
+++ b/doc/sai-ptf/fdb_test_plan.md
@@ -13,31 +13,21 @@
     - [Case6: test_no_learn_invalidate_vlan](#case6-test_no_learn_invalidate_vlan)
     - [Case7: test_no_learn_broadcast_src](#case7-test_no_learn_broadcast_src)
     - [Case8: test_no_learn_multicast_src](#case8-test_no_learn_multicast_src)
-  - [Test Group2: MAC move](#test-group2-mac-move)
-    - [Case9:  test_disable_move_drop](#case9--test_disable_move_drop)
-    - [Case10: test_dynamic_mac_move](#case10-test_dynamic_mac_move)
-    - [Case11: test_static_mac_move](#case11-test_static_mac_move)
-  - [Test Group3: FDB age](#test-group3-fdb-age)
-    - [Case12: test_port_age](#case12-test_port_age)
-    - [Case13: test_aging_after_move](#case13-test_aging_after_move)
-  - [Test Group4: FDB flush](#test-group4-fdb-flush)
-    - [Case14: test_flush_vlan_static](#case14-test_flush_vlan_static)
-    - [Case15: test_flush_vlan_dynamic](#case15-test_flush_vlan_dynamic)
-    - [Case16: test_flush_port_static](#case16-test_flush_port_static)
-    - [Case17: test_flush_port_dynamic](#case17-test_flush_port_dynamic)
-    - [Case18: test_flush_all_static](#case18-test_flush_all_static)
-    - [Case19: test_flush_all_dynamic](#case19-test_flush_all_dynamic)
-    - [Case20: test_flush_all](#case20-test_flush_all)
-  - [Test Group5: FDB miss](#test-group5-fdb-miss)
-    - [Case21: test_unicast_action_copy](#case21-test_unicast_action_copy)
-    - [Case22: test_unicast_action_trap](#case22-test_unicast_action_trap)
-    - [Case23: test_unicast_action_drop](#case23-test_unicast_action_drop)
-    - [Case24: test_multicast_action_copy](#case24-test_multicast_action_copy)
-    - [Case25: test_multicast_action_trap](#case25-test_multicast_action_trap)
-    - [Case26: test_multicast_action_drop](#case26-test_multicast_action_drop)
-    - [Case27: test_broadcast_action_copy](#case27-test_broadcast_action_copy)
-    - [Case28: test_broadcast_action_trap](#case28-test_broadcast_action_trap)
-    - [Case29: test_broadcast_action_drop](#case29-test_broadcast_action_drop)
+  - [Test Group2: FDB age](#test-group2-fdb-age)
+    - [Case1: test_port_age](#case1-test_port_age)
+    - [Case2: test_aging_after_move](#case2-test_aging_after_move)
+  - [Test Group3: FDB flush](#test-group3-fdb-flush)
+    - [Case1: test_flush_vlan_static](#case1-test_flush_vlan_static)
+    - [Case2: test_flush_vlan_dynamic](#case2-test_flush_vlan_dynamic)
+    - [Case3: test_flush_port_static](#case3-test_flush_port_static)
+    - [Case4: test_flush_port_dynamic](#case4-test_flush_port_dynamic)
+    - [Case5: test_flush_all_static](#case5-test_flush_all_static)
+    - [Case6: test_flush_all_dynamic](#case6-test_flush_all_dynamic)
+    - [Case7: test_flush_all](#case7-test_flush_all)
+  - [Test Group4: MAC move](#test-group4-mac-move)
+    - [Case1:  test_disable_move_drop](#case1--test_disable_move_drop)
+    - [Case2: test_dynamic_mac_move](#case2-test_dynamic_mac_move)
+    - [Case3: test_static_mac_move](#case3-test_static_mac_move)
 
 # Test Configuration
 
@@ -133,10 +123,84 @@ Verify newly added VLAN members can learn.
 7. check FDB entries, no new entry
 
 
-## Test Group2: MAC move
-### Case9:  test_disable_move_drop
-### Case10: test_dynamic_mac_move
-### Case11: test_static_mac_move
+## Test Group2: FDB age
+### Case1: test_port_age
+### Case2: test_aging_after_move
+### Testing Objective <!-- omit in toc -->
+Verifying if the dynamic FDB entry associated with the port is removed after the aging interval.
+Verifying the aging time refreshed if dynamic FDB entry associated with one port and then moved to another port (not the initial learning time)
+
+
+### Test steps: <!-- omit in toc --> 
+- test_port_age
+
+1. Set FDB aging time=10
+2. Create Packet with SMAC=``MacX`` DMAC=``Port1 MAC`` 
+3. Send packet on port2
+4. verify only receive a packet on port1
+5. Create a packet with DMAC=``MacX``
+6. Send packet on port1
+7. Verify only receive a packet on port2
+8. Wait for the ``aging`` time
+9. Send packet on port1
+10. Verify flooding packet to VLAN10 ports, except port1
+
+- test_aging_after_move
+
+1. Set FDB aging time=10
+2. Create Packet with SMAC=``MacX`` DMAC=``Port1 MAC`` 
+3. Send packet on port2
+4. verify only receive a packet on port1
+5. Create a packet with DMAC=``MacX``
+6. Send packet on port1
+7. Verify only receive a packet on port2
+8. Wait for the ``aging`` time
+9. Send packet on port1
+10. Verify flooding packet to VLAN10 ports, except port1
+
+## Test Group3: FDB flush
+### Case1: test_flush_vlan_static
+### Case2: test_flush_vlan_dynamic
+### Case3: test_flush_port_static
+### Case4: test_flush_port_dynamic
+### Case5: test_flush_all_static
+### Case6: test_flush_all_dynamic
+### Case7: test_flush_all
+
+### Testing Objective <!-- omit in toc -->
+Verify flushing of static/dynamic entries on VLAN/Port/All.
+### Test steps: <!-- omit in toc --> 
+- test_flush_vlan_static
+- test_flush_port_static
+- test_flush_all_static
+
+1. Flush with conditions for each case: ``Static`` flush on ``VLAN10``; ``Static`` flush on ``Port1``; flush for all ``Static`` 
+2. Send packets for each case in sequence: ``port1`` DMAC=``Port2 MAC``; ``Port2`` DMAC=``Port1 MAC``; ``port1`` DMAC=``Port2 MAC``
+3. Verify flooding happened, packets received in related VLAN, except the ingress port.
+4. Send packets for each case in sequence:  ``Port9`` DMAC=``Port10 MAC``; ``Port10`` DMAC=``Port9 MAC``; `  ``Port9`` DMAC=``Port10 MAC``
+5. Verify flush happens in a certain domain, unicast to the corresponding port.
+
+- test_flush_vlan_dynamic
+- test_flush_port_dynamic
+- test_flush_all_dynamic
+  
+1. Flush with conditions for each case in sequence: ``Dynamic`` flush on ``VLAN20``;  ``Dynamic`` flush on ``Port9``; flush for all ``Dynamic`` 
+2. Send packets for each case in sequence: ``Port9`` DMAC=``Port10 MAC``;  ``Port10`` DMAC=``Port9 MAC``; ``Port9`` DMAC=``Port10 MAC``
+3. Verify flooding happened, packets received in related VLAN, except the ingress port.
+4. Send packets for each case in sequence:  ``port1`` DMAC=``Port2 MAC``;``Port2`` DMAC=``Port1 MAC``; ``port1`` DMAC=``Port2 MAC``;
+5.  Verify flush happens in a certain domain, unicast to the corresponding port.
+
+- test_flush_all
+
+1. Flush with conditions: flush for ``All``
+2. Send packets : ``port1`` DMAC=``Port2 MAC``; ``Port9`` DMAC=``Port10 MAC``; 
+3. Verify flooding happened, packets received in related VLAN, except the ingress port.
+
+
+## Test Group4: MAC move
+### Case1:  test_disable_move_drop
+### Case2: test_dynamic_mac_move
+### Case3: test_static_mac_move
 ### Testing Objective <!-- omit in toc --> 
 Verify if disable MAC move, drop packet with known SMAC, the SMAC was learned previously on other port.
 Verify when enabling MAC move, if after receiving a packet with known SMAC, but from another port that on which, it was learned previously, next packets with such DMACs are forwarded to the new port.
@@ -175,122 +239,3 @@ Verify when enabling MAC move, if after receiving a packet with known SMAC, but 
 8. Install static FDB entry for port3 with ``Port1 MAC``  
 9. Send packet in step2 on port3
 10. Verify packet received on port2
-
-## Test Group3: FDB age
-### Case12: test_port_age
-### Case13: test_aging_after_move
-### Testing Objective <!-- omit in toc -->
-Verifying if the dynamic FDB entry associated with the port is removed after the aging interval.
-Verifying the aging time refreshed if dynamic FDB entry associated with one port and then moved to another port (not the initial learning time)
-
-
-### Test steps: <!-- omit in toc --> 
-- test_port_age
-
-1. Set FDB aging time=10
-2. Create Packet with SMAC=``MacX`` DMAC=``Port1 MAC`` 
-3. Send packet on port2
-4. verify only receive a packet on port1
-5. Create a packet with DMAC=``MacX``
-6. Send packet on port1
-7. Verify only receive a packet on port2
-8. Wait for the ``aging`` time
-9. Send packet on port1
-10. Verify flooding packet to VLAN10 ports, except port1
-
-- test_aging_after_move
-
-1. Set FDB aging time=10
-2. Create Packet with SMAC=``MacX`` DMAC=``Port1 MAC`` 
-3. Send packet on port2
-4. verify only receive a packet on port1
-5. Create a packet with DMAC=``MacX``
-6. Send packet on port1
-7. Verify only receive a packet on port2
-8. Wait for the ``aging`` time
-9. Send packet on port1
-10. Verify flooding packet to VLAN10 ports, except port1
-
-## Test Group4: FDB flush
-### Case14: test_flush_vlan_static
-### Case15: test_flush_vlan_dynamic
-### Case16: test_flush_port_static
-### Case17: test_flush_port_dynamic
-### Case18: test_flush_all_static
-### Case19: test_flush_all_dynamic
-### Case20: test_flush_all
-
-### Testing Objective <!-- omit in toc -->
-Verify flushing of static/dynamic entries on VLAN/Port/All.
-### Test steps: <!-- omit in toc --> 
-- test_flush_vlan_static
-- test_flush_port_static
-- test_flush_all_static
-
-1. Flush with conditions for each case: ``Static`` flush on ``VLAN10``; ``Static`` flush on ``Port1``; flush for all ``Static`` 
-2. Send packets for each case in sequence: ``port1`` DMAC=``Port2 MAC``; ``Port2`` DMAC=``Port1 MAC``; ``port1`` DMAC=``Port2 MAC``
-3. Verify flooding happened, packets received in related VLAN, except the ingress port.
-4. Send packets for each case in sequence:  ``Port9`` DMAC=``Port10 MAC``; ``Port10`` DMAC=``Port9 MAC``; `  ``Port9`` DMAC=``Port10 MAC``
-5. Verify flush happens in a certain domain, unicast to the corresponding port.
-
-- test_flush_vlan_dynamic
-- test_flush_port_dynamic
-- test_flush_all_dynamic
-  
-1. Flush with conditions for each case in sequence: ``Dynamic`` flush on ``VLAN20``;  ``Dynamic`` flush on ``Port9``; flush for all ``Dynamic`` 
-2. Send packets for each case in sequence: ``Port9`` DMAC=``Port10 MAC``;  ``Port10`` DMAC=``Port9 MAC``; ``Port9`` DMAC=``Port10 MAC``
-3. Verify flooding happened, packets received in related VLAN, except the ingress port.
-4. Send packets for each case in sequence:  ``port1`` DMAC=``Port2 MAC``;``Port2`` DMAC=``Port1 MAC``; ``port1`` DMAC=``Port2 MAC``;
-5.  Verify flush happens in a certain domain, unicast to the corresponding port.
-
-- test_flush_all
-
-1. Flush with conditions: flush for ``All``
-2. Send packets : ``port1`` DMAC=``Port2 MAC``; ``Port9`` DMAC=``Port10 MAC``; 
-3. Verify flooding happened, packets received in related VLAN, except the ingress port.
-
-## Test Group5: FDB miss
-### Case21: test_unicast_action_copy
-### Case22: test_unicast_action_trap
-### Case23: test_unicast_action_drop
-### Case24: test_multicast_action_copy
-### Case25: test_multicast_action_trap
-### Case26: test_multicast_action_drop
-### Case27: test_broadcast_action_copy
-### Case28: test_broadcast_action_trap
-### Case29: test_broadcast_action_drop
-
-### Testing Objective <!-- omit in toc --> 
-Verify if unicast/multicast/broadcast packets are dropped or redirected/copy to the CPU after setting miss packet action to drop, trap or copy.
-
-### Test steps: <!-- omit in toc --> 
-- test_unicast_action_drop
-- test_multicast_action_drop
-- test_broadcast_action_drop
-
-1. Set the FDB unicast/multicast/broadcast missing action to SAI_PACKET_ACTION_DROP 
-2. Create a packet with DMAC as unknown ``MacX``, ``Multicase MAC`` or ``Broadcast MAC`` for each case
-3. Send the packet to port1
-4. Verify the packet gets dropped
-
-- test_unicast_action_trap
-- test_multicast_action_trap
-- test_broadcast_action_trap
-
-1. Set the FDB unicast/multicast/broadcast missing action to SAI_PACKET_ACTION_TRAP 
-2. Create a packet with DMAC as unknown ``MacX``, ``Multicase MAC`` or ``Broadcast MAC`` for each case
-3. Get the queue0 status SAI_QUEUE_STAT_PACKETS
-4. Send the packet on port1
-5. Verify the packet gets dropped
-6. Check the SAI_QUEUE_STAT_PACKETS increased by 1
-
-- test_unicast_action_copy
-- test_multicast_action_copy
-- test_broadcast_action_copy
-
-1. Set the FDB unicast/multicast/broadcast missing action to SAI_PACKET_ACTION_TRAP 
-2. Create a packet with DMAC as unknown ``MacX``, ``Multicase MAC`` or ``Broadcast MAC`` for each case
-3. Get the queue0 status SAI_QUEUE_STAT_PACKETS
-4. Send the packet on port1
-5. Verify the packet flooding to vlan10 ports, except port1
-6. Check the SAI_QUEUE_STAT_PACKETS increased by 1

--- a/doc/sai-ptf/fdb_test_plan.md
+++ b/doc/sai-ptf/fdb_test_plan.md
@@ -73,7 +73,7 @@ In this FDB test, the example packet structure is below.
 - test_non_bgPort_no_learn: Verify if MAC addresses are not learned on the port when the port is not a bridge port.
 - test_new_vlan_member_learn: Verify newly added VLAN members can learn.
 - test_remove_vlan_member_no_learn: Verify no MAC addresses are learned on the removed vlan member.
-- test_no_learn_invalidate_vlan: Verify no MAC addresses are learned on invalidate vlan member.
+- test_no_learn_invalidate_vlan: Verify no MAC addresses are learned on invalidate vlan ID.
 - test_no_learn_broadcast_src: Verify broadcast mac address is learned.
 - test_no_learn_multicast_src: Verify multicast mac address is learned.
 
@@ -135,7 +135,7 @@ In this FDB test, the example packet structure is below.
 ### Testing Objective <!-- omit in toc -->
 - test_port_age: Verifying if the dynamic FDB entry associated with the port is removed after the aging interval.
 - test_aging_after_move: Verifying the aging time refreshed if dynamic FDB entry associated with one port and then moved to another port (not the initial learning time)
-- test_mac_moving_after_aging: Verifying the mac can be learnt if the mac aging reached.
+- test_mac_moving_after_aging: Verifying the mac can be learnt again after the mac aging reached.
 
 
 ### Test steps: <!-- omit in toc --> 

--- a/doc/sai-ptf/fdb_test_plan.md
+++ b/doc/sai-ptf/fdb_test_plan.md
@@ -279,7 +279,7 @@ Verify if unicast/multicast/broadcast packets are dropped or redirected/copy to 
 
 1. Set the FDB unicast/multicast/broadcast missing action to SAI_PACKET_ACTION_TRAP 
 2. Create a packet with DMAC as unknown ``MacX``, ``Multicase MAC`` or ``Broadcast MAC`` for each case
-3. Get the queue status SAI_QUEUE_STAT_PACKETS
+3. Get the queue0 status SAI_QUEUE_STAT_PACKETS
 4. Send the packet on port1
 5. Verify the packet gets dropped
 6. Check the SAI_QUEUE_STAT_PACKETS increased by 1
@@ -290,7 +290,7 @@ Verify if unicast/multicast/broadcast packets are dropped or redirected/copy to 
 
 1. Set the FDB unicast/multicast/broadcast missing action to SAI_PACKET_ACTION_TRAP 
 2. Create a packet with DMAC as unknown ``MacX``, ``Multicase MAC`` or ``Broadcast MAC`` for each case
-3. Get the queue status SAI_QUEUE_STAT_PACKETS
+3. Get the queue0 status SAI_QUEUE_STAT_PACKETS
 4. Send the packet on port1
 5. Verify the packet flooding to vlan10 ports, except port1
 6. Check the SAI_QUEUE_STAT_PACKETS increased by 1


### PR DESCRIPTION
Add FDB test plan.
It includes:
Test Group1: MAC learning
Case1: test_vlan_port_learn_disable
Case2: test_bg_port_learn_disable
Case3: test_non_bgPort_no_learn
Case4: test_new_vlan_member_learn
Case5: test_remove_vlan_member_no_learn
Case6: test_no_learn_invalidate_vlan
Case7: test_no_learn_broadcast_src
Case8: test_no_learn_multicast_src
Test Group2: FDB age
Case1: test_port_age
Case2: test_aging_after_move
Test Group3: FDB flush
Case1: test_flush_vlan_static
Case2: test_flush_vlan_dynamic
Case3: test_flush_port_static
Case4: test_flush_port_dynamic
Case5: test_flush_all_static
Case6: test_flush_all_dynamic
Case7: test_flush_all
Test Group4: MAC move
Case1: test_disable_move_drop
Case2: test_dynamic_mac_move
Case3: test_static_mac_move