### PR TITLE
config lag neighbor and route according to config

### DIFF
--- a/test/sai_test/config/route_configer.py
+++ b/test/sai_test/config/route_configer.py
@@ -23,10 +23,11 @@ from sai_thrift.sai_adapter import *
 from sai_utils import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 from constant import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 
-def t0_route_config_helper(test_obj, is_create_route=True, is_create_route_for_lag=True):
+def t0_route_config_helper(test_obj, is_create_default_route=True, is_create_route_for_lag=True):
     route_configer = RouteConfiger(test_obj)
-    if is_create_route:
+    if is_create_default_route:
         route_configer.create_default_route()
+        test_obj.port1_rif = route_configer.create_router_interface_for_port(port_id=test_obj.port_list[1])
 
     if is_create_route_for_lag:
         # config neighbor and route for lag1

--- a/test/sai_test/config/route_configer.py
+++ b/test/sai_test/config/route_configer.py
@@ -29,15 +29,17 @@ def t0_route_config_helper(test_obj, is_create_route=True, is_create_route_for_l
         route_configer.create_default_route()
 
     if is_create_route_for_lag:
-        route_configer.create_route_and_neighbor_entry_for_port(ip_addr=test_obj.lag1_ip,
-            mac_addr=test_obj.lag1_nb_mac,
-            port_id=test_obj.lag1.lag_id,
-            virtual_router_id=test_obj.default_vrf)
+        # config neighbor and route for lag1
+        test_obj.lag1_rif = route_configer.create_router_interface_for_port(port_id=test_obj.lag1.lag_id)
+        test_obj.lag1_nbr = route_configer.create_neighbor_for_rif(rif_id=test_obj.lag1_rif, ip_addr=test_obj.lag1_nhop_ip, mac_addr=test_obj.lag1_nb_mac)
+        test_obj.lag1_nhop = route_configer.create_next_hop_for_rif(ip_addr=test_obj.lag1_nhop_ip, rif=test_obj.lag1_rif)
+        test_obj.lag1_route = route_configer.create_route_entry(dst_ip=test_obj.lag1_route_dst+'/24', next_hop=test_obj.lag1_nhop)
 
-        route_configer.create_route_and_neighbor_entry_for_port(ip_addr=test_obj.lag2_ip,
-            mac_addr=test_obj.lag2_nb_mac,
-            port_id=test_obj.lag2.lag_id,
-            virtual_router_id=test_obj.default_vrf)
+        # config neighbor and route for lag2
+        test_obj.lag2_rif = route_configer.create_router_interface_for_port(port_id=test_obj.lag2.lag_id)
+        test_obj.lag2_nbr = route_configer.create_neighbor_for_rif(rif_id=test_obj.lag2_rif, ip_addr=test_obj.lag2_nhop_ip, mac_addr=test_obj.lag2_nb_mac)
+        test_obj.lag2_nhop = route_configer.create_next_hop_for_rif(ip_addr=test_obj.lag2_nhop_ip, rif=test_obj.lag2_rif)
+        test_obj.lag2_route = route_configer.create_route_entry(dst_ip=test_obj.lag2_route_dst+'/24', next_hop=test_obj.lag2_nhop)   
 
 class RouteConfiger(object):
     """
@@ -131,3 +133,35 @@ class RouteConfiger(object):
         nhop = sai_thrift_create_next_hop(self.client, ip=sai_ipaddress(ip_addr), router_interface_id=rif_id1, type=SAI_NEXT_HOP_TYPE_IP)
         route1 =sai_thrift_route_entry_t(vr_id=virtual_router_id, destination=sai_ipprefix(ip_addr+'/24'))
         sai_thrift_create_route_entry(self.client, route1, next_hop_id=nhop)
+    
+    def create_router_interface_for_port(self, port_id, virtual_router_id=None):
+        if virtual_router_id is None:
+            virtual_router_id = self.test_obj.default_vrf
+
+        rif_id1 = sai_thrift_create_router_interface(self.client, virtual_router_id=virtual_router_id, type=SAI_ROUTER_INTERFACE_TYPE_PORT, port_id=port_id)
+        self.test_obj.assertEqual(self.test_obj.status(), SAI_STATUS_SUCCESS)
+
+        return rif_id1
+    
+    def create_next_hop_for_rif(self, ip_addr, rif):
+        nhop = sai_thrift_create_next_hop(self.client, ip=sai_ipaddress(ip_addr), router_interface_id=rif, type=SAI_NEXT_HOP_TYPE_IP)
+        self.test_obj.assertEqual(self.test_obj.status(), SAI_STATUS_SUCCESS)
+
+        return nhop
+
+    def create_neighbor_for_rif(self, rif_id, ip_addr, mac_addr):
+        nbr_entry_v4 = sai_thrift_neighbor_entry_t(rif_id=rif_id, ip_address=sai_ipaddress(ip_addr))
+        status = sai_thrift_create_neighbor_entry(self.client, nbr_entry_v4, dst_mac_address=mac_addr)
+        self.test_obj.assertEqual(status, SAI_STATUS_SUCCESS)
+
+        return nbr_entry_v4
+
+    def create_route_entry(self, dst_ip, next_hop, virtual_router_id=None):
+        if virtual_router_id is None:
+            virtual_router_id = self.test_obj.default_vrf
+
+        route1 = sai_thrift_route_entry_t(vr_id=virtual_router_id, destination=sai_ipprefix(dst_ip))
+        status = sai_thrift_create_route_entry(self.client, route_entry=route1, next_hop_id=next_hop)
+        self.test_obj.assertEqual(status, SAI_STATUS_SUCCESS)
+
+        return route1

--- a/test/sai_test/sai_lag_test.py
+++ b/test/sai_test/sai_lag_test.py
@@ -38,27 +38,27 @@ class LagConfigTest(T0TestBase):
                                            virtual_router_id=self.default_vrf,
                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
                                            port_id=self.port_list[1])
-        ip_dst = self.lag1_ip
-        pkt1 = simple_tcp_packet(eth_dst=self.router_mac,
+        ip_dst = self.lag1_route_dst
+        pkt1 = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                  eth_src=self.local_server_mac_list[1],
                                  ip_dst=ip_dst,
                                  ip_src=self.local_server_ip_list[1],
                                  ip_id=105,
                                  ip_ttl=64)
-        pkt2 = simple_tcp_packet(eth_dst=self.router_mac,
+        pkt2 = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                  eth_src=self.local_server_mac_list[2],
                                  ip_dst=ip_dst,
                                  ip_src=self.local_server_ip_list[2],
                                  ip_id=105,
                                  ip_ttl=64)
         exp_pkt1 = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
-                                     eth_src=self.router_mac,
+                                     eth_src=ROUTER_MAC,
                                      ip_dst=ip_dst,
                                      ip_src=self.local_server_ip_list[1],
                                      ip_id=105,
                                      ip_ttl=63)
         exp_pkt2 = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
-                                     eth_src=self.router_mac,
+                                     eth_src=ROUTER_MAC,
                                      ip_dst=ip_dst,
                                      ip_src=self.local_server_ip_list[2],
                                      ip_id=105,
@@ -104,16 +104,16 @@ class LoadbalanceOnSrcPortTest(T0TestBase):
             rcv_count = [0, 0]
             for i in range(0, max_itrs):
                 src_port = begin_port + i
-                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                         eth_src=self.local_server_mac_list[1],
-                                        ip_dst=self.lag1_ip,
+                                        ip_dst=self.lag1_route_dst,
                                         ip_src=self.local_server_ip_list[1],
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
-                                            eth_src=self.router_mac,
-                                            ip_dst=self.lag1_ip,
+                                            eth_src=ROUTER_MAC,
+                                            ip_dst=self.lag1_route_dst,
                                             ip_src=self.local_server_ip_list[1],
                                             tcp_sport=src_port,
                                             ip_id=105,
@@ -159,16 +159,16 @@ class LoadbalanceOnDesPortTest(T0TestBase):
             rcv_count = [0, 0]
             for i in range(0, max_itrs):
                 des_port = begin_port + i
-                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                         eth_src=self.local_server_mac_list[1],
-                                        ip_dst=self.lag1_ip,
+                                        ip_dst=self.lag1_route_dst,
                                         ip_src=self.local_server_ip_list[1],
                                         tcp_dport=des_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
-                                            eth_src=self.router_mac,
-                                            ip_dst=self.lag1_ip,
+                                            eth_src=ROUTER_MAC,
+                                            ip_dst=self.lag1_route_dst,
                                             ip_src=self.local_server_ip_list[1],
                                             tcp_dport=des_port,
                                             ip_id=105,
@@ -213,15 +213,15 @@ class LoadbalanceOnSrcIPTest(T0TestBase):
             rcv_count = [0, 0]
             for i in range(0, max_itrs):
                 ip_src = '192.168.0.{}'.format(i)
-                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                         eth_src=self.local_server_mac_list[1],
-                                        ip_dst=self.lag1_ip,
+                                        ip_dst=self.lag1_route_dst,
                                         ip_src=ip_src,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
-                                            eth_src=self.router_mac,
-                                            ip_dst=self.lag1_ip,
+                                            eth_src=ROUTER_MAC,
+                                            ip_dst=self.lag1_route_dst,
                                             ip_src=ip_src,
                                             ip_id=105,
                                             ip_ttl=63)                                                
@@ -263,15 +263,15 @@ class LoadbalanceOnDesIPTest(T0TestBase):
             max_itrs = 150
             rcv_count = [0, 0]
             for i in range(0, max_itrs):
-                ip_dst = '10.1.1.{}'.format(i)
-                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                ip_dst = '192.168.11.{}'.format(i)
+                pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                         eth_src=self.local_server_mac_list[1],
                                         ip_dst=ip_dst,
                                         ip_src=self.local_server_ip_list[1],
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
-                                            eth_src=self.router_mac,
+                                            eth_src=ROUTER_MAC,
                                             ip_dst=ip_dst,
                                             ip_src=self.local_server_ip_list[1],
                                             ip_id=105,
@@ -289,13 +289,13 @@ class LoadbalanceOnDesIPTest(T0TestBase):
 
 
 """
-Skip test for broadcom, can't load balance on protocal such as tcp and udp
+Skip test for broadcom, can't load balance on protocol such as tcp and udp
 Item: 15023123
 """
 @skip
-class LoadbalanceOnProtocalTest(T0TestBase):
+class LoadbalanceOnProtocolTest(T0TestBase):
     """
-    Test load balance of l3 by destinstion IP.
+    Test load balance of l3 by protocol.
     """
     def setUp(self):
         """
@@ -311,7 +311,7 @@ class LoadbalanceOnProtocalTest(T0TestBase):
         4. Check if packets are received on ports of lag1 equally.
         """
         try:
-            print("Lag l3 load balancing test based on protocal")
+            print("Lag l3 load balancing test based on protocol")
             sai_thrift_create_router_interface(self.client,
                                                virtual_router_id=self.default_vrf,
                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
@@ -320,29 +320,29 @@ class LoadbalanceOnProtocalTest(T0TestBase):
             rcv_count = [0, 0]
             for i in range(0, max_itrs):
                 if i % 2 == 0:
-                    pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                    pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                             eth_src=self.local_server_mac_list[1],
-                                            ip_dst=self.lag1_ip,
+                                            ip_dst=self.lag1_route_dst,
                                             ip_src=self.local_server_ip_list[1],
                                             ip_id=105,
                                             ip_ttl=64)
                     exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
-                                                eth_src=self.router_mac,
-                                                ip_dst=self.lag1_ip,
+                                                eth_src=ROUTER_MAC,
+                                                ip_dst=self.lag1_route_dst,
                                                 ip_src=self.local_server_ip_list[1],
                                                 ip_id=105,
                                                 ip_ttl=63)
                 else:
                     print("icmp")
-                    pkt = simple_icmp_packet(eth_dst=self.router_mac,
+                    pkt = simple_icmp_packet(eth_dst=ROUTER_MAC,
                                              eth_src=self.local_server_mac_list[1],
-                                             ip_dst=self.lag1_ip,
+                                             ip_dst=self.lag1_route_dst,
                                              ip_src=self.local_server_ip_list[1],
                                              ip_id=105,
                                              ip_ttl=64)
                     exp_pkt = simple_icmp_packet(eth_dst=self.lag1_nb_mac,
-                                                eth_src=self.router_mac,
-                                                ip_dst=self.lag1_ip,
+                                                eth_src=ROUTER_MAC,
+                                                ip_dst=self.lag1_route_dst,
                                                 ip_src=self.local_server_ip_list[1],
                                                 ip_id=105,
                                                 ip_ttl=63)                                                
@@ -390,16 +390,16 @@ class DisableEgressTest(T0TestBase):
             exp_drop = []
             for i in range(0, pkts_num):
                 src_port = begin_port + i
-                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                         eth_src=self.local_server_mac_list[1],
-                                        ip_dst=self.lag1_ip,
+                                        ip_dst=self.lag1_route_dst,
                                         ip_src=self.local_server_ip_list[1],
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
-                                            eth_src=self.router_mac,
-                                            ip_dst=self.lag1_ip,
+                                            eth_src=ROUTER_MAC,
+                                            ip_dst=self.lag1_route_dst,
                                             ip_src=self.local_server_ip_list[1],
                                             tcp_sport=src_port,
                                             ip_id=105,
@@ -418,16 +418,16 @@ class DisableEgressTest(T0TestBase):
 
             for i in range(0, pkts_num):
                 src_port = begin_port + i
-                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                         eth_src=self.local_server_mac_list[1],
-                                        ip_dst=self.lag1_ip,
+                                        ip_dst=self.lag1_route_dst,
                                         ip_src=self.local_server_ip_list[1],
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
-                                            eth_src=self.router_mac,
-                                            ip_dst=self.lag1_ip,
+                                            eth_src=ROUTER_MAC,
+                                            ip_dst=self.lag1_route_dst,
                                             ip_src=self.local_server_ip_list[1],
                                             tcp_sport=src_port,
                                             ip_id=105,
@@ -482,17 +482,17 @@ class DisableIngressTest(T0TestBase):
             begin_port = 2000
             for i in range(0, pkts_num):
                 src_port = begin_port + i
-                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                         eth_src=self.lag1_nb_mac,
                                         ip_dst=self.local_server_ip_list[1],
-                                        ip_src=self.lag1_ip,
+                                        ip_src=self.lag1_route_dst,
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.local_server_mac_list[1],
-                                            eth_src=self.router_mac,
+                                            eth_src=ROUTER_MAC,
                                             ip_dst=self.local_server_ip_list[1],
-                                            ip_src=self.lag1_ip,
+                                            ip_src=self.lag1_route_dst,
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
@@ -505,17 +505,17 @@ class DisableIngressTest(T0TestBase):
 
             for i in range(0, pkts_num):
                 src_port = begin_port + i
-                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                         eth_src=self.lag1_nb_mac,
                                         ip_dst=self.local_server_ip_list[1],
-                                        ip_src=self.lag1_ip,
+                                        ip_src=self.lag1_route_dst,
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.local_server_mac_list[1],
-                                            eth_src=self.router_mac,
+                                            eth_src=ROUTER_MAC,
                                             ip_dst=self.local_server_ip_list[1],
-                                            ip_src=self.lag1_ip,
+                                            ip_src=self.lag1_route_dst,
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
@@ -557,16 +557,16 @@ class RemoveLagMemberTest(T0TestBase):
             begin_port = 2000
             for i in range(0, pkts_num):
                 src_port = begin_port + i
-                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                         eth_src=self.local_server_mac_list[1],
-                                        ip_dst=self.lag1_ip,
+                                        ip_dst=self.lag1_route_dst,
                                         ip_src=self.local_server_ip_list[1],
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
-                                            eth_src=self.router_mac,
-                                            ip_dst=self.lag1_ip,
+                                            eth_src=ROUTER_MAC,
+                                            ip_dst=self.lag1_route_dst,
                                             ip_src=self.local_server_ip_list[1],
                                             tcp_sport=src_port,
                                             ip_id=105,
@@ -579,16 +579,16 @@ class RemoveLagMemberTest(T0TestBase):
 
             for i in range(0, pkts_num):
                 src_port = begin_port + i
-                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                         eth_src=self.local_server_mac_list[1],
-                                        ip_dst=self.lag1_ip,
+                                        ip_dst=self.lag1_route_dst,
                                         ip_src=self.local_server_ip_list[1],
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
-                                            eth_src=self.router_mac,
-                                            ip_dst=self.lag1_ip,
+                                            eth_src=ROUTER_MAC,
+                                            ip_dst=self.lag1_route_dst,
                                             ip_src=self.local_server_ip_list[1],
                                             tcp_sport=src_port,
                                             ip_id=105,
@@ -635,16 +635,16 @@ class AddLagMemberTest(T0TestBase):
             rcv_count = [0, 0, 0]
             for i in range(0, pkts_num):
                 src_port = begin_port + i
-                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                         eth_src=self.local_server_mac_list[1],
-                                        ip_dst=self.lag1_ip,
+                                        ip_dst=self.lag1_route_dst,
                                         ip_src=self.local_server_ip_list[1],
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
-                                            eth_src=self.router_mac,
-                                            ip_dst=self.lag1_ip,
+                                            eth_src=ROUTER_MAC,
+                                            ip_dst=self.lag1_route_dst,
                                             ip_src=self.local_server_ip_list[1],
                                             tcp_sport=src_port,
                                             ip_id=105,
@@ -652,22 +652,23 @@ class AddLagMemberTest(T0TestBase):
                 send_packet(self, 1, pkt)
                 verify_packet_any_port(self, exp_pkt, [17, 18])
             print("add port21 into lag1")
-            sai_thrift_create_lag_member(self.client,
+            new_lag_member = sai_thrift_create_lag_member(self.client,
                                         lag_id=self.lag1.lag_id,
                                         port_id=self.port_list[21])
+            self.lag1.lag_members.append(new_lag_member)
 
             for i in range(0, pkts_num):
                 src_port = begin_port + i
-                pkt = simple_tcp_packet(eth_dst=self.router_mac,
+                pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                         eth_src=self.local_server_mac_list[1],
-                                        ip_dst=self.lag1_ip,
+                                        ip_dst=self.lag1_route_dst,
                                         ip_src=self.local_server_ip_list[1],
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
-                                            eth_src=self.router_mac,
-                                            ip_dst=self.lag1_ip,
+                                            eth_src=ROUTER_MAC,
+                                            ip_dst=self.lag1_route_dst,
                                             ip_src=self.local_server_ip_list[1],
                                             tcp_sport=src_port,
                                             ip_id=105,
@@ -679,6 +680,7 @@ class AddLagMemberTest(T0TestBase):
                 self.assertGreater(cnt, 0, "each member in lag1 should receive pkt")
             status = sai_thrift_remove_lag_member(self.client, self.lag1.lag_members[2])
             self.assertEqual(status, SAI_STATUS_SUCCESS)
+            self.lag1.lag_members.remove(new_lag_member)
         finally:
             pass
 
@@ -698,15 +700,15 @@ class IndifferenceIngressPortTest(T0TestBase):
                                                virtual_router_id=self.default_vrf,
                                                type=SAI_ROUTER_INTERFACE_TYPE_VLAN,
                                                vlan_id=10)
-            pkt = simple_tcp_packet(eth_dst=self.router_mac,
+            pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                     eth_src=self.local_server_mac_list[1],
-                                    ip_dst=self.lag1_ip,
+                                    ip_dst=self.lag1_route_dst,
                                     ip_src=self.local_server_ip_list[1],
                                     ip_id=105,
                                     ip_ttl=64)
             exp_pkt = simple_tcp_packet(eth_dst=self.lag1_nb_mac,
-                                        eth_src=self.router_mac,
-                                        ip_dst=self.lag1_ip,
+                                        eth_src=ROUTER_MAC,
+                                        ip_dst=self.lag1_route_dst,
                                         ip_src=self.local_server_ip_list[1],
                                         ip_id=105,
                                         ip_ttl=63)

--- a/test/sai_test/sai_lag_test.py
+++ b/test/sai_test/sai_lag_test.py
@@ -34,10 +34,6 @@ class LagConfigTest(T0TestBase):
         T0TestBase.setUp(self)
 
     def load_balance_on_src_ip(self):
-        sai_thrift_create_router_interface(self.client,
-                                           virtual_router_id=self.default_vrf,
-                                           type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                           port_id=self.port_list[1])
         ip_dst = self.lag1_route_dst
         pkt1 = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                  eth_src=self.local_server_mac_list[1],
@@ -88,17 +84,12 @@ class LoadbalanceOnSrcPortTest(T0TestBase):
 
     def runTest(self):
         """
-        1. Create router interface
-        2. Generate different packets by updating src port
-        3. send these packets on port 1
-        4. Check if packets are received on ports of lag1 equally.
+        1. Generate different packets by updating src port
+        2. send these packets on port1
+        3. Check if packets are received on ports of lag1 equally
         """
         try:
             print("Lag l3 load balancing test based on src port")
-            sai_thrift_create_router_interface(self.client,
-                                               virtual_router_id=self.default_vrf,
-                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                               port_id=self.port_list[1])
             max_itrs = 150
             begin_port = 2000
             rcv_count = [0, 0]
@@ -143,17 +134,13 @@ class LoadbalanceOnDesPortTest(T0TestBase):
 
     def runTest(self):
         """
-        1. Create router interface
-        2. Generate different packets by updating des port
-        3. send these packets on port 1
-        4. Check if packets are received on ports of lag1 equally.
+        1. Generate different packets by updating des port
+        2. send these packets on port1
+        3. Check if packets are received on ports of lag1 equally
         """
         try:
             print("Lag l3 load balancing test based on des port")
-            sai_thrift_create_router_interface(self.client,
-                                               virtual_router_id=self.default_vrf,
-                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                               port_id=self.port_list[1])
+
             max_itrs = 150
             begin_port = 2000
             rcv_count = [0, 0]
@@ -198,17 +185,13 @@ class LoadbalanceOnSrcIPTest(T0TestBase):
 
     def runTest(self):
         """
-        1. Create router interface
-        2. Generate different packets by updating src ip
-        3. send these packets on port 1
-        4. Check if packets are received on ports of lag1 equally.
+        1. Generate different packets by updating src ip
+        2. send these packets on port1
+        3. Check if packets are received on ports of lag1 equally
         """
         try:
             print("Lag l3 load balancing test based on src IP")
-            sai_thrift_create_router_interface(self.client,
-                                               virtual_router_id=self.default_vrf,
-                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                               port_id=self.port_list[1])
+
             max_itrs = 150
             rcv_count = [0, 0]
             for i in range(0, max_itrs):
@@ -249,17 +232,13 @@ class LoadbalanceOnDesIPTest(T0TestBase):
 
     def runTest(self):
         """
-        1. Create router interface
-        2. Generate different packets by updating des ip
-        3. send these packets on port 1
-        4. Check if packets are received on ports of lag1 equally.
+        1. Generate different packets by updating des ip
+        2. send these packets on port1
+        3. Check if packets are received on ports of lag1 equally
         """
         try:
             print("Lag l3 load balancing test based on des IP")
-            sai_thrift_create_router_interface(self.client,
-                                               virtual_router_id=self.default_vrf,
-                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                               port_id=self.port_list[1])
+
             max_itrs = 150
             rcv_count = [0, 0]
             for i in range(0, max_itrs):
@@ -305,17 +284,13 @@ class LoadbalanceOnProtocolTest(T0TestBase):
 
     def runTest(self):
         """
-        1. Create router interface
-        2. Generate different packets with tcp and icmp
-        3. send these packets on port 1
-        4. Check if packets are received on ports of lag1 equally.
+        1. Generate different packets with tcp and icmp
+        2. send these packets on port1
+        3. Check if packets are received on ports of lag1 equally
         """
         try:
             print("Lag l3 load balancing test based on protocol")
-            sai_thrift_create_router_interface(self.client,
-                                               virtual_router_id=self.default_vrf,
-                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                               port_id=self.port_list[1])
+
             max_itrs = 150
             rcv_count = [0, 0]
             for i in range(0, max_itrs):
@@ -370,21 +345,17 @@ class DisableEgressTest(T0TestBase):
 
     def runTest(self):
         """
-        1. Create router interface
-        2. Generate different packets by updating src_port
-        3. send these packets on port 1
-        4. Check if packets are received on ports of lag1 equally.
-        5. Disable port18 egress
-        6. Generate different packets by updating src_port
-        7. send these packets on port 1
-        8. Check if packets are received on port 17.
+        1. Generate different packets by updating src_port
+        2. send these packets on port1
+        3. Check if packets are received on ports of lag1 equally
+        4. Disable port18 egress
+        5. Generate different packets by updating src_port
+        6. send these packets on port1
+        7. Check if packets are received on port17
         """
         try:
             print("Lag disable egress lag member test")
-            sai_thrift_create_router_interface(self.client,
-                                               virtual_router_id=self.default_vrf,
-                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                               port_id=self.port_list[1])
+
             pkts_num = 10
             begin_port = 2000
             exp_drop = []
@@ -463,14 +434,13 @@ class DisableIngressTest(T0TestBase):
 
     def runTest(self):
         """
-        1. Create router interface
-        2. Generate different packets by updating src_port
-        3. send these packets on port 18
-        4. Check if packets are received on port 1
-        5. Disable port18 igress
-        6. Generate different packets by updating src_port
-        7. send these packets on port 18
-        8. Check if packets are received on port 1
+        1. Generate different packets by updating src_port
+        2. send these packets on port 18
+        3. Check if packets are received on port1
+        4. Disable port18 ingress
+        5. Generate same different packets in step 1 by updating src_port
+        6. send these packets on port 18
+        7. Check if packets are received on port1
         """
         try:
             print("Lag disable ingress lag member test")
@@ -527,7 +497,7 @@ class DisableIngressTest(T0TestBase):
 
 class RemoveLagMemberTest(T0TestBase):
     """
-    When  remove lag member, we expect traffic drop on the removed lag member.
+    When remove lag member, we expect traffic drop on the removed lag member.
     """
     def setUp(self):
         """
@@ -537,21 +507,16 @@ class RemoveLagMemberTest(T0TestBase):
 
     def runTest(self):
         """
-        1. Create router interface
-        2. Generate different packets by updating src_port
-        3. send these packets on port 1
-        4. Check if packets are received on ports of lag1 equally.
-        5. remove port18 in lag1 
-        6. Generate different packets by updating src_port
-        7. send these packets on port 1
-        8. Check if packets are't received on port 18.
+        1. Generate different packets by updating src_port
+        2. Send these packets on port1
+        3. Check if packets are received on ports of lag1 equally
+        4. Remove port18 in lag1 
+        5. Generate same different packets in step 1 by updating src_port
+        6. Send these packets on port1
+        7. Check if packets aren't received on port18
         """
         try:
             print("Lag remove lag member test")
-            sai_thrift_create_router_interface(self.client,
-                                               virtual_router_id=self.default_vrf,
-                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                               port_id=self.port_list[1])
 
             pkts_num = 10
             begin_port = 2000
@@ -615,21 +580,17 @@ class AddLagMemberTest(T0TestBase):
 
     def runTest(self):
         """
-        1. Create router interface
-        2. Generate different packets by updating src_port
-        3. send these packets on port 1
-        4. Check if packets are received on ports of lag1 equally.
-        5. add port21 as lag1 member
-        6. Generate different packets by updating src_port
-        7. send these packets on port 1
-        8. Check if packets are received on lag1(port 17,18,21).
+        1. Generate different packets by updating src_port
+        2. Send these packets on port1
+        3. Check if packets are received on ports of lag1 equally
+        4. Add port21 as lag1 member
+        5. Generate same different packets in step 1 by updating src_port
+        6. Send these packets on port1
+        7. Check if packets are received on lag1(port 17,18,21)
         """
         try:
             print("Lag add lag member test")
-            sai_thrift_create_router_interface(self.client,
-                                               virtual_router_id=self.default_vrf,
-                                               type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                               port_id=self.port_list[1])
+
             pkts_num = 10
             begin_port = 2000
             rcv_count = [0, 0, 0]

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -221,7 +221,7 @@ class T0TestBase(ThriftInterfaceDataPlane):
               is_reset_default_vlan=True,
               is_create_vlan=True,
               is_create_fdb=True,
-              is_create_route=True,
+              is_create_default_route=True,
               is_create_lag=True,
               is_create_route_for_lag=True,
               wait_sec=5):
@@ -255,7 +255,7 @@ class T0TestBase(ThriftInterfaceDataPlane):
                 is_create_lag=is_create_lag)
             t0_route_config_helper(
                 test_obj=self,
-                is_create_route=is_create_route,
+                is_create_default_route=is_create_default_route,
                 is_create_route_for_lag=is_create_route_for_lag)
 
         print("Waiting for switch to get ready before test, {} seconds ...".format(

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -317,9 +317,10 @@ class T0TestBase(ThriftInterfaceDataPlane):
     
     def create_other_mac_ip(self):
         #LAG
-        self.lag1_ip = '10.1.1.100'
-        self.lag2_ip = '10.1.2.100'
-        self.router_mac = '00:77:66:55:44:00'
+        self.lag1_route_dst = '192.168.11.0'
+        self.lag2_route_dst = '192.168.12.0'
+        self.lag1_nhop_ip = '10.1.1.100'
+        self.lag2_nhop_ip = '10.1.2.100'
         self.lag1_nb_mac = '00:01:01:01:01:a0'
         self.lag2_nb_mac = '00:01:01:01:02:a0'
 


### PR DESCRIPTION
Signed-off-by: zitingguo <zitingguo@microsoft.com>
## Description of PR
Config lag neighbor and route according to config.

## Approach
### What is the motivation for this PR?
Config lag route according to config and save lag neighbor and route for further use.

### How did you do it?
Refactor the config process for lag route and neighbor.
Change the dst ip in lag test case to lag route dst ip.

## How did you test/verify it?
Test all lag cases under DUT except the skipped test LoadbalanceOnProtocolTest and DisableIngressTest
