### PR TITLE
[SAI-PTF]persist and read dut

### DIFF
--- a/test/sai_test/data_module/dut.py
+++ b/test/sai_test/data_module/dut.py
@@ -17,7 +17,6 @@
 #    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
 #
 #
-
 from typing import Dict, List
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:

--- a/test/sai_test/data_module/persist.py
+++ b/test/sai_test/data_module/persist.py
@@ -19,7 +19,10 @@
 #
 import pickle
 import os
+from typing import Dict
+from typing import List
 from data_module.dut import Dut
+from data_module.device import Device
 
 
 class PersistHelper:
@@ -38,9 +41,26 @@ class PersistHelper:
         Args:
             dut: Dut instance,including all dut configure
         '''
-
         with open(os.path.join(self.dir, 'dut'), 'wb') as output:
             pickle.dump(dut, output, pickle.HIGHEST_PROTOCOL)
+
+    def persist_server_list(self, server_list: Dict[int, List[Device]]):
+        '''
+        persist server list
+        Args:
+            server_list: server(type: device) list
+        '''
+        with open(os.path.join(self.dir, 'server_list'), 'wb') as output:
+            pickle.dump(server_list, output, pickle.HIGHEST_PROTOCOL)
+
+    def persist_t1_list(self, t1_list: Dict[int, List[Device]]):
+        '''
+        persist t1 list
+        Args:
+            t1_list: server(type: device) list
+        '''
+        with open(os.path.join(self.dir, 't1_list'), 'wb') as output:
+            pickle.dump(t1_list, output, pickle.HIGHEST_PROTOCOL)
 
     def read_dut(self) -> Dut:
         '''
@@ -49,4 +69,22 @@ class PersistHelper:
             dut: Dut instance, init by reading from file
         '''
         with open(os.path.join(self.dir, 'dut'), 'rb') as input_obj:
+            return pickle.load(input_obj)
+
+    def read_server_list(self) -> Dict[int, List[Device]]:
+        '''
+        read server list
+        Return:
+            server_list: init server list by reading from file
+        '''
+        with open(os.path.join(self.dir, 'server_list'), 'rb') as input_obj:
+            return pickle.load(input_obj)
+
+    def read_t1_list(self) -> Dict[int, List[Device]]:
+        '''
+        read dut
+        Return:
+            t1_list: init t1 list by reading from file
+        '''
+        with open(os.path.join(self.dir, 't1_list'), 'rb') as input_obj:
             return pickle.load(input_obj)

--- a/test/sai_test/data_module/persist.py
+++ b/test/sai_test/data_module/persist.py
@@ -24,7 +24,7 @@ from data_module.dut import Dut
 
 class PersistHelper:
     '''
-        store and restore data model
+    store and restore data model
     '''
 
     def __init__(self) -> None:
@@ -35,14 +35,18 @@ class PersistHelper:
     def persist_dut(self, dut: Dut):
         '''
         persist dut intance
+        Args:
+            dut: Dut instance,including all dut configure
         '''
 
         with open(os.path.join(self.dir, 'dut'), 'wb') as output:
             pickle.dump(dut, output, pickle.HIGHEST_PROTOCOL)
 
-    def read_dut(self):
+    def read_dut(self) -> Dut:
         '''
         read dut
+        Return:
+            dut: Dut instance, init by reading from file
         '''
         with open(os.path.join(self.dir, 'dut'), 'rb') as input_obj:
             return pickle.load(input_obj)

--- a/test/sai_test/data_module/persist.py
+++ b/test/sai_test/data_module/persist.py
@@ -46,8 +46,3 @@ class PersistHelper:
         '''
         with open(os.path.join(self.dir, 'dut'), 'rb') as input_obj:
             return pickle.load(input_obj)
-
-if __name__== '__main__':
-    d = Dut()
-    p = PersistHelper()
-    p.persist_dut(d)

