### PR TITLE
[meta] Add test to verify if vendor implemented all global apis

### DIFF
--- a/meta/Makefile
+++ b/meta/Makefile
@@ -86,6 +86,10 @@ all: toolsversions saisanitycheck saimetadatatest saiserializetest saidepgraph.s
 	./saiserializetest >/dev/null
 	./saisanitycheck
 
+apitest: saimetadatatest.c
+	$(CC) -o apitest saimetadatatest.c -DAPI_IMPLEMENTED_TEST -lsai $(CFLAGS) $(OBJ)
+	./apitest
+
 toolsversions:
 	@make -v | grep -i make
 	@$(CC) --version | grep gcc

--- a/meta/test.pm
+++ b/meta/test.pm
@@ -530,6 +530,31 @@ sub CreateStatEnumTest
     WriteTest "}";
 }
 
+sub CreateApiImplementedTest
+{
+    # make sure that all apis are implemented in vendor library
+
+    DefineTestName "api_implemented";
+
+    WriteTest "{";
+
+    WriteTest "#ifdef API_IMPLEMENTED_TEST";
+
+    for my $name (sort keys %main::GLOBAL_APIS)
+    {
+        my $type = $main::GLOBAL_APIS{$name}{type};
+
+        # link will fail if one of below apis is not implemented and exported in vendor sai library
+
+        WriteTest "    ${name}_fn var_$name = &$name;";
+        WriteTest "    PP(var_$name);";
+    }
+
+    WriteTest "#endif";
+
+    WriteTest "}";
+}
+
 sub WriteTestHeader
 {
     #
@@ -617,6 +642,8 @@ sub CreateTests
     CreateSerializeUnionsTest();
 
     CreateStatEnumTest();
+
+    CreateApiImplementedTest();
 
     CreatePragmaPop();
 


### PR DESCRIPTION
Typing "make apitest" will force to link -lsai library, later on
this could be updated to be a specified perameter for convinience