### PR TITLE
[SAI-PTF]Support init swtich from syncd-rpc container

### DIFF
--- a/meta/gensairpc.pl
+++ b/meta/gensairpc.pl
@@ -281,7 +281,7 @@ sub generate_server_template_from_skeleton {
 
                 # Define global variable before "class"
                 print {$server_template}
-"\nextern sai_object_id_t switch_id;\nsai_object_id_t switch_id;\n\n\n";
+"\nextern sai_object_id_t switch_id;\nsai_object_id_t switch_id;\nextern sai_object_id_t gSwitchId;\n\n\n";
 
                 # Define helper functions
                 print {$server_template} "[% PROCESS helper_functions %]\n\n\n";

--- a/meta/templates/sai_rpc_server_functions.tt
+++ b/meta/templates/sai_rpc_server_functions.tt
@@ -54,6 +54,12 @@
     if (switch_id != NULL) {
         return switch_id;
     }
+
+    //check if the switch created in syncd
+    if (gSwitchId != NULL) {
+      switch_id = gSwitchId;
+      return switch_id;
+    }
    
 [%- END -%]
 


### PR DESCRIPTION
Support init swtich from syncd-rpc container

In Syncd starting process, it will try to start the switch and assign the gSwtichId to the sai implementation.
In the syncd rpc container, in order to get the swtich id after syncd initalization, we need to get and check the switch id.

Meanwhile support build the saithrift with vs platform

Test done:
Test the syncd-rpc container can start and the switch id can be retrieve from thrift client