--- a/test/sai_test/data_module/persist.py
+++ b/test/sai_test/data_module/persist.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+#
+import pickle
+import os
+from data_module.dut import Dut
+
+
+class PersistHelper:
+    '''
+        store and restore data model
+    '''
+
+    def __init__(self) -> None:
+        self.dir = '/tmp/sai_model'
+        if not os.path.exists(self.dir):
+            os.makedirs(self.dir)
+
+    def persist_dut(self, dut: Dut):
+        '''
+        persist dut intance
+        '''
+
+        with open(os.path.join(self.dir, 'dut'), 'wb') as output:
+            pickle.dump(dut, output, pickle.HIGHEST_PROTOCOL)
+
+    def read_dut(self):
+        '''
+        read dut
+        '''
+        with open(os.path.join(self.dir, 'dut'), 'rb') as input_obj:
+            return pickle.load(input_obj)
+
+if __name__== '__main__':
+    d = Dut()
+    p = PersistHelper()
+    p.persist_dut(d)

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -360,8 +360,6 @@ class T0TestBase(ThriftInterfaceDataPlane):
               wait_sec=5):
         super(T0TestBase, self).setUp()
 
-        self.create_device()
-
         self.port_configer = PortConfiger(self)
         self.switch_configer = SwitchConfiger(self)
         self.fdb_configer = FdbConfiger(self)
@@ -370,6 +368,7 @@ class T0TestBase(ThriftInterfaceDataPlane):
         self.lag_configer = LagConfiger(self)
 
         if force_config or not self.common_configured:
+            self.create_device()
             t0_switch_config_helper(self)
             t0_port_config_helper(
                 test_obj=self,
@@ -394,14 +393,18 @@ class T0TestBase(ThriftInterfaceDataPlane):
                 test_obj=self,
                 is_create_default_route=is_create_default_route,
                 is_create_route_for_lag=is_create_route_for_lag)
-
+            print("common config done.persist it")
+            self.persist_helper.persist_dut(self.dut)
+            self.persist_helper.persist_server_list(self.servers)
+            self.persist_helper.persist_t1_list(self.t1_list)
             print("Waiting for switch to get ready before test, {} seconds ...".format(
                 wait_sec))
             time.sleep(wait_sec)
-            self.persist_helper.persist_dut(self.dut)
         else:
             print("switch keeps running, read config from storage")
             self.dut = self.persist_helper.read_dut()
