### PR TITLE
[SAI Test] Add lag test

### DIFF
--- a/test/sai_test/config/route_configer.py
+++ b/test/sai_test/config/route_configer.py
@@ -34,17 +34,10 @@ def t0_route_config_helper(test_obj, is_create_route=True, is_create_route_for_l
             port_id=test_obj.lag1.lag_id,
             virtual_router_id=test_obj.default_vrf)
 
-
         route_configer.create_route_and_neighbor_entry_for_port(ip_addr=test_obj.lag2_ip,
             mac_addr=test_obj.lag2_nb_mac,
             port_id=test_obj.lag2.lag_id,
             virtual_router_id=test_obj.default_vrf)
-
-        route_configer.create_route_and_neighbor_entry_for_port(ip_addr=test_obj.local_server_ip_list[1], 
-            mac_addr=test_obj.local_server_mac_list[1],
-            port_id=test_obj.port_list[1],
-            virtual_router_id=test_obj.default_vrf)
-
 
 class RouteConfiger(object):
     """

--- a/test/sai_test/config/route_configer.py
+++ b/test/sai_test/config/route_configer.py
@@ -21,26 +21,28 @@
 
 from sai_thrift.sai_adapter import *
 from sai_utils import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+from constant import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
 def t0_route_config_helper(test_obj, is_create_route=True, is_create_route_for_lag=True):
     route_configer = RouteConfiger(test_obj)
-
     if is_create_route:
         route_configer.create_default_route()
 
     if is_create_route_for_lag:
-        ip_addr1 = '10.10.10.0'
-        mac_addr1 = '02:04:02:01:01:01'
-        route_configer.create_route_and_neighbor_entry_for_port(ip_addr=ip_addr1, 
-            mac_addr=mac_addr1, 
-            port_id=test_obj.lag1.lag_id, 
+        route_configer.create_route_and_neighbor_entry_for_port(ip_addr=test_obj.lag1_ip,
+            mac_addr=test_obj.lag1_nb_mac,
+            port_id=test_obj.lag1.lag_id,
             virtual_router_id=test_obj.default_vrf)
 
-        ip_addr2 = '10.1.2.100'
-        mac_addr2 = '02:04:02:01:02:01'
-        route_configer.create_route_and_neighbor_entry_for_port(ip_addr=ip_addr1, 
-            mac_addr=mac_addr2, 
-            port_id=test_obj.lag2.lag_id, 
+
+        route_configer.create_route_and_neighbor_entry_for_port(ip_addr=test_obj.lag2_ip,
+            mac_addr=test_obj.lag2_nb_mac,
+            port_id=test_obj.lag2.lag_id,
+            virtual_router_id=test_obj.default_vrf)
+
+        route_configer.create_route_and_neighbor_entry_for_port(ip_addr=test_obj.local_server_ip_list[1], 
+            mac_addr=test_obj.local_server_mac_list[1],
+            port_id=test_obj.port_list[1],
             virtual_router_id=test_obj.default_vrf)
 
 

--- a/test/sai_test/constant.py
+++ b/test/sai_test/constant.py
@@ -40,3 +40,7 @@ THRIFT_PORT = 9092
 
 FDB_SERVER_NUM = '99'
 """Stand for the server in the fdb"""
+
+SERVER_IP_PREFIX = '192.168.{}.{}'
+T0_IP_PREFIX = '10.0.{}.{}'
+T1_IP_PREFIX = '10.1.{}.{}'

--- a/test/sai_test/sai_lag_test.py
+++ b/test/sai_test/sai_lag_test.py
@@ -17,9 +17,10 @@
 #    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
 #
 #
-
+from unittest import skip
 from sai_test_base import T0TestBase
 from sai_utils import *
+
 
 class LagConfigTest(T0TestBase):
     """
@@ -33,39 +34,38 @@ class LagConfigTest(T0TestBase):
         T0TestBase.setUp(self)
 
     def load_balance_on_src_ip(self):
-        sai_thrift_create_router_interface(self.client, virtual_router_id=self.default_vrf, type=SAI_ROUTER_INTERFACE_TYPE_PORT, port_id=self.port_list[21])
-        router_mac = '00:77:66:55:44:00'
-        ip_src1 = '192.168.0.1'
-        ip_src2 = '192.168.0.2'
-        ip_dst = '10.10.10.1'
-        pkt1 = simple_tcp_packet(eth_dst=router_mac,
-                                 eth_src='00:22:22:22:22:22',
+        sai_thrift_create_router_interface(self.client,
+                                           virtual_router_id=self.default_vrf,
+                                           type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                           port_id=self.port_list[1])
+        ip_dst = self.lag1_ip
+        pkt1 = simple_tcp_packet(eth_dst=self.router_mac,
+                                 eth_src=self.local_server_mac_list[1],
                                  ip_dst=ip_dst,
-                                 ip_src=ip_src1,
+                                 ip_src=self.local_server_ip_list[1],
                                  ip_id=105,
                                  ip_ttl=64)
-        pkt2 = simple_tcp_packet(eth_dst=router_mac,
-                                 eth_src='00:22:22:22:22:22',
+        pkt2 = simple_tcp_packet(eth_dst=self.router_mac,
+                                 eth_src=self.local_server_mac_list[2],
                                  ip_dst=ip_dst,
-                                 ip_src=ip_src2,
+                                 ip_src=self.local_server_ip_list[2],
                                  ip_id=105,
                                  ip_ttl=64)
-        exp_pkt1 = simple_tcp_packet(eth_dst='02:04:02:01:01:01',
-                                    eth_src=router_mac,
-                                    ip_dst=ip_dst,
-                                    ip_src=ip_src1,
-                                    ip_id=105,
-                                    ip_ttl=63)
-        exp_pkt2 = simple_tcp_packet(eth_dst='02:04:02:01:01:01',
-                                    eth_src=router_mac,
-                                    ip_dst=ip_dst,
-                                    ip_src=ip_src2,
-                                    ip_id=105,
-                                    ip_ttl=63)
-        
-        send_packet(self, 21, pkt1)
+        exp_pkt1 = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
+                                     eth_src=self.router_mac,
+                                     ip_dst=ip_dst,
+                                     ip_src=self.local_server_ip_list[1],
+                                     ip_id=105,
+                                     ip_ttl=63)
+        exp_pkt2 = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
+                                     eth_src=self.router_mac,
+                                     ip_dst=ip_dst,
+                                     ip_src=self.local_server_ip_list[2],
+                                     ip_id=105,
+                                     ip_ttl=63)
+        send_packet(self, 1, pkt1)
         verify_packet_any_port(self, exp_pkt1, [17, 18])
-        send_packet(self, 21, pkt2)
+        send_packet(self, 1, pkt2)
         verify_packet_any_port(self, exp_pkt2, [17, 18])
 
     def runTest(self):
@@ -74,44 +74,281 @@ class LagConfigTest(T0TestBase):
         finally:
             pass
 
+
 class LoadbalanceOnSrcPortTest(T0TestBase):
     """
     Test load balance of l3 by source port.
     """
+
     def setUp(self):
+        """
+        Test the basic setup process
+        """
         T0TestBase.setUp(self)
 
     def runTest(self):
+        """
+        1. Create router interface
+        2. Generate different packets by updating src port
+        3. send these packets on port 1
+        4. Check if packets are received on ports of lag1 equally.
+        """
         try:
             print("Lag l3 load balancing test based on src port")
-            sai_thrift_create_router_interface(self.client, virtual_router_id=self.default_vrf, type=SAI_ROUTER_INTERFACE_TYPE_PORT, port_id=self.port_list[21])
-            eth_src = '00:22:22:22:22:22'
-            eth_dst = '00:77:66:55:44:00'
-            ip_src = '192.168.0.1'
-            ip_dst = '10.10.10.1'
-
+            sai_thrift_create_router_interface(self.client,
+                                               virtual_router_id=self.default_vrf,
+                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                               port_id=self.port_list[1])
             max_itrs = 150
             begin_port = 2000
             rcv_count = [0, 0]
             for i in range(0, max_itrs):
                 src_port = begin_port + i
-                pkt = simple_tcp_packet(eth_dst=eth_dst,
-                                        eth_src=eth_src,
-                                        ip_dst=ip_dst,
-                                        ip_src=ip_src,
+                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                                        eth_src=self.local_server_mac_list[1],
+                                        ip_dst=self.lag1_ip,
+                                        ip_src=self.local_server_ip_list[1],
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst='02:04:02:01:01:01',
-                                        eth_src=eth_dst,
-                                        ip_dst=ip_dst,
-                                        ip_src=ip_src,
-                                        tcp_sport=src_port,
-                                        ip_id=105,
-                                        ip_ttl=63)                                                            
-                send_packet(self, 21, pkt)
+                exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
+                                            eth_src=self.router_mac,
+                                            ip_dst=self.lag1_ip,
+                                            ip_src=self.local_server_ip_list[1],
+                                            tcp_sport=src_port,
+                                            ip_id=105,
+                                            ip_ttl=63)                                                    
+                send_packet(self, 1, pkt)
                 rcv_idx, _ = verify_packet_any_port(self, exp_pkt, [17, 18])
                 print('src_port={}, rcv_port={}'.format(src_port, rcv_idx))
