### PR TITLE
[SAI-PTF] FIX - remove and cleanup is_ipv4

### DIFF
--- a/test/sai_test/sai_rif_test.py
+++ b/test/sai_test/sai_rif_test.py
@@ -99,7 +99,7 @@ class IngressMacUpdateTestV6(T0TestBase):
         """
         Test the basic setup process.
         """
-        T0TestBase.setUp(self, is_ipv4=False)
+        T0TestBase.setUp(self)
 
     def test_ingress_mac_update(self):
         """
@@ -230,7 +230,7 @@ class IngressDisableTestV6(T0TestBase):
         Test the basic setup process.
         """
 
-        T0TestBase.setUp(self, is_ipv4=False)
+        T0TestBase.setUp(self)
         self.port1 = self.dut.port_list[1]
 
     def test_ingress_disable_ipv6(self):
@@ -381,7 +381,7 @@ class IngressMtuTestV6(T0TestBase):
         Test the basic setup process.
         """
 
-        T0TestBase.setUp(self, is_ipv4=False)
+        T0TestBase.setUp(self)
 
     def test_ingress_mtu_v6(self):
         """

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -355,7 +355,6 @@ class T0TestBase(ThriftInterfaceDataPlane):
               is_create_default_route=True,
               is_create_lag=True,
               is_create_route_for_lag=True,
-              is_ipv4=True,
               wait_sec=5):
         super(T0TestBase, self).setUp()
 
@@ -392,8 +391,7 @@ class T0TestBase(ThriftInterfaceDataPlane):
             t0_route_config_helper(
                 test_obj=self,
                 is_create_default_route=is_create_default_route,
-                is_create_route_for_lag=is_create_route_for_lag,
-                is_ipv4=is_ipv4)
+                is_create_route_for_lag=is_create_route_for_lag)
 
         print("Waiting for switch to get ready before test, {} seconds ...".format(
             wait_sec))


### PR DESCRIPTION
Remove and clean up is_ipv4.
This parameter is not used any more after refactor, and this parameters cause running error.

Detail:
Remove all the place referencing this parameter

Test done:
Test with FDB case

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>