+            self.t1_list = self.persist_helper.read_t1_list()
+            self.servers = self.persist_helper.read_server_list()
 
     def restore_fdb_config(self):
         """

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -363,7 +363,6 @@ class T0TestBase(ThriftInterfaceDataPlane):
         self.create_device()
 
         self.port_configer = PortConfiger(self)
-
         self.switch_configer = SwitchConfiger(self)
         self.fdb_configer = FdbConfiger(self)
         self.vlan_configer = VlanConfiger(self)
@@ -401,7 +400,7 @@ class T0TestBase(ThriftInterfaceDataPlane):
             time.sleep(wait_sec)
             self.persist_helper.persist_dut(self.dut)
         else:
-            print("swith keeps running, read config from storage")
+            print("switch keeps running, read config from storage")
             self.dut = self.persist_helper.read_dut()
 
     def restore_fdb_config(self):
@@ -481,8 +480,8 @@ class T0TestBase(ThriftInterfaceDataPlane):
     def tearDown(self):
         '''
         tear down
+        todo:
+            if we change the common configure in ths case,
+            we need persist dut again 
         '''
-        t0_fdb_tear_down_helper(self)
-        t0_vlan_tear_down_helper(self)
-        t0_port_tear_down_helper(self)
         super().tearDown()

--- a/test/sai_test/sai_vlan_test.py
+++ b/test/sai_test/sai_vlan_test.py
@@ -79,7 +79,7 @@ class Vlan_Domain_Forwarding_Test(T0TestBase):
             pass
 
     def tearDown(self):
-        pass
+        super().tearDown()
 
 
 class UntagAccessToAccessTest(T0TestBase):
@@ -122,7 +122,7 @@ class UntagAccessToAccessTest(T0TestBase):
             pass
 
     def tearDown(self):
-        pass
+        super().tearDown()
 
 
 class MismatchDropTest(T0TestBase):
@@ -165,7 +165,7 @@ class MismatchDropTest(T0TestBase):
             pass
 
     def tearDown(self):
-        pass
+        super().tearDown()
 
 
 class TaggedFrameFilteringTest(T0TestBase):
@@ -200,7 +200,7 @@ class TaggedFrameFilteringTest(T0TestBase):
             pass
 
     def tearDown(self):
-        pass
+        super().tearDown()
 
 
 class UnTaggedFrameFilteringTest(T0TestBase):
@@ -235,7 +235,7 @@ class UnTaggedFrameFilteringTest(T0TestBase):
             pass
 
     def tearDown(self):
-        pass
+        super().tearDown()
 
 
 class TaggedVlanFloodingTest(T0TestBase):
@@ -264,7 +264,7 @@ class TaggedVlanFloodingTest(T0TestBase):
             pass
 
     def tearDown(self):
-        pass
+        super().tearDown()
 
 
 class UnTaggedVlanFloodingTest(T0TestBase):
@@ -293,7 +293,7 @@ class UnTaggedVlanFloodingTest(T0TestBase):
             pass
 
     def tearDown(self):
-        pass
+        super().tearDown()
 
 
 class BroadcastTest(T0TestBase):
@@ -330,7 +330,7 @@ class BroadcastTest(T0TestBase):
             pass
 
     def tearDown(self):
-        pass
+        super().tearDown()
 
 
 class UntaggedMacLearningTest(T0TestBase):
@@ -410,6 +410,7 @@ class TaggedMacLearningTest(T0TestBase):
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC)
         sleep(2)
+        super().tearDown()
 
 
 class VlanMemberListTest(T0TestBase):
@@ -477,7 +478,7 @@ class VlanMemberListTest(T0TestBase):
                 self.dut.vlans[20].vlan_mport_oids[i - 8], mbr_list[i])
 
     def tearDown(self):
-        pass
+        super().tearDown()
 
 
 class VlanMemberInvalidTest(T0TestBase):
@@ -499,7 +500,7 @@ class VlanMemberInvalidTest(T0TestBase):
         self.assertEqual(incorrect_member, 0)
 
     def tearDown(self):
-        pass
+        super().tearDown()
 
 
 class DisableMacLearningTaggedTest(T0TestBase):
@@ -564,7 +565,7 @@ class DisableMacLearningUntaggedTest(T0TestBase):
         self.assertEqual(attr["available_fdb_entry"] - current_fdb_entry, 0)
 
     def tearDown(self):
-        pass
+        super().tearDown()
 
 
 class ArpRequestFloodingTest(T0TestBase):
@@ -588,7 +589,7 @@ class ArpRequestFloodingTest(T0TestBase):
             self, [self.arp_request], [self.dut.dev_port_list[2:9]])
 
     def tearDown(self):
-        pass
+        super().tearDown()
 
 
 class ArpRequestLearningTest(T0TestBase):
@@ -707,7 +708,7 @@ class TaggedVlanStatusTest(T0TestBase):
         # self.assertEqual(out_bytes, 0, 'vlan OUT bytes counter is not 0')
 
     def tearDown(self):
-        pass
+        super().tearDown()
 
 
 class UntaggedVlanStatusTest(T0TestBase):
@@ -795,4 +796,4 @@ class UntaggedVlanStatusTest(T0TestBase):
         # self.assertEqual(out_bytes, 0, 'vlan OUT bytes counter is not 0')
 
     def tearDown(self):
-        pass
+        super().tearDown()

--- a/test/sai_test/sai_vlan_test.py
+++ b/test/sai_test/sai_vlan_test.py
@@ -370,6 +370,8 @@ class UntaggedMacLearningTest(T0TestBase):
     def tearDown(self):
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC)
+        sleep(2)
+        super().tearDown()
 
 
 class TaggedMacLearningTest(T0TestBase):
@@ -533,7 +535,7 @@ class DisableMacLearningTaggedTest(T0TestBase):
         self.assertEqual(attr["available_fdb_entry"] - current_fdb_entry, 0)
 
     def tearDown(self):
-        pass
+        super().tearDown()
 
 
 class DisableMacLearningUntaggedTest(T0TestBase):

--- a/test/sai_test/sai_vlan_test.py
+++ b/test/sai_test/sai_vlan_test.py
@@ -79,7 +79,7 @@ class Vlan_Domain_Forwarding_Test(T0TestBase):
             pass
 
     def tearDown(self):
-        super().tearDown()
+        pass
 
 
 class UntagAccessToAccessTest(T0TestBase):
@@ -122,7 +122,7 @@ class UntagAccessToAccessTest(T0TestBase):
             pass
 
     def tearDown(self):
-        super().tearDown()
+        pass
 
 
 class MismatchDropTest(T0TestBase):
@@ -165,7 +165,7 @@ class MismatchDropTest(T0TestBase):
             pass
 
     def tearDown(self):
-        super().tearDown()
+        pass
 
 
 class TaggedFrameFilteringTest(T0TestBase):
@@ -200,7 +200,7 @@ class TaggedFrameFilteringTest(T0TestBase):
             pass
 
     def tearDown(self):
-        super().tearDown()
+        pass
 
 
 class UnTaggedFrameFilteringTest(T0TestBase):
@@ -235,7 +235,7 @@ class UnTaggedFrameFilteringTest(T0TestBase):
             pass
 
     def tearDown(self):
-        super().tearDown()
+        pass
 
 
 class TaggedVlanFloodingTest(T0TestBase):
@@ -264,7 +264,7 @@ class TaggedVlanFloodingTest(T0TestBase):
             pass
 
     def tearDown(self):
-        super().tearDown()
+        pass
 
 
 class UnTaggedVlanFloodingTest(T0TestBase):
@@ -293,7 +293,7 @@ class UnTaggedVlanFloodingTest(T0TestBase):
             pass
 
     def tearDown(self):
-        super().tearDown()
+        pass
 
 
 class BroadcastTest(T0TestBase):
@@ -330,7 +330,7 @@ class BroadcastTest(T0TestBase):
             pass
 
     def tearDown(self):
-        super().tearDown()
+        pass
 
 
 class UntaggedMacLearningTest(T0TestBase):
@@ -368,7 +368,8 @@ class UntaggedMacLearningTest(T0TestBase):
             pass
 
     def tearDown(self):
-        super().tearDown()
+        sai_thrift_flush_fdb_entries(
+            self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC)
 
 
 class TaggedMacLearningTest(T0TestBase):
@@ -406,7 +407,9 @@ class TaggedMacLearningTest(T0TestBase):
             pass
 
     def tearDown(self):
-        super().tearDown()
+        sai_thrift_flush_fdb_entries(
+            self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC)
+        sleep(2)
 
 
 class VlanMemberListTest(T0TestBase):
@@ -474,7 +477,7 @@ class VlanMemberListTest(T0TestBase):
                 self.dut.vlans[20].vlan_mport_oids[i - 8], mbr_list[i])
 
     def tearDown(self):
-        super().tearDown()
+        pass
 
 
 class VlanMemberInvalidTest(T0TestBase):
@@ -496,7 +499,7 @@ class VlanMemberInvalidTest(T0TestBase):
         self.assertEqual(incorrect_member, 0)
 
     def tearDown(self):
-        super().tearDown()
+        pass
 
 
 class DisableMacLearningTaggedTest(T0TestBase):
@@ -529,7 +532,7 @@ class DisableMacLearningTaggedTest(T0TestBase):
         self.assertEqual(attr["available_fdb_entry"] - current_fdb_entry, 0)
 
     def tearDown(self):
-        super().tearDown()
+        pass
 
 
 class DisableMacLearningUntaggedTest(T0TestBase):
@@ -561,7 +564,7 @@ class DisableMacLearningUntaggedTest(T0TestBase):
         self.assertEqual(attr["available_fdb_entry"] - current_fdb_entry, 0)
 
     def tearDown(self):
-        super().tearDown()
+        pass
 
 
 class ArpRequestFloodingTest(T0TestBase):
@@ -585,7 +588,7 @@ class ArpRequestFloodingTest(T0TestBase):
             self, [self.arp_request], [self.dut.dev_port_list[2:9]])
 
     def tearDown(self):
-        super().tearDown()
+        pass
 
 
 class ArpRequestLearningTest(T0TestBase):
@@ -614,7 +617,9 @@ class ArpRequestLearningTest(T0TestBase):
         verify_no_other_packets(self)
 
     def tearDown(self):
-        super().tearDown()
+        sai_thrift_flush_fdb_entries(
+            self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC)
+        sleep(2)
 
 
 class TaggedVlanStatusTest(T0TestBase):
@@ -702,7 +707,7 @@ class TaggedVlanStatusTest(T0TestBase):
         # self.assertEqual(out_bytes, 0, 'vlan OUT bytes counter is not 0')
 
     def tearDown(self):
-        super().tearDown()
+        pass
 
 
 class UntaggedVlanStatusTest(T0TestBase):
@@ -790,4 +795,4 @@ class UntaggedVlanStatusTest(T0TestBase):
         # self.assertEqual(out_bytes, 0, 'vlan OUT bytes counter is not 0')
 
     def tearDown(self):
-        super().tearDown()
+        pass


### PR DESCRIPTION
GOAL:
   run all the vlan cases, no need restart, no need common configure multiple times.
METHOD:
  when first common config, we persist dut instance. when test remaining cases,  don't do common configure again and read dut configure.
 In the tearDown for each cases, we just remove all the configure we set locally.
TEST:
   test all vlan cases

COMMAND:
we use `common_configured` to control whether writing or reading common configures. there are two examples blow,you can also use[ this script](https://github.com/ms-junyi/ms-script/blob/master/run.sh) to run multiple cases per time.

- writing configures(first time):

`    ptf --test-dir $DIR $testcase --interface '0-0@eth0' --interface '0-1@eth1' --interface '0-2@eth2' --interface '0-3@eth3' --interface '0-4@eth4' --interface '0-5@eth5' --interface '0-6@eth6' --interface '0-7@eth7' --interface '0-8@eth8' --interface '0-9@eth9' --interface '0-10@eth10' --interface '0-11@eth11' --interface '0-12@eth12' --interface '0-13@eth13' --interface '0-14@eth14' --interface '0-15@eth15' --interface '0-16@eth16' --interface '0-17@eth17' --interface '0-18@eth18' --interface '0-19@eth19' --interface '0-20@eth20' --interface '0-21@eth21' --interface '0-22@eth22' --interface '0-23@eth23' --interface '0-24@eth24' --interface '0-25@eth25' --interface '0-26@eth26' --interface '0-27@eth27' --interface '0-28@eth28' --interface '0-29@eth29' --interface '0-30@eth30' --interface '0-31@eth31'  --relax "--test-params=thrift_server='$DUTIP';port_config_ini='$PORTPATH';common_configured=false";
`

- reading configures(remaining cases):

`    ptf --test-dir $DIR $testcase --interface '0-0@eth0' --interface '0-1@eth1' --interface '0-2@eth2' --interface '0-3@eth3' --interface '0-4@eth4' --interface '0-5@eth5' --interface '0-6@eth6' --interface '0-7@eth7' --interface '0-8@eth8' --interface '0-9@eth9' --interface '0-10@eth10' --interface '0-11@eth11' --interface '0-12@eth12' --interface '0-13@eth13' --interface '0-14@eth14' --interface '0-15@eth15' --interface '0-16@eth16' --interface '0-17@eth17' --interface '0-18@eth18' --interface '0-19@eth19' --interface '0-20@eth20' --interface '0-21@eth21' --interface '0-22@eth22' --interface '0-23@eth23' --interface '0-24@eth24' --interface '0-25@eth25' --interface '0-26@eth26' --interface '0-27@eth27' --interface '0-28@eth28' --interface '0-29@eth29' --interface '0-30@eth30' --interface '0-31@eth31'  --relax "--test-params=thrift_server='$DUTIP';port_config_ini='$PORTPATH';common_configured=true";
`
Signed-off-by: ms-junyi <t-junyixiao@microsoft.com>