### PR TITLE
Distributed HW resource management infrastructure

### DIFF
--- a/doc/SAI-Proposal-HW-Resource.md
+++ b/doc/SAI-Proposal-HW-Resource.md
@@ -152,7 +152,7 @@ New workflow will identify if a given trap is applicable to ingress/egress/both.
 
 4. Create hostif trap for ingress stage
     sai_object_id_t trap_id;
-    sai_attribute_t trap_attrs[3];
+    sai_attribute_t trap_attrs[2];
 
     trap_attrs[0].id =
         (sai_attr_id_t) SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE;
@@ -160,18 +160,13 @@ New workflow will identify if a given trap is applicable to ingress/egress/both.
         SAI_HOSTIF_TRAP_TYPE_DNAT_MISS;
         
     trap_attrs[1].id =
-        (sai_attr_id_t) SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE;
-    trap_attrs[1].value =
-        SAI_HOSTIF_TRAP_TYPE_NAT_HAIRPIN;
-        
-    trap_attrs[2].id =
         (sai_attr_id_t)SAI_HOSTIF_TRAP_ATTR_TRAP_GROUP;
-    trap_attrs[2].value.oid =
+    trap_attrs[1].value.oid =
         trap_group_id;
 
     sai_hostif_trap_api->create_hostif_trap(
         &trap_id,
-        3,
+        2,
         trap_attrs);
 ```
 

--- a/doc/SAI-Proposal-HW-Resource.md
+++ b/doc/SAI-Proposal-HW-Resource.md
@@ -29,10 +29,22 @@ New data type sai_object_stage_t is introduced. This data type specifies if a re
 
 ## Capability Query
 ----------------
-Capability query API is enhanced with a query for attribute stage.NOS can query the attribute for a given HW support
+New  query API is introduced for an attribute's stage. NOS can query the stage of an object's attribute for a given HW support. One of the following stage is returned as part the API
+- SAI_ATTR_STAGE_NA: Stage is not applicable
 - SAI_ATTR_STAGE_BOTH: Attribute is common to ingress and egress stage
 - SAI_ATTR_STAGE_INGRESS: Attribute is applicable only to ingress stage
 - SAI_ATTR_STAGE_EGRESS: Attribute is applicabe only to egress stage
+
+Length of the returned array "stage" is attr_count. Caller must provide the buffer for array "stage".
+ 
+```
+sai_status_t sai_query_object_stage(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list,
+        _Out_ sai_object_stage_t *stage);
+```
 
 ## HOSTIF Trap Group
 -----------------

--- a/doc/SAI-Proposal-HW-Resource.md
+++ b/doc/SAI-Proposal-HW-Resource.md
@@ -91,9 +91,9 @@ New workflow will identify if a given trap is applicable to ingress/egress/both.
     trap_attrs[0].value.s32 = 
         SAI_HOSTIF_TRAP_TYPE_DNAT_MISS;
     
-    trap_attrs[2].id = 
+    trap_attrs[1].id = 
         SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE;
-    trap_attrs[2].value.s32 = 
+    trap_attrs[1].value.s32 = 
         SAI_HOSTIF_TRAP_TYPE_NAT_HAIRPIN;  
     
     sai_status_t sai_query_object_stage(

--- a/doc/SAI-Proposal-HW-Resource.md
+++ b/doc/SAI-Proposal-HW-Resource.md
@@ -1,0 +1,155 @@
+SAI Infra for distributed HW resource management
+-------------------------------------------------------------------------------
+ Title       | SAI distributed HW resource management
+-------------|-----------------------------------------------------------------
+ Authors     | Jai Kumar, Broadcom Inc.
+ Status      | In review
+ Type        | Standards track
+ Created     | 07/08/2022: Initial Draft
+ SAI-Version | 1.9
+-------------------------------------------------------------------------------
+
+Modern chips have distributed architecture where HW resources are split between ingress and egress stages of the pipleine for scaling and performance reasons.
+
+PR #1482 introduces a method to
+1. Specify the stage of a resource
+2. Query an object's attribute stage for a given HW using capability API
+3. Error handling for incorrect resource stage specification
+
+## Common Data Type
+-----------------
+New data type sai_object_stage_t is introduced. This data type specifies if a resource is of type
+
+- SAI_OBJECT_STAGE_BOTH:
+  Resource is a common shared resource between ingress and egress HW pipeline
+- SAI_OBJECT_STAGE_INGRESS:
+  Resource belongs to ingress stage of HW pipeline
+- SAI_OBJECT_STAGE_EGRESS:
+  Resource belongs to egress stage of HW pipeline
+
+## Capability Query
+----------------
+Capability query API is enhanced with a query for attribute stage.NOS can query the attribute for a given HW support
+- SAI_ATTR_STAGE_BOTH: Attribute is common to ingress and egress stage
+- SAI_ATTR_STAGE_INGRESS: Attribute is applicable only to ingress stage
+- SAI_ATTR_STAGE_EGRESS: Attribute is applicabe only to egress stage
+
+## HOSTIF Trap Group
+-----------------
+A new CREATE_ONLY trap group attribute is introduced. NOS can set this attribute to specify the stage of the trap group.
+- SAI_HOTIF_TRAP_GROUP_ATTR_OBJECT_STAGE: 
+CREATE_ONLY attribute to configure a trap group of type stage ingress/egress/both
+
+## Policer Pool
+------------
+A new CREATE_ONLY policer attribute is introduced. NOS can set this attribute
+to specify the stage of the pool.
+- SAI_POLICER_ATTR_STAGE:
+  CREATE_ONLY attribute that specifies the stage of the policer pool. Default is kept as SAI_STAGE_BOTH common pool for backward compatibility.
+
+## Example
+-------
+Hostif trap's are implemented as an ingress or egress pipeline stage based on a HW architecture. In this example workflow, a hostif trap capability is queried. Based on returned value, appropriate trap group and policer pool is assigned to it. For e.g. a trap of type ingress will be assigned a trap group of type ingress using an ingress policer pool.
+
+## Sample Existing Workflow
+------------------------
+There is no concept of stages in this workflow.
+By default this trap is created in SAI_SWITCH_ATTR_DEFAULT_TRAP_GROUP trap group.
+
+```
+1. create_hostif_trap_group()
+2. create_hostif_trap(): 
+    By default this trap is created in 
+    SAI_SWITCH_ATTR_DEFAULT_TRAP_GROUP trap group.
+or
+2. create_hostif_trap():
+    For trap group created in step 1.
+3. create_policer()
+4. Attach policer to the trap using set of 
+    SAI_HOSTIF_TRAP_GROUP_ATTR_POLICER attribute.
+```
+
+### Sample New Workflow
+-------------------
+New workflow will identify if a given trap is applicable to ingress/egress/both. This will be done based on the enhanced capability query API.
+```
+1. Query the HW capability for a given trap
+    sai_status_t sai_query_attribute_capability(
+        switch_id,
+        SAI_OBJECT_TYPE_HOSTIF_TRAP,
+        SAI_HOSTIF_TRAP_TYPE_DNAT_MISS,
+        attr_capability);
+
+    SAI adapter will fill attr_capability->attr_stage with appropriate HW pipeline stage where this trap is handled. Lets say give HW supports this attribute in ingress pipeline and will return SAI_ATTR_STAGE_INGRESS as the attr_stage value.
+
+2. Create a policer pool for ingress stage
+    sai_object_id_t ingress_policer_id;
+    sai_attribute_t ingress_policer_attrs[2];
+
+    ingress_policer_attrs[0].id =
+        (sai_attr_id_t)SAI_POLICER_ATTR_METER_TYPE;
+    ingress_policer_attrs[0].value =
+        SAI_METER_TYPE_PACKETS;
+
+    ingress_policer_attrs[1].id =
+        (sai_attr_id_t)SAI_POLICER_ATTR_OBJECT_STAGE;
+    ingress_policer_attrs[1].value =
+        SAI_OBJECT_STAGE_INGRESS;
+
+    sai_hostif_trap_api->create_policer(
+        &ingress_policer_id,
+        2,
+        ingress_policer_attrs);
+
+3. Create a hostif trap group for ingress stage
+    sai_object_id_t trap_group_id;
+    sai_attribute_t trap_group_attrs[3];
+
+    trap_group_attrs[0].id =
+        (sai_attr_id_t)SAI_HOSTIF_TRAP_GROUP_ATTR_QUEUE;
+    trap_group_attrs[0].value.u32 =
+        0x10;
+
+    trap_group_attrs[1].id =
+        (sai_attr_id_t)SAI_HOSTIF_TRAP_GROUP_ATTR_POLICER,
+    trap_group_attrs[1].value.oid =
+        ingress_policer_id;
+
+    trap_group_attrs[2].id =
+        (sai_attr_id_t)SAI_HOSTIF_TRAP_GROUP_ATTR_OBJECT_STAGE,
+    trap_group_attrs[2].value =
+        SAI_OBJECT_STAGE_INGRESS;
+
+    sai_hostif_trap_group_api->create_hostif_trap_group(
+        &trap_group_id,
+        3,
+        trap_group_attrs);
+
+4. Create hostif trap for ingress stage
+    sai_object_id_t trap_id;
+    sai_attribute_t trap_attrs[2];
+
+    trap_attrs[0].id =
+        (sai_attr_id_t) SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE;
+    trap_attrs[0].value =
+        SAI_HOSTIF_TRAP_TYPE_DNAT_MISS;
+
+    trap_attrs[1].id =
+        (sai_attr_id_t)SAI_HOSTIF_TRAP_ATTR_TRAP_GROUP;
+    trap_attrs[1].value.oid =
+        trap_group_id;
+
+    sai_hostif_trap_api->create_hostif_trap(
+        &trap_id,
+        2,
+        trap_attrs);
+```
+
+### Error Handling
+--------------
+New error codepoint SAI_STATUS_MISMATCH is introduced. SAI adapter must 
+return this error status if there is a mismatch between trap group, trap 
+and policer pool.
+- If trap group and trap type is of different stage e.g. trap group is of 
+  SAI_OBJECT_STAGE_INGRESS and trap capability is SAI_ATTR_STAGE_EGRESS
+- If trap group and policer pool is of different stage

--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -90,6 +90,15 @@ typedef enum _sai_hostif_trap_group_attr_t
     SAI_HOSTIF_TRAP_GROUP_ATTR_POLICER,
 
     /**
+     * @brief Hostif trap group object stage
+     *
+     * @type sai_object_stage_t
+     * @flags CREATE_ONLY
+     * @default SAI_OBJECT_STAGE_BOTH
+     */
+    SAI_HOSTIF_TRAP_GROUP_ATTR_OBJECT_STAGE,
+
+    /**
      * @brief End of attributes
      */
     SAI_HOSTIF_TRAP_GROUP_ATTR_END,

--- a/inc/saiobject.h
+++ b/inc/saiobject.h
@@ -102,22 +102,6 @@ typedef struct _sai_object_key_t
 
 } sai_object_key_t;
 
-typedef enum _sai_attr_stage_t
-{
-    /** Not applicable */
-    SAI_ATTR_STAGE_NA,
-
-    /** Common stage */
-    SAI_ATTR_STAGE_BOTH,
-
-    /** Ingress stage */
-    SAI_ATTR_STAGE_INGRESS,
-
-    /** Egress stage */
-    SAI_ATTR_STAGE_EGRESS
-
-} sai_attr_stage_t;
-
 /**
  * @brief Structure for attribute capabilities per operation
  */

--- a/inc/saiobject.h
+++ b/inc/saiobject.h
@@ -102,6 +102,22 @@ typedef struct _sai_object_key_t
 
 } sai_object_key_t;
 
+typedef enum _sai_attr_stage_t
+{
+    /** Not applicable */
+    SAI_ATTR_STAGE_NA,
+
+    /** Common stage */
+    SAI_ATTR_STAGE_BOTH,
+
+    /** Ingress stage */
+    SAI_ATTR_STAGE_INGRESS,
+
+    /** Egress stage */
+    SAI_ATTR_STAGE_EGRESS
+
+} sai_attr_stage_t;
+
 /**
  * @brief Structure for attribute capabilities per operation
  */
@@ -121,6 +137,11 @@ typedef struct _sai_attr_capability_t
      * @brief Get is implemented
      */
     bool get_implemented;
+
+    /**
+     * @brief Attribute stage if applicable
+     */
+    sai_attr_stage_t attr_stage;
 } sai_attr_capability_t;
 
 /**

--- a/inc/saiobject.h
+++ b/inc/saiobject.h
@@ -138,10 +138,6 @@ typedef struct _sai_attr_capability_t
      */
     bool get_implemented;
 
-    /**
-     * @brief Attribute stage if applicable
-     */
-    sai_attr_stage_t attr_stage;
 } sai_attr_capability_t;
 
 /**
@@ -326,6 +322,24 @@ sai_status_t sai_bulk_object_clear_stats(
         _In_ const sai_stat_id_t *counter_ids,
         _In_ sai_stats_mode_t mode,
         _Inout_ sai_status_t *object_statuses);
+
+/**
+ * @brief Query the HW stage of an attribute for the specified object type
+ *
+ * @param[in] switch_id SAI Switch object id
+ * @param[in] object_type SAI object type
+ * @param[in] attr_count Count of attributes
+ * @param[in] attr_list List of attributes
+ * @param[out] stage HW stage of the attributes. Length of the array should be attr_count. Caller must allocate the buffer.
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+sai_status_t sai_query_object_stage(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_object_type_t object_type,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list,
+        _Out_ sai_object_stage_t *stage);
 
 /**
  * @}

--- a/inc/saipolicer.h
+++ b/inc/saipolicer.h
@@ -201,6 +201,15 @@ typedef enum _sai_policer_attr_t
     SAI_POLICER_ATTR_ENABLE_COUNTER_PACKET_ACTION_LIST = 0x0000000a,
 
     /**
+     * @brief Policer pool stage
+     *
+     * @type sai_object_stage_t
+     * @flags CREATE_ONLY
+     * @default SAI_OBJECT_STAGE_BOTH
+     */
+    SAI_POLICER_ATTR_OBJECT_STAGE = 0x0000000b,
+
+    /**
      * @brief End of attributes
      */
     SAI_POLICER_ATTR_END,

--- a/inc/saistatus.h
+++ b/inc/saistatus.h
@@ -174,6 +174,11 @@
 #define SAI_STATUS_NOT_EXECUTED                     SAI_STATUS_CODE(0x00000017L)
 
 /**
+ * @brief Object pipeline stage mismatch
+ */
+#define SAI_STATUS_STAGE_MISMATCH                   SAI_STATUS_CODE(0x00000018L)
+
+/**
  * @brief Attribute is invalid
  *
  * Range from 0x00010000L to 0x0001FFFFL.

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1486,6 +1486,19 @@ typedef struct _sai_stat_capability_list_t
 
 } sai_stat_capability_list_t;
 
+typedef enum _sai_object_stage_t
+{
+    /** Common stage */
+    SAI_OBJECT_STAGE_BOTH,
+
+    /** Ingress stage */
+    SAI_OBJECT_STAGE_INGRESS,
+
+    /** Egress stage */
+    SAI_OBJECT_STAGE_EGRESS
+
+} sai_object_stage_t;
+
 /**
  * @}
  */


### PR DESCRIPTION
This PR introduces an infrastructure to be able to query the HW resource for its ingress, egress or both stages i.e. that if physical resource belongs to ingress pipeline, egress pipeline or is a shared resource across ingress/egress stages of pipeline.

Additionally hostif trap group and policer pool object is enhancement with an attribute to specific which stage of the pipeline trap group and/or policer pool belongs.

For details and sample workflow please refer to the spec.