### PR TITLE
Check for NULL APIs returned by sai_api_query() and handle gracefully instead of crashing.

### DIFF
--- a/meta/templates/sai_rpc_server_functions.tt
+++ b/meta/templates/sai_rpc_server_functions.tt
@@ -28,6 +28,16 @@
 [% END -%]
 [%- END -%]
 
+[%- BLOCK check_sai_function -%]
+[% name = function.name; UNLESS methods.$name %]
+[% END -%]
+if ([% api %]_api->[% name = function.name; GET methods.$name %] == (void *)0) {
+        std::cerr << "NULL ptr: [% api %]_api->[% name = function.name; GET methods.$name %]" << std::endl;
+        [%- PROCESS throw_null_api_exception %]
+    }
+
+[%- END -%]
+
 [%- ######################################################################## -%]
 
 [%- ######################################################################## -%]
@@ -130,6 +140,14 @@
     [%- indentation = indentation || 2; tab = 2; indent = ' '; indent = indent.repeat(tab*indentation) %]
 [% indent %]sai_thrift_exception e;
 [% indent %]e.status = [% status_variable %];
+[% indent %]throw e;
+[%- END -%]
+
+[%- BLOCK throw_null_api_exception -%]
+    [%- indentation = indentation || 2; tab = 2; indent = ' '; indent = indent.repeat(tab*indentation) %]
+    
+[% indent %]sai_thrift_exception e;
+[% indent %]e.status = SAI_STATUS_NOT_IMPLEMENTED;
 [% indent %]throw e;
 [%- END -%]
 
@@ -350,6 +368,9 @@
         [%- PROCESS sai_api_query -%]
 
         [%- PROCESS preprocess_arguments %]
+
+        [%- # Ensure function ptr not NULL -%]
+    [% name = function.name; UNLESS methods.$name %]//[% END %][% PROCESS check_sai_function -%]
 
         [%- # Now just call the function -%]
     [% name = function.name; UNLESS methods.$name %]//[% END %]status = [% PROCESS call_sai_function -%]


### PR DESCRIPTION
Fixes https://github.com/opencomputeproject/SAI/issues/1535. I modified the code-generator template to check for null SAI function pointers before calling, and throwing an exception with helpful message on the console.

Replaces https://github.com/opencomputeproject/SAI/pull/1536 which had some rebasing conflicts.

The changed file of interest is actually just meta/templates/sai_rpc_server_functions.tt.

Example console trace when calling switch_api->get_switch_attribute() which isn't implemented and has a null pointer. The process does not crash anymore.

Starting SAI RPC server on port 9092
NULL ptr: switch_api->get_switch_attribute
To understand how this works, the template inserts the following code (as an example) automatically:


    if (switch_api->get_switch_stats == (void *)0) {
        std::cerr << "NULL ptr: switch_api->get_switch_stats" << std::endl;
    
      sai_thrift_exception e;
      e.status = SAI_STATUS_NOT_IMPLEMENTED;
      throw e;
    }
right before making any API call such as:

    status = switch_api->get_switch_stats(switch_id, number_of_counters, sai_counter_ids, sai_counters);