+                rcv_count[rcv_idx] += 1
+            print(rcv_count)
+            for i in range(0, 2):
+                self.assertTrue((rcv_count[i] >= ((max_itrs/2) * 0.8)),
+                                "Not all paths are equally balanced")
+        finally:
+            pass
+
+
+class LoadbalanceOnDesPortTest(T0TestBase):
+    """
+    Test load balance of l3 by destinstion port.
+    """
+
+    def setUp(self):
+        """
+        Test the basic setup process
+        """
+        T0TestBase.setUp(self)
+
+    def runTest(self):
+        """
+        1. Create router interface
+        2. Generate different packets by updating des port
+        3. send these packets on port 1
+        4. Check if packets are received on ports of lag1 equally.
+        """
+        try:
+            print("Lag l3 load balancing test based on des port")
+            sai_thrift_create_router_interface(self.client,
+                                               virtual_router_id=self.default_vrf,
+                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                               port_id=self.port_list[1])
+            max_itrs = 150
+            begin_port = 2000
+            rcv_count = [0, 0]
+            for i in range(0, max_itrs):
+                des_port = begin_port + i
+                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                                        eth_src=self.local_server_mac_list[1],
+                                        ip_dst=self.lag1_ip,
+                                        ip_src=self.local_server_ip_list[1],
+                                        tcp_dport=des_port,
+                                        ip_id=105,
+                                        ip_ttl=64)
+                exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
+                                            eth_src=self.router_mac,
+                                            ip_dst=self.lag1_ip,
+                                            ip_src=self.local_server_ip_list[1],
+                                            tcp_dport=des_port,
+                                            ip_id=105,
+                                            ip_ttl=63)           
+                send_packet(self, 1, pkt)
+                rcv_idx, _ = verify_packet_any_port(self, exp_pkt, [17, 18])
+                print('des_port={}, rcv_port={}'.format(des_port, rcv_idx))
+                rcv_count[rcv_idx] += 1
+
+            print(rcv_count)
+            for i in range(0, 2):
+                self.assertTrue((rcv_count[i] >= ((max_itrs/2) * 0.8)), "Not all paths are equally balanced")
+        finally:
+            pass
+
+
+class LoadbalanceOnSrcIPTest(T0TestBase):
+    """
+    Test load balance of l3 by source IP.
+    """
+
+    def setUp(self):
+        """
+        Test the basic setup process
+        """
+        T0TestBase.setUp(self)
+
+    def runTest(self):
+        """
+        1. Create router interface
+        2. Generate different packets by updating src ip
+        3. send these packets on port 1
+        4. Check if packets are received on ports of lag1 equally.
+        """
+        try:
+            print("Lag l3 load balancing test based on src IP")
+            sai_thrift_create_router_interface(self.client,
+                                               virtual_router_id=self.default_vrf,
+                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                               port_id=self.port_list[1])
+            max_itrs = 150
+            rcv_count = [0, 0]
+            for i in range(0, max_itrs):
+                ip_src = '192.168.0.{}'.format(i)
+                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                                        eth_src=self.local_server_mac_list[1],
+                                        ip_dst=self.lag1_ip,
+                                        ip_src=ip_src,
+                                        ip_id=105,
+                                        ip_ttl=64)
+                exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
+                                            eth_src=self.router_mac,
+                                            ip_dst=self.lag1_ip,
+                                            ip_src=ip_src,
+                                            ip_id=105,
+                                            ip_ttl=63)                                                
+                send_packet(self, 1, pkt)
+                rcv_idx, _ = verify_packet_any_port(self, exp_pkt, [17, 18])
+                print('ip_src={}, rcv_port={}'.format(ip_src, rcv_idx))
+                rcv_count[rcv_idx] += 1
+
+            print(rcv_count)
+            for i in range(0, 2):
+                self.assertTrue((rcv_count[i] >= ((max_itrs/2) * 0.8)), "Not all paths are equally balanced")
+        finally:
+            pass
+
+
+class LoadbalanceOnDesIPTest(T0TestBase):
+    """
+    Test load balance of l3 by destinstion IP.
+    """
+    def setUp(self):
+        """
+        Test the basic setup process
+        """
+        T0TestBase.setUp(self)
+
+    def runTest(self):
+        """
+        1. Create router interface
+        2. Generate different packets by updating des ip
+        3. send these packets on port 1
+        4. Check if packets are received on ports of lag1 equally.
+        """
+        try:
+            print("Lag l3 load balancing test based on des IP")
+            sai_thrift_create_router_interface(self.client,
+                                               virtual_router_id=self.default_vrf,
+                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                               port_id=self.port_list[1])
+            max_itrs = 150
+            rcv_count = [0, 0]
+            for i in range(0, max_itrs):
+                ip_dst = '10.1.1.{}'.format(i)
+                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                                        eth_src=self.local_server_mac_list[1],
+                                        ip_dst=ip_dst,
+                                        ip_src=self.local_server_ip_list[1],
+                                        ip_id=105,
+                                        ip_ttl=64)
+                exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
+                                            eth_src=self.router_mac,
+                                            ip_dst=ip_dst,
+                                            ip_src=self.local_server_ip_list[1],
+                                            ip_id=105,
+                                            ip_ttl=63)                                              
+                send_packet(self, 1, pkt)
+                rcv_idx, _ = verify_packet_any_port(self, exp_pkt, [17, 18])
+                print('des_src={}, rcv_port={}'.format(self.local_server_ip_list[1], rcv_idx))
+                rcv_count[rcv_idx] += 1
+
+            print(rcv_count)
+            for i in range(0, 2):
+                self.assertTrue((rcv_count[i] >= ((max_itrs/2) * 0.8)), "Not all paths are equally balanced")
+        finally:
+            pass
+
+
+"""
+Skip test for broadcom, can't load balance on protocal such as tcp and udp
+Item: 15023123
+"""
+#@skip
+class LoadbalanceOnProtocalTest(T0TestBase):
+    """
+    Test load balance of l3 by destinstion IP.
+    """
+    def setUp(self):
+        """
+        Test the basic setup process
+        """
+        T0TestBase.setUp(self)
+
+    def runTest(self):
+        """
+        1. Create router interface
+        2. Generate different packets with tcp and icmp
+        3. send these packets on port 1
+        4. Check if packets are received on ports of lag1 equally.
+        """
+        try:
+            print("Lag l3 load balancing test based on protocal")
+            sai_thrift_create_router_interface(self.client,
+                                               virtual_router_id=self.default_vrf,
+                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                               port_id=self.port_list[1])
+            max_itrs = 150
+            rcv_count = [0, 0]
+            for i in range(0, max_itrs):
+                if i % 2 == 0:
+                    pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                                            eth_src=self.local_server_mac_list[1],
+                                            ip_dst=self.lag1_ip,
+                                            ip_src=self.local_server_ip_list[1],
+                                            ip_id=105,
+                                            ip_ttl=64)
+                    exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
+                                                eth_src=self.router_mac,
+                                                ip_dst=self.lag1_ip,
+                                                ip_src=self.local_server_ip_list[1],
+                                                ip_id=105,
+                                                ip_ttl=63)
+                else:
+                    print("icmp")
+                    pkt = simple_icmp_packet(eth_dst=self.router_mac,
+                                             eth_src=self.local_server_mac_list[1],
+                                             ip_dst=self.lag1_ip,
+                                             ip_src=self.local_server_ip_list[1],
+                                             ip_id=105,
+                                             ip_ttl=64)
+                    exp_pkt = simple_icmp_packet(eth_dst=self.lag1_nb_mac,
+                                                eth_src=self.router_mac,
+                                                ip_dst=self.lag1_ip,
+                                                ip_src=self.local_server_ip_list[1],
+                                                ip_id=105,
+                                                ip_ttl=63)                                                
+                send_packet(self, 1, pkt)
+                rcv_idx, _ = verify_packet_any_port(self, exp_pkt, [17, 18])
+                print('des_src={}, rcv_port={}'.format(self.local_server_ip_list[1], rcv_idx))
                 rcv_count[rcv_idx] += 1
 
             print(rcv_count)
@@ -126,67 +363,317 @@ class DisableEgressTest(T0TestBase):
     When disable egress on a lag member, we expect traffic drop on the disabled lag member.
     """
     def setUp(self):
+        """
+        Test the basic setup process
+        """
         T0TestBase.setUp(self)
 
     def runTest(self):
+        """
+        1. Create router interface
+        2. Generate different packets by updating src_port
+        3. send these packets on port 1
+        4. Check if packets are received on ports of lag1 equally.
+        5. Disable port18 egress
+        6. Generate different packets by updating src_port
+        7. send these packets on port 1
+        8. Check if packets are received on port 17.
+        """
         try:
             print("Lag disable egress lag member test")
-            sai_thrift_create_router_interface(self.client, virtual_router_id=self.default_vrf, type=SAI_ROUTER_INTERFACE_TYPE_PORT, port_id=self.port_list[21])
-            eth_src = '00:22:22:22:22:22'
-            eth_dst = '00:77:66:55:44:00'
-            ip_src = '192.168.0.1'
-            ip_dst = '10.10.10.1'
-
+            sai_thrift_create_router_interface(self.client,
+                                               virtual_router_id=self.default_vrf,
+                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                               port_id=self.port_list[1])
             pkts_num = 10
             begin_port = 2000
             exp_drop = []
             for i in range(0, pkts_num):
                 src_port = begin_port + i
-                pkt = simple_tcp_packet(eth_dst=eth_dst,
-                                        eth_src=eth_src,
-                                        ip_dst=ip_dst,
-                                        ip_src=ip_src,
+                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                                        eth_src=self.local_server_mac_list[1],
+                                        ip_dst=self.lag1_ip,
+                                        ip_src=self.local_server_ip_list[1],
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst='02:04:02:01:01:01',
-                                        eth_src=eth_dst,
-                                        ip_dst=ip_dst,
-                                        ip_src=ip_src,
-                                        tcp_sport=src_port,
-                                        ip_id=105,
-                                        ip_ttl=63)
-                send_packet(self, 21, pkt)
+                exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
+                                            eth_src=self.router_mac,
+                                            ip_dst=self.lag1_ip,
+                                            ip_src=self.local_server_ip_list[1],
+                                            tcp_sport=src_port,
+                                            ip_id=105,
+                                            ip_ttl=63)
+                send_packet(self, 1, pkt)
                 rcv_idx, _ = verify_packet_any_port(self, exp_pkt, [17, 18])
                 if rcv_idx == 18:
                     exp_drop.append(src_port)
                 
             # disable egress of lag member: port18
             print("disable port18 egress")
-            status = sai_thrift_set_lag_member_attribute(self.client, self.lag1.lag_members[1], egress_disable=True)
+            status = sai_thrift_set_lag_member_attribute(self.client,
+                                                         self.lag1.lag_members[1],
+                                                         egress_disable=True)
             self.assertEqual(status, SAI_STATUS_SUCCESS)
 
             for i in range(0, pkts_num):
                 src_port = begin_port + i
-                pkt = simple_tcp_packet(eth_dst=eth_dst,
-                                        eth_src=eth_src,
-                                        ip_dst=ip_dst,
-                                        ip_src=ip_src,
+                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                                        eth_src=self.local_server_mac_list[1],
+                                        ip_dst=self.lag1_ip,
+                                        ip_src=self.local_server_ip_list[1],
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst='02:04:02:01:01:01',
-                                        eth_src=eth_dst,
-                                        ip_dst=ip_dst,
-                                        ip_src=ip_src,
-                                        tcp_sport=src_port,
-                                        ip_id=105,
-                                        ip_ttl=63)
-                send_packet(self, 21, pkt)
+                exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
+                                            eth_src=self.router_mac,
+                                            ip_dst=self.lag1_ip,
+                                            ip_src=self.local_server_ip_list[1],
+                                            tcp_sport=src_port,
+                                            ip_id=105,
+                                            ip_ttl=63)
+                send_packet(self, 1, pkt)
                 if src_port in exp_drop:
                     verify_no_packet(self, exp_pkt, 18)
-                else:
-                    verify_packet(self, exp_pkt, 17)
+                verify_packet(self, exp_pkt, 17)
+        finally:
+            pass
+
+
+"""
+Skip test for broadcom, can't disable ingress of lag member
+Item: 14988584
+"""
+@skip
+class DisableIngressTest(T0TestBase):
+    
+    """
+    When disable ingress on a lag member, we expect traffic drop on the disabled lag member.
+    """
+    def setUp(self):
+        """
+        Test the basic setup process
+        """
+        T0TestBase.setUp(self)
+
+    def runTest(self):
+        """
+        1. Create router interface
+        2. Generate different packets by updating src_port
+        3. send these packets on port 18
+        4. Check if packets are received on port 1
+        5. Disable port18 igress
+        6. Generate different packets by updating src_port
+        7. send these packets on port 18
+        8. Check if packets are received on port 1
+        """
+        try:
+            print("Lag disable ingress lag member test")
+            sai_thrift_create_router_interface(self.client,
+                                               virtual_router_id=self.default_vrf,
+                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                               port_id=self.lag1.lag_id)
+            pkts_num = 10
+            begin_port = 2000
+            for i in range(0, pkts_num):
+                src_port = begin_port + i
+                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                                        eth_src=self.lag1_nb_mac,
+                                        ip_dst=self.local_server_ip_list[1],
+                                        ip_src=self.lag1_ip,
+                                        tcp_sport=src_port,
+                                        ip_id=105,
+                                        ip_ttl=64)
+                exp_pkt = simple_tcp_packet(eth_dst=self.local_server_mac_list[1],
+                                            eth_src=self.router_mac,
+                                            ip_dst=self.local_server_ip_list[1],
+                                            ip_src=self.lag1_ip,
+                                            tcp_sport=src_port,
+                                            ip_id=105,
+                                            ip_ttl=63)
+                send_packet(self, 18, pkt)
+                verify_packet(self, exp_pkt, 1)
+            # git disable ingress of lag member: port18
+            print("disable port18 ingress")
+            status = sai_thrift_set_lag_member_attribute(self.client, self.lag1.lag_members[1], ingress_disable=True)
+            self.assertEqual(status, SAI_STATUS_SUCCESS)
+
+            for i in range(0, pkts_num):
+                src_port = begin_port + i
+                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                                        eth_src=self.lag1_nb_mac,
+                                        ip_dst=self.local_server_ip_list[1],
+                                        ip_src=self.lag1_ip,
+                                        tcp_sport=src_port,
+                                        ip_id=105,
+                                        ip_ttl=64)
+                exp_pkt = simple_tcp_packet(eth_dst=self.local_server_mac_list[1],
+                                            eth_src=self.router_mac,
+                                            ip_dst=self.local_server_ip_list[1],
+                                            ip_src=self.lag1_ip,
+                                            tcp_sport=src_port,
+                                            ip_id=105,
+                                            ip_ttl=63)
+                send_packet(self, 18, pkt)
+                verify_no_packet(self, exp_pkt, 1)
+        finally:
+            pass
+
+
+class RemoveLagMemberTest(T0TestBase):
+    """
+    When  remove lag member, we expect traffic drop on the removed lag member.
+    """
+    def setUp(self):
+        """
+        Test the basic setup process
+        """
+        T0TestBase.setUp(self)
+
+    def runTest(self):
+        """
+        1. Create router interface
+        2. Generate different packets by updating src_port
+        3. send these packets on port 1
+        4. Check if packets are received on ports of lag1 equally.
+        5. remove port18 in lag1 
+        6. Generate different packets by updating src_port
+        7. send these packets on port 1
+        8. Check if packets are't received on port 18.
+        """
+        try:
+            print("Lag remove lag member test")
+            sai_thrift_create_router_interface(self.client,
+                                               virtual_router_id=self.default_vrf,
+                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                               port_id=self.port_list[1])
+
+            pkts_num = 10
+            begin_port = 2000
+            for i in range(0, pkts_num):
+                src_port = begin_port + i
+                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                                        eth_src=self.local_server_mac_list[1],
+                                        ip_dst=self.lag1_ip,
+                                        ip_src=self.local_server_ip_list[1],
+                                        tcp_sport=src_port,
+                                        ip_id=105,
+                                        ip_ttl=64)
+                exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
+                                            eth_src=self.router_mac,
+                                            ip_dst=self.lag1_ip,
+                                            ip_src=self.local_server_ip_list[1],
+                                            tcp_sport=src_port,
+                                            ip_id=105,
+                                            ip_ttl=63)
+                send_packet(self, 1, pkt)
+                verify_packet_any_port(self, exp_pkt, [17, 18])
+
+            status = sai_thrift_remove_lag_member(self.client, self.lag1.lag_members[1])
+            self.assertEqual(status, SAI_STATUS_SUCCESS)
+
+            for i in range(0, pkts_num):
+                src_port = begin_port + i
+                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                                        eth_src=self.local_server_mac_list[1],
+                                        ip_dst=self.lag1_ip,
+                                        ip_src=self.local_server_ip_list[1],
+                                        tcp_sport=src_port,
+                                        ip_id=105,
+                                        ip_ttl=64)
+                exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
+                                            eth_src=self.router_mac,
+                                            ip_dst=self.lag1_ip,
+                                            ip_src=self.local_server_ip_list[1],
+                                            tcp_sport=src_port,
+                                            ip_id=105,
+                                            ip_ttl=63)
+                send_packet(self, 1, pkt)
+                verify_no_packet(self, exp_pkt, 18)
+            sai_thrift_create_lag_member(self.client,
+                                        lag_id=self.lag1.lag_id,
+                                        port_id=self.port_list[18])
+            self.assertEqual(status, SAI_STATUS_SUCCESS)
+        finally:
+            pass
+
+
+class AddLagMemberTest(T0TestBase):
+    """
+    When  add lag member, we expect traffic appear on the added lag member.
+    """
+    def setUp(self):
+        """
+        set up configurations
+        """
+        T0TestBase.setUp(self)
+
+    def runTest(self):
+        """
+        1. Create router interface
+        2. Generate different packets by updating src_port
+        3. send these packets on port 1
+        4. Check if packets are received on ports of lag1 equally.
+        5. add port21 as lag1 member
+        6. Generate different packets by updating src_port
+        7. send these packets on port 1
+        8. Check if packets are received on lag1(port 17,18,21).
+        """
+        try:
+            print("Lag add lag member test")
+            sai_thrift_create_router_interface(self.client,
+                                               virtual_router_id=self.default_vrf,
+                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                               port_id=self.port_list[1])
+            pkts_num = 10
+            begin_port = 2000
+            rcv_count = [0, 0, 0]
+            for i in range(0, pkts_num):
+                src_port = begin_port + i
+                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                                        eth_src=self.local_server_mac_list[1],
+                                        ip_dst=self.lag1_ip,
+                                        ip_src=self.local_server_ip_list[1],
+                                        tcp_sport=src_port,
+                                        ip_id=105,
+                                        ip_ttl=64)
+                exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
+                                            eth_src=self.router_mac,
+                                            ip_dst=self.lag1_ip,
+                                            ip_src=self.local_server_ip_list[1],
+                                            tcp_sport=src_port,
+                                            ip_id=105,
+                                            ip_ttl=63)
+                send_packet(self, 1, pkt)
+                verify_packet_any_port(self, exp_pkt, [17, 18])
+            print("add port21 into lag1")
+            sai_thrift_create_lag_member(self.client,
+                                        lag_id=self.lag1.lag_id,
+                                        port_id=self.port_list[21])
+
+            for i in range(0, pkts_num):
+                src_port = begin_port + i
+                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                                        eth_src=self.local_server_mac_list[1],
+                                        ip_dst=self.lag1_ip,
+                                        ip_src=self.local_server_ip_list[1],
+                                        tcp_sport=src_port,
+                                        ip_id=105,
+                                        ip_ttl=64)
+                exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
+                                            eth_src=self.router_mac,
+                                            ip_dst=self.lag1_ip,
+                                            ip_src=self.local_server_ip_list[1],
+                                            tcp_sport=src_port,
+                                            ip_id=105,
+                                            ip_ttl=63)
+                send_packet(self, 1, pkt)
+                rcv_idx, _ = verify_packet_any_port(self, exp_pkt, [17, 18, 21])
+                rcv_count[rcv_idx] += 1
+            for cnt in rcv_count:
+                self.assertGreater(cnt, 0, "each member in lag1 should receive pkt")
+            status = sai_thrift_remove_lag_member(self.client, self.lag1.lag_members[2])
+            self.assertEqual(status, SAI_STATUS_SUCCESS)
         finally:
             pass
 
@@ -202,24 +689,22 @@ class IndifferenceIngressPortTest(T0TestBase):
 
     def runTest(self):
         try:
-            sai_thrift_create_router_interface(self.client, virtual_router_id=self.default_vrf, type=SAI_ROUTER_INTERFACE_TYPE_VLAN, vlan_id=10)
-            eth_src = '00:22:22:22:22:22'
-            eth_dst = '00:77:66:55:44:00'
-            ip_src = '192.168.0.1'
-            ip_dst = '10.10.10.1'
-
-            pkt = simple_tcp_packet(eth_dst=eth_dst,
-                                    eth_src=eth_src,
-                                    ip_dst=ip_dst,
-                                    ip_src=ip_src,
+            sai_thrift_create_router_interface(self.client,
+                                               virtual_router_id=self.default_vrf,
+                                               type=SAI_ROUTER_INTERFACE_TYPE_VLAN,
+                                               vlan_id=10)
+            pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                                    eth_src=self.local_server_mac_list[1],
+                                    ip_dst=self.lag1_ip,
+                                    ip_src=self.local_server_ip_list[1],
                                     ip_id=105,
                                     ip_ttl=64)
-            exp_pkt = simple_tcp_packet(eth_dst='02:04:02:01:01:01',
-                                    eth_src=eth_dst,
-                                    ip_dst=ip_dst,
-                                    ip_src=ip_src,
-                                    ip_id=105,
-                                    ip_ttl=63)
+            exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
+                                        eth_src=self.router_mac,
+                                        ip_dst=self.lag1_ip,
+                                        ip_src=self.local_server_ip_list[1],
+                                        ip_id=105,
+                                        ip_ttl=63)
 
             exp_port_idx = -1
             exp_port_list = [17, 18]

--- a/test/sai_test/sai_lag_test.py
+++ b/test/sai_test/sai_lag_test.py
@@ -455,6 +455,11 @@ class DisableIngressTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
+        self.route_configer.create_route_and_neighbor_entry_for_port(ip_addr=self.local_server_ip_list[1], 
+            mac_addr=self.local_server_mac_list[1],
+            port_id=self.port_list[1],
+            virtual_router_id=self.default_vrf)
+
 
     def runTest(self):
         """

--- a/test/sai_test/sai_lag_test.py
+++ b/test/sai_test/sai_lag_test.py
@@ -292,7 +292,7 @@ class LoadbalanceOnDesIPTest(T0TestBase):
 Skip test for broadcom, can't load balance on protocal such as tcp and udp
 Item: 15023123
 """
-#@skip
+@skip
 class LoadbalanceOnProtocalTest(T0TestBase):
     """
     Test load balance of l3 by destinstion IP.

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -278,7 +278,7 @@ class T0TestBase(ThriftInterfaceDataPlane):
 
     def create_server_mac_list(self):
         """
-        Create server mac list.
+        Create servers(0-17) mac list.
 
         Add those following attribute to this class:
         self.local_server_mac_list for all the local server mac
@@ -298,7 +298,7 @@ class T0TestBase(ThriftInterfaceDataPlane):
 
     def create_server_ip_list(self):
         """
-        Create server ip list.
+        Create servers(1-17) ip list.
 
         Add those following attribute to this class:
         self.local_server_ip_list for all the local server mac

--- a/test/sai_test/sai_utils.py
+++ b/test/sai_test/sai_utils.py
@@ -158,3 +158,21 @@ def generate_mac_address_list(role, group, indexes):
             '{:02d}'.format(group) + ':' + '{:02d}'.format(index)
         mac_list.append(mac)
     return mac_list
+
+def generate_ip_address_list(role, group, indexes):
+    """
+    Generate ip addresses.
+
+    Args:
+        role: Role which is represented by the ip address(base on test plan config)
+        group: group number for the ip address(base on test plan config)
+        indexes: ip indexes
+
+    Returns:
+        default_1q_bridge_id
+    """
+    print("Generate IP ...")
+    ip_list = []
+    for index in indexes:
+        ip_list.append(role.format(group,index))
+    return ip_list


### PR DESCRIPTION
Test LAG cases from group1 to goup4 according to [lag test plan](https://github.com/opencomputeproject/SAI/blob/master/doc/sai-ptf/lag_test_plan.md)

verify the PortChannel Load balancing based on different attributes(source IP, destination IP, source port, destination port, and protocol).
verify traffic drop on the disabled lag member after disabling ingress or egress on a lag member
verify traffic to drop/appear on the lag member after removing/adding the lag members
verify the ingress ports should not be as a Hash Factor in Lag load balance. When forwarding the packet from different ingress ports, if only the ingress port changed, then the load balance should not happen among lag members.
Test:
Test all lag cases at DUT
Skip the LoadbalanceOnProtocalTest and DisableIngressTest