### PR TITLE
reconfig servers list start from 0 instead of 1

### DIFF
--- a/test/sai_test/config/fdb_configer.py
+++ b/test/sai_test/config/fdb_configer.py
@@ -48,12 +48,12 @@ def t0_fdb_config_helper(test_obj: 'T0TestBase', is_create_fdb=True):
             vlan_oid=test_obj.dut.default_vlan_id)
         test_obj.dut.vlan_10_fdb_list = configer.create_fdb_entries(
             switch_id=test_obj.dut.switch_id,
-            server_list=test_obj.servers[1][0:8],
+            server_list=test_obj.servers[1][1:9],
             port_idxs=range(1, 9),
             vlan_oid=test_obj.dut.vlans[10].vlan_oid)
         test_obj.dut.vlan_20_fdb_list = configer.create_fdb_entries(
             switch_id=test_obj.dut.switch_id,
-            server_list=test_obj.servers[2][0:8],
+            server_list=test_obj.servers[2][1:9],
             port_idxs=range(9, 17),
             vlan_oid=test_obj.dut.vlans[20].vlan_oid)
     # Todo dynamic use the vlan_member_port_map to add data to fdb

--- a/test/sai_test/config/route_configer.py
+++ b/test/sai_test/config/route_configer.py
@@ -35,11 +35,14 @@ if TYPE_CHECKING:
     from sai_test_base import T0TestBase
 
 
-def t0_route_config_helper(test_obj: 'T0TestBase', is_create_default_route=True, is_create_route_for_lag=True):
+def t0_route_config_helper(test_obj: 'T0TestBase', is_create_default_route=True, is_create_default_loopback_interface=False, is_create_route_for_lag=True):
     route_configer = RouteConfiger(test_obj)
     if is_create_default_route:
         route_configer.create_default_route()
         route_configer.create_router_interface_by_port_idx(port_idx=0)
+
+    if is_create_default_loopback_interface:
+        route_configer.create_default_loopback_interface()
 
     if is_create_route_for_lag:
         test_obj.servers[11][0].ip_prefix = '24'
@@ -79,7 +82,6 @@ class RouteConfiger(object):
     def create_default_route(self):
         self.create_default_route_intf()
         self.create_default_v4_v6_route_entry()
-        # self.create_local_v6_route()
 
     def create_default_route_intf(self):
         """
@@ -91,6 +93,7 @@ class RouteConfiger(object):
         self.test_obj.assertNotEqual(attr['default_virtual_router_id'], 0)
         self.test_obj.dut.default_vrf = attr['default_virtual_router_id']
 
+    def create_default_loopback_interface(self):
         self.test_obj.dut.loopback_intf = sai_thrift_create_router_interface(self.client,
                                                                              type=SAI_ROUTER_INTERFACE_TYPE_LOOPBACK, virtual_router_id=self.test_obj.dut.default_vrf)
         self.test_obj.assertEqual(self.test_obj.status(), SAI_STATUS_SUCCESS)

--- a/test/sai_test/config/route_configer.py
+++ b/test/sai_test/config/route_configer.py
@@ -36,6 +36,17 @@ if TYPE_CHECKING:
 
 
 def t0_route_config_helper(test_obj: 'T0TestBase', is_create_default_route=True, is_create_default_loopback_interface=False, is_create_route_for_lag=True):
+    """
+    Make t0 route configurations base on the configuration in the test plan.
+    Set the configuration in test directly.
+
+    Set the following test_obj attributes:
+        int: default_vrf
+        port_rif_list[0]
+        default_ipv6_route_entry
+        default_ipv4_route_entry
+        neighbor and route for lag
+    """
     route_configer = RouteConfiger(test_obj)
     if is_create_default_route:
         route_configer.create_default_route()

--- a/test/sai_test/config/route_configer.py
+++ b/test/sai_test/config/route_configer.py
@@ -45,19 +45,19 @@ def t0_route_config_helper(test_obj: 'T0TestBase', is_create_default_route=True,
         test_obj.servers[11][0].ip_prefix = '24'
         test_obj.servers[11][0].ip_prefix_v6 = '112'
         route_configer.create_neighbor_by_lag(
-            nexthop_device=test_obj.t1_list[1][0], lag=test_obj.dut.lag1)
+            nexthop_device=test_obj.t1_list[1][100], lag=test_obj.dut.lag1)
         route_configer.create_route_path_by_nexthop_from_lag(
             dest_device=test_obj.servers[11][0],
-            nexthop_device=test_obj.t1_list[1][0],
+            nexthop_device=test_obj.t1_list[1][100],
             lag=test_obj.dut.lag1)
 
         test_obj.servers[12][0].ip_prefix = '24'
         test_obj.servers[12][0].ip_prefix_v6 = '112'
         route_configer.create_neighbor_by_lag(
-            nexthop_device=test_obj.t1_list[2][0], lag=test_obj.dut.lag2)
+            nexthop_device=test_obj.t1_list[2][100], lag=test_obj.dut.lag2)
         route_configer.create_route_path_by_nexthop_from_lag(
             dest_device=test_obj.servers[12][0],
-            nexthop_device=test_obj.t1_list[2][0],
+            nexthop_device=test_obj.t1_list[2][100],
             lag=test_obj.dut.lag2)
 
 

--- a/test/sai_test/config/route_configer.py
+++ b/test/sai_test/config/route_configer.py
@@ -80,20 +80,23 @@ class RouteConfiger(object):
         self.client = test_obj.client
 
     def create_default_route(self):
-        self.create_default_route_intf()
+        self.get_default_virtual_router()
         self.create_default_v4_v6_route_entry()
 
-    def create_default_route_intf(self):
+    def get_default_virtual_router(self):
         """
-        Create default route interface on loop back interface.
+        Get default virtual_router_id
         """
-        print("Create loop back interface...")
+        print("Get default virtual router id...")
         attr = sai_thrift_get_switch_attribute(
             self.client, default_virtual_router_id=True)
         self.test_obj.assertNotEqual(attr['default_virtual_router_id'], 0)
         self.test_obj.dut.default_vrf = attr['default_virtual_router_id']
 
     def create_default_loopback_interface(self):
+        """
+        Create loopback interface on default virtual router.
+        """
         self.test_obj.dut.loopback_intf = sai_thrift_create_router_interface(self.client,
                                                                              type=SAI_ROUTER_INTERFACE_TYPE_LOOPBACK, virtual_router_id=self.test_obj.dut.default_vrf)
         self.test_obj.assertEqual(self.test_obj.status(), SAI_STATUS_SUCCESS)

--- a/test/sai_test/data_module/device.py
+++ b/test/sai_test/data_module/device.py
@@ -36,9 +36,9 @@ class Device(object):
     """
         Create servers(0-17) ip list.
 
-        server0: IP 192.168.0.1~150
-        server1: IP 192.168.1.1~150
-        server2: IP 192.168.2.1~150
+        server0: IP 192.168.0.0~150
+        server1: IP 192.168.1.0~150
+        server2: IP 192.168.2.0~150
         .....
 
         class attributes:

--- a/test/sai_test/data_module/device.py
+++ b/test/sai_test/data_module/device.py
@@ -34,18 +34,10 @@ class DeviceType(Enum):
 
 class Device(object):
     """
-        Create servers(0-17) ip list.
-
-        server0: IP 192.168.0.0~150
-        server1: IP 192.168.1.0~150
-        server2: IP 192.168.2.0~150
-        .....
-
         class attributes:
             type: device type, T1, Server
             id: device id, equals to index
             group_id: device group id
-            ip_num: numbers of ips
             mac: mac address
             ipv4: ip v4
             ipv6: ip v6
@@ -61,7 +53,7 @@ class Device(object):
             fdb_entry
     """
 
-    def __init__(self, device_type, id, group_id=None, ip_num=150):
+    def __init__(self, device_type, id, group_id=None):
         """
         Init the Device object, different device type  have different attributes
 
@@ -69,7 +61,6 @@ class Device(object):
             type: device type, T1, Server
             id: device id, equals to index
             group_id: device group id
-            ip_num: numbers of ips
             mac: mac address
             ipv4: ip v4
             ipv6: ip v6
@@ -111,10 +102,7 @@ class Device(object):
         """
         device group id
         """
-        self.ip_num = ip_num
-        """
-        numbers of ips
-        """
+
         self.ip_prefix = None
         self.ip_prefix_v6 = None
         if self.type == DeviceType.server:

--- a/test/sai_test/sai_fdb_test.py
+++ b/test/sai_test/sai_fdb_test.py
@@ -50,15 +50,15 @@ class L2PortForwardingTest(T0TestBase):
                 print("L2 Forwarding from {} to port: {}".format(
                     self.dut.dev_port_list[1],
                     self.dut.dev_port_list[index]))
-                pkt = simple_udp_packet(eth_dst=self.servers[1][index-1].mac,
-                                        eth_src=self.servers[1][0].mac,
+                pkt = simple_udp_packet(eth_dst=self.servers[1][index].mac,
+                                        eth_src=self.servers[1][1].mac,
                                         vlan_vid=10,
                                         ip_id=101,
                                         ip_ttl=64)
 
                 send_packet(self, self.dut.dev_port_list[1], pkt)
                 verify_packet(
-                    self, pkt, self.servers[1][index-1].l2_egress_port_idx)
+                    self, pkt, self.servers[1][index].l2_egress_port_idx)
                 verify_no_other_packets(self)
         finally:
             pass
@@ -364,16 +364,16 @@ class NewVlanmemberLearnTest(T0TestBase):
         """
         print("NewVlanmemberLearnTest")
         unknown_mac1 = "00:01:01:99:99:99"
-        self.pkt1 = simple_udp_packet(eth_dst=self.servers[1][0].mac,
+        self.pkt1 = simple_udp_packet(eth_dst=self.servers[1][1].mac,
                                       eth_src=unknown_mac1)
         self.pkt2 = simple_udp_packet(eth_dst=unknown_mac1,
-                                      eth_src=self.servers[1][0].mac)
+                                      eth_src=self.servers[1][1].mac)
         attr = sai_thrift_get_switch_attribute(
             self.client, available_fdb_entry=True)
         saved_fdb_entry = attr["available_fdb_entry"]
 
         send_packet(self, 24, self.pkt1)
-        verify_packet(self, self.pkt1, self.servers[1][0].l2_egress_port_idx)
+        verify_packet(self, self.pkt1, self.servers[1][1].l2_egress_port_idx)
         verify_no_other_packets(self)
 
         send_packet(self, 1, self.pkt2)
@@ -420,11 +420,11 @@ class RemoveVlanmemberLearnTest(T0TestBase):
         """
         print("RemoveVlanmemberLearnTest")
         unknown_mac1 = "00:01:01:99:99:99"
-        self.pkt1 = simple_udp_packet(eth_dst=self.servers[1][1].mac,
+        self.pkt1 = simple_udp_packet(eth_dst=self.servers[1][2].mac,
                                       eth_src=unknown_mac1,
                                       vlan_vid=10)
         self.pkt2 = simple_udp_packet(eth_dst=unknown_mac1,
-                                      eth_src=self.servers[1][0].mac,
+                                      eth_src=self.servers[1][1].mac,
                                       vlan_vid=10)
         attr = sai_thrift_get_switch_attribute(
             self.client, available_fdb_entry=True)
@@ -475,11 +475,11 @@ class InvalidateVlanmemberNoLearnTest(T0TestBase):
         """
         print("InvalidateVlanmemberNoLearnTest")
         unknown_mac1 = "00:01:01:99:99:99"
-        self.pkt1 = simple_udp_packet(eth_dst=self.servers[1][0].mac,
+        self.pkt1 = simple_udp_packet(eth_dst=self.servers[1][1].mac,
                                       eth_src=unknown_mac1,
                                       vlan_vid=11)
         self.pkt2 = simple_udp_packet(eth_dst=unknown_mac1,
-                                      eth_src=self.servers[1][0].mac,
+                                      eth_src=self.servers[1][1].mac,
                                       vlan_vid=11)
         attr = sai_thrift_get_switch_attribute(
             self.client, available_fdb_entry=True)
@@ -636,25 +636,25 @@ class FdbAgingTest(T0TestBase):
         """
         print("FdbAgingTest")
         unknown_mac1 = "00:01:01:99:99:99"
-        pkt = simple_udp_packet(eth_dst=self.servers[1][0].mac,
+        pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
                                 eth_src=unknown_mac1,
                                 pktlen=100)
-        tag_pkt = simple_udp_packet(eth_dst=self.servers[1][0].mac,
+        tag_pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
                                     eth_src=unknown_mac1,
                                     dl_vlan_enable=True,
                                     vlan_vid=10,
                                     pktlen=104)
         send_packet(self, 2, tag_pkt)
-        verify_packets(self, pkt, [self.servers[1][0].l2_egress_port_idx])
+        verify_packets(self, pkt, [self.servers[1][1].l2_egress_port_idx])
         verify_no_other_packets(self)
         time.sleep(1)
 
         print("Verifying if MAC address was learned")
         pkt = simple_udp_packet(eth_dst=unknown_mac1,
-                                eth_src=self.servers[1][0].mac,
+                                eth_src=self.servers[1][1].mac,
                                 pktlen=100)
         tag_pkt = simple_udp_packet(eth_dst=unknown_mac1,
-                                    eth_src=self.servers[1][0].mac,
+                                    eth_src=self.servers[1][1].mac,
                                     dl_vlan_enable=True,
                                     vlan_vid=10,
                                     pktlen=104)
@@ -722,19 +722,19 @@ class FdbAgingAfterMoveTest(T0TestBase):
         """
         print("FdbAgingAfterMoveTest")
         unknown_mac1 = "00:01:01:99:99:99"
-        pkt = simple_udp_packet(eth_dst=self.servers[1][0].mac,
+        pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
                                 eth_src=unknown_mac1,
                                 pktlen=100)
-        tag_pkt = simple_udp_packet(eth_dst=self.servers[1][0].mac,
+        tag_pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
                                     eth_src=unknown_mac1,
                                     dl_vlan_enable=True,
                                     vlan_vid=10,
                                     pktlen=104)
         chk_pkt = simple_udp_packet(eth_dst=unknown_mac1,
-                                    eth_src=self.servers[1][0].mac,
+                                    eth_src=self.servers[1][1].mac,
                                     pktlen=100)
         chk_tag_pkt = simple_udp_packet(eth_dst=unknown_mac1,
-                                        eth_src=self.servers[1][0].mac,
+                                        eth_src=self.servers[1][1].mac,
                                         dl_vlan_enable=True,
                                         vlan_vid=10,
                                         pktlen=104)
@@ -828,19 +828,19 @@ class FdbMacMovingAfterAgingTest(T0TestBase):
         """
         print("FdbMacMovingAfterAgingTest")
         unknown_mac1 = "00:01:01:99:99:99"
-        pkt = simple_udp_packet(eth_dst=self.servers[1][0].mac,
+        pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
                                 eth_src=unknown_mac1,
                                 pktlen=100)
-        tag_pkt = simple_udp_packet(eth_dst=self.servers[1][0].mac,
+        tag_pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
                                     eth_src=unknown_mac1,
                                     dl_vlan_enable=True,
                                     vlan_vid=10,
                                     pktlen=104)
         chk_pkt = simple_udp_packet(eth_dst=unknown_mac1,
-                                    eth_src=self.servers[1][0].mac,
+                                    eth_src=self.servers[1][1].mac,
                                     pktlen=100)
         chk_tag_pkt = simple_udp_packet(eth_dst=unknown_mac1,
-                                        eth_src=self.servers[1][0].mac,
+                                        eth_src=self.servers[1][1].mac,
                                         dl_vlan_enable=True,
                                         vlan_vid=10,
                                         pktlen=104)
@@ -912,14 +912,14 @@ class FdbFlushVlanStaticTest(T0TestBase):
         4. Send packets :  ``Port9`` DMAC=``Port10 MAC``
         5. Verify flush happens in a certain domain, unicast to the corresponding port.
         """
-        pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
+        pkt = simple_udp_packet(eth_dst=self.servers[1][2].mac,
                                 pktlen=100)
         send_packet(self, 1, pkt)
         verify_each_packet_on_multiple_port_lists(
             self, [pkt], [self.dut.dev_port_list[2:9]])
         print("\tVerified the flooding happend")
         time.sleep(1)
-        pkt = simple_udp_packet(eth_dst=self.servers[1][9].mac,
+        pkt = simple_udp_packet(eth_dst=self.servers[1][10].mac,
                                 pktlen=100)
         send_packet(self, 9, pkt)
         verify_each_packet_on_multiple_port_lists(
@@ -960,14 +960,14 @@ class FdbFlushPortStaticTest(T0TestBase):
         4. Send packets  ``Port10`` DMAC=``Port9 MAC``
         5. Verify flush happens in a certain domain, unicast to the corresponding port.
         """
-        pkt = simple_udp_packet(eth_dst=self.servers[1][0].mac,
+        pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
                                 pktlen=100)
         send_packet(self, 2, pkt)
         verify_each_packet_on_multiple_port_lists(
             self, [pkt], [self.dut.dev_port_list[2:9]])
         print("\tVerified the flooding happend")
         time.sleep(1)
-        pkt = simple_udp_packet(eth_dst=self.servers[1][8].mac,
+        pkt = simple_udp_packet(eth_dst=self.servers[1][9].mac,
                                 pktlen=100)
         send_packet(self, 10, pkt)
         verify_each_packet_on_multiple_port_lists(
@@ -1007,14 +1007,14 @@ class FdbFlushAllStaticTest(T0TestBase):
         4. Send packets :  ``Port9`` DMAC=``Port10 MAC``
         5. Verify flush happens in a certain domain, unicast to the corresponding port.
         """
-        pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
+        pkt = simple_udp_packet(eth_dst=self.servers[1][2].mac,
                                 pktlen=100)
         send_packet(self, 1, pkt)
         verify_each_packet_on_multiple_port_lists(
             self, [pkt], [self.dut.dev_port_list[2:9]])
         print("\tVerified the flooding happend")
         time.sleep(1)
-        pkt = simple_udp_packet(eth_dst=self.servers[1][9].mac,
+        pkt = simple_udp_packet(eth_dst=self.servers[1][10].mac,
                                 pktlen=100)
         send_packet(self, 9, pkt)
         verify_each_packet_on_multiple_port_lists(
@@ -1125,19 +1125,19 @@ class FdbFlushPortDynamicTest(T0TestBase):
         9. verify flooding happen
         """
         unknown_mac1 = "00:01:01:99:99:99"
-        pkt = simple_udp_packet(eth_dst=self.servers[1][9].mac,
+        pkt = simple_udp_packet(eth_dst=self.servers[1][10].mac,
                                 eth_src=unknown_mac1,
                                 pktlen=100)
-        tag_pkt = simple_udp_packet(eth_dst=self.servers[1][9].mac,
+        tag_pkt = simple_udp_packet(eth_dst=self.servers[1][10].mac,
                                     eth_src=unknown_mac1,
                                     dl_vlan_enable=True,
                                     vlan_vid=20,
                                     pktlen=104)
         chk_pkt = simple_udp_packet(eth_dst=unknown_mac1,
-                                    eth_src=self.servers[1][9].mac,
+                                    eth_src=self.servers[1][10].mac,
                                     pktlen=100)
         chk_tag_pkt = simple_udp_packet(eth_dst=unknown_mac1,
-                                        eth_src=self.servers[1][9].mac,
+                                        eth_src=self.servers[1][10].mac,
                                         dl_vlan_enable=True,
                                         vlan_vid=20,
                                         pktlen=104)
@@ -1199,19 +1199,19 @@ class FdbFlushAllDynamicTest(T0TestBase):
         9. verify flooding happen
         """
         unknown_mac1 = "00:01:01:99:99:99"
-        pkt = simple_udp_packet(eth_dst=self.servers[1][9].mac,
+        pkt = simple_udp_packet(eth_dst=self.servers[1][10].mac,
                                 eth_src=unknown_mac1,
                                 pktlen=100)
-        tag_pkt = simple_udp_packet(eth_dst=self.servers[1][9].mac,
+        tag_pkt = simple_udp_packet(eth_dst=self.servers[1][10].mac,
                                     eth_src=unknown_mac1,
                                     dl_vlan_enable=True,
                                     vlan_vid=20,
                                     pktlen=104)
         chk_pkt = simple_udp_packet(eth_dst=unknown_mac1,
-                                    eth_src=self.servers[1][9].mac,
+                                    eth_src=self.servers[1][10].mac,
                                     pktlen=100)
         chk_tag_pkt = simple_udp_packet(eth_dst=unknown_mac1,
-                                        eth_src=self.servers[1][9].mac,
+                                        eth_src=self.servers[1][10].mac,
                                         dl_vlan_enable=True,
                                         vlan_vid=20,
                                         pktlen=104)
@@ -1279,19 +1279,19 @@ class FdbFlushAllTest(T0TestBase):
         9. verify flooding happen
         """
         unknown_mac1 = "00:01:01:99:99:99"
-        pkt = simple_udp_packet(eth_dst=self.servers[1][9].mac,
+        pkt = simple_udp_packet(eth_dst=self.servers[1][10].mac,
                                 eth_src=unknown_mac1,
                                 pktlen=100)
-        tag_pkt = simple_udp_packet(eth_dst=self.servers[1][9].mac,
+        tag_pkt = simple_udp_packet(eth_dst=self.servers[1][10].mac,
                                     eth_src=unknown_mac1,
                                     dl_vlan_enable=True,
                                     vlan_vid=20,
                                     pktlen=104)
         chk_pkt = simple_udp_packet(eth_dst=unknown_mac1,
-                                    eth_src=self.servers[1][9].mac,
+                                    eth_src=self.servers[1][10].mac,
                                     pktlen=100)
         chk_tag_pkt = simple_udp_packet(eth_dst=unknown_mac1,
-                                        eth_src=self.servers[1][9].mac,
+                                        eth_src=self.servers[1][10].mac,
                                         dl_vlan_enable=True,
                                         vlan_vid=20,
                                         pktlen=104)
@@ -1340,7 +1340,7 @@ class FdbDisableMacMoveDropTest(T0TestBase):
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         self.fdb_entry = sai_thrift_fdb_entry_t(switch_id=self.dut.switch_id,
-                                                mac_address=self.servers[1][0].mac,
+                                                mac_address=self.servers[1][1].mac,
                                                 bv_id=self.dut.vlans[10].vlan_oid)
         status = sai_thrift_create_fdb_entry(self.client,
                                              self.fdb_entry,
@@ -1358,11 +1358,11 @@ class FdbDisableMacMoveDropTest(T0TestBase):
         5. Send packet in step2 on port3
         6. Verify the packet gets dropped
         """
-        self.pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
-                                     eth_src=self.servers[1][0].mac,
+        self.pkt = simple_udp_packet(eth_dst=self.servers[1][2].mac,
+                                     eth_src=self.servers[1][1].mac,
                                      pktlen=100)
         send_packet(self, 1, self.pkt)
-        verify_packet(self, self.pkt, self.servers[1][1].l2_egress_port_idx)
+        verify_packet(self, self.pkt, self.servers[1][2].l2_egress_port_idx)
 
         send_packet(self, 3, self.pkt)
         verify_no_other_packets(self)
@@ -1402,15 +1402,15 @@ class FdbDynamicMacMoveTest(T0TestBase):
         8. Send packet in step2 on port3
         9. Verify packet received on port2
         """
-        self.pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
-                                     eth_src=self.servers[1][0].mac,
+        self.pkt = simple_udp_packet(eth_dst=self.servers[1][2].mac,
+                                     eth_src=self.servers[1][1].mac,
                                      pktlen=100)
         send_packet(self, 1, self.pkt)
-        verify_packet(self, self.pkt, self.servers[1][1].l2_egress_port_idx)
+        verify_packet(self, self.pkt, self.servers[1][2].l2_egress_port_idx)
         # inititally add moving MAC to FDB
         self.moving_fdb_entry = sai_thrift_fdb_entry_t(
             switch_id=self.dut.switch_id,
-            mac_address=self.servers[1][0].mac)
+            mac_address=self.servers[1][1].mac)
         status = sai_thrift_create_fdb_entry(
             self.client,
             self.moving_fdb_entry,
@@ -1451,7 +1451,7 @@ class FdbStaticMacMoveTest(T0TestBase):
             self.client,
             entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)
         self.fdb_entry1 = sai_thrift_fdb_entry_t(switch_id=self.dut.switch_id,
-                                                 mac_address=self.servers[1][1].mac,
+                                                 mac_address=self.servers[1][2].mac,
                                                  bv_id=self.dut.vlans[10].vlan_oid)
         status = sai_thrift_create_fdb_entry(self.client,
                                              self.fdb_entry1,
@@ -1460,7 +1460,7 @@ class FdbStaticMacMoveTest(T0TestBase):
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
         self.fdb_entry2 = sai_thrift_fdb_entry_t(switch_id=self.dut.switch_id,
-                                                 mac_address=self.servers[1][0].mac,
+                                                 mac_address=self.servers[1][1].mac,
                                                  bv_id=self.dut.vlans[10].vlan_oid)
         status = sai_thrift_create_fdb_entry(self.client,
                                              self.fdb_entry2,
@@ -1482,16 +1482,16 @@ class FdbStaticMacMoveTest(T0TestBase):
         9. Send packet in step2 on port3
         10. Verify packet received on port2
         """
-        self.pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
-                                     eth_src=self.servers[1][0].mac,
+        self.pkt = simple_udp_packet(eth_dst=self.servers[1][2].mac,
+                                     eth_src=self.servers[1][1].mac,
                                      pktlen=100)
         send_packet(self, 1, self.pkt)
-        verify_packet(self, self.pkt, self.servers[1][1].l2_egress_port_idx)
+        verify_packet(self, self.pkt, self.servers[1][2].l2_egress_port_idx)
 
         # inititally add moving MAC to FDB
         self.moving_fdb_entry = sai_thrift_fdb_entry_t(
             switch_id=self.dut.switch_id,
-            mac_address=self.servers[1][0].mac)
+            mac_address=self.servers[1][1].mac)
         status = sai_thrift_create_fdb_entry(
             self.client,
             self.moving_fdb_entry,

--- a/test/sai_test/sai_lag_test.py
+++ b/test/sai_test/sai_lag_test.py
@@ -38,29 +38,29 @@ class LagConfigTest(T0TestBase):
                                                             virtual_router_id=self.dut.default_vrf,
                                                             type=SAI_ROUTER_INTERFACE_TYPE_PORT,
                                                             port_id=self.dut.port_list[1])
-        ip_dst = self.servers[11][0].ipv4
+        ip_dst = self.servers[11][1].ipv4
         pkt1 = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                 eth_src=self.servers[1][0].mac,
+                                 eth_src=self.servers[1][1].mac,
                                  ip_dst=ip_dst,
-                                 ip_src=self.servers[1][0].ipv4,
+                                 ip_src=self.servers[1][1].ipv4,
                                  ip_id=105,
                                  ip_ttl=64)
         pkt2 = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                 eth_src=self.servers[2][0].mac,
+                                 eth_src=self.servers[2][1].mac,
                                  ip_dst=ip_dst,
-                                 ip_src=self.servers[2][0].ipv4,
+                                 ip_src=self.servers[2][1].ipv4,
                                  ip_id=105,
                                  ip_ttl=64)
         exp_pkt1 = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
                                      eth_src=ROUTER_MAC,
                                      ip_dst=ip_dst,
-                                     ip_src=self.servers[1][0].ipv4,
+                                     ip_src=self.servers[1][1].ipv4,
                                      ip_id=105,
                                      ip_ttl=63)
         exp_pkt2 = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
                                      eth_src=ROUTER_MAC,
                                      ip_dst=ip_dst,
-                                     ip_src=self.servers[2][0].ipv4,
+                                     ip_src=self.servers[2][1].ipv4,
                                      ip_id=105,
                                      ip_ttl=63)
         send_packet(self, 1, pkt1)
@@ -111,16 +111,16 @@ class LoadbalanceOnSrcPortTest(T0TestBase):
             for i in range(0, max_itrs):
                 src_port = begin_port + i
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                        eth_src=self.servers[1][0].mac,
-                                        ip_dst=self.servers[11][0].ipv4,
-                                        ip_src=self.servers[1][0].ipv4,
+                                        eth_src=self.servers[1][1].mac,
+                                        ip_dst=self.servers[11][1].ipv4,
+                                        ip_src=self.servers[1][1].ipv4,
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
                                             eth_src=ROUTER_MAC,
-                                            ip_dst=self.servers[11][0].ipv4,
-                                            ip_src=self.servers[1][0].ipv4,
+                                            ip_dst=self.servers[11][1].ipv4,
+                                            ip_src=self.servers[1][1].ipv4,
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
@@ -171,16 +171,16 @@ class LoadbalanceOnDesPortTest(T0TestBase):
             for i in range(0, max_itrs):
                 des_port = begin_port + i
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                        eth_src=self.servers[1][0].mac,
-                                        ip_dst=self.servers[11][0].ipv4,
-                                        ip_src=self.servers[1][0].ipv4,
+                                        eth_src=self.servers[1][1].mac,
+                                        ip_dst=self.servers[11][1].ipv4,
+                                        ip_src=self.servers[1][1].ipv4,
                                         tcp_dport=des_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
                                             eth_src=ROUTER_MAC,
-                                            ip_dst=self.servers[11][0].ipv4,
-                                            ip_src=self.servers[1][0].ipv4,
+                                            ip_dst=self.servers[11][1].ipv4,
+                                            ip_src=self.servers[1][1].ipv4,
                                             tcp_dport=des_port,
                                             ip_id=105,
                                             ip_ttl=63)
@@ -228,16 +228,16 @@ class LoadbalanceOnSrcIPTest(T0TestBase):
                                                                 port_id=self.dut.port_list[1])
             max_itrs = 99
             rcv_count = [0, 0]
-            for i in range(0, max_itrs):
+            for i in range(1, max_itrs):
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                         eth_src=self.servers[1][i].mac,
-                                        ip_dst=self.servers[11][0].ipv4,
+                                        ip_dst=self.servers[11][1].ipv4,
                                         ip_src=self.servers[1][i].ipv4,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
                                             eth_src=ROUTER_MAC,
-                                            ip_dst=self.servers[11][0].ipv4,
+                                            ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][i].ipv4,
                                             ip_id=105,
                                             ip_ttl=63)
@@ -286,24 +286,24 @@ class LoadbalanceOnDesIPTest(T0TestBase):
                                                                 port_id=self.dut.port_list[1])
             max_itrs = 99
             rcv_count = [0, 0]
-            for i in range(0, max_itrs):
+            for i in range(1, max_itrs):
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                        eth_src=self.servers[1][0].mac,
+                                        eth_src=self.servers[1][1].mac,
                                         ip_dst=self.servers[11][i].ipv4,
-                                        ip_src=self.servers[1][0].ipv4,
+                                        ip_src=self.servers[1][1].ipv4,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][i].ipv4,
-                                            ip_src=self.servers[1][0].ipv4,
+                                            ip_src=self.servers[1][1].ipv4,
                                             ip_id=105,
                                             ip_ttl=63)
                 send_packet(self, 1, pkt)
                 rcv_idx, _ = verify_packet_any_port(
                     self, exp_pkt, self.dut.lag1.member_port_indexs)
                 print('des_src={}, rcv_port={}'.format(
-                    self.servers[1][0].ipv4, rcv_idx))
+                    self.servers[1][1].ipv4, rcv_idx))
                 rcv_count[rcv_idx] += 1
 
             print(rcv_count)
@@ -354,36 +354,36 @@ class LoadbalanceOnProtocolTest(T0TestBase):
             for i in range(0, max_itrs):
                 if i % 2 == 0:
                     pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                            eth_src=self.servers[1][0].mac,
-                                            ip_dst=self.servers[11][0].ipv4,
-                                            ip_src=self.servers[1][0].ipv4,
+                                            eth_src=self.servers[1][1].mac,
+                                            ip_dst=self.servers[11][1].ipv4,
+                                            ip_src=self.servers[1][1].ipv4,
                                             ip_id=105,
                                             ip_ttl=64)
                     exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
                                                 eth_src=ROUTER_MAC,
-                                                ip_dst=self.servers[11][0].ipv4,
-                                                ip_src=self.servers[1][0].ipv4,
+                                                ip_dst=self.servers[11][1].ipv4,
+                                                ip_src=self.servers[1][1].ipv4,
                                                 ip_id=105,
                                                 ip_ttl=63)
                 else:
                     print("icmp")
                     pkt = simple_icmp_packet(eth_dst=ROUTER_MAC,
-                                             eth_src=self.servers[1][0].mac,
-                                             ip_dst=self.servers[11][0].ipv4,
-                                             ip_src=self.servers[1][0].ipv4,
+                                             eth_src=self.servers[1][1].mac,
+                                             ip_dst=self.servers[11][1].ipv4,
+                                             ip_src=self.servers[1][1].ipv4,
                                              ip_id=105,
                                              ip_ttl=64)
                     exp_pkt = simple_icmp_packet(eth_dst=self.t1_list[1][0].mac,
                                                  eth_src=ROUTER_MAC,
-                                                 ip_dst=self.servers[11][0].ipv4,
-                                                 ip_src=self.servers[1][0].ipv4,
+                                                 ip_dst=self.servers[11][1].ipv4,
+                                                 ip_src=self.servers[1][1].ipv4,
                                                  ip_id=105,
                                                  ip_ttl=63)
                 send_packet(self, 1, pkt)
                 rcv_idx, _ = verify_packet_any_port(
                     self, exp_pkt, self.dut.lag1.member_port_indexs)
                 print('des_src={}, rcv_port={}'.format(
-                    self.servers[1][0].ipv4, rcv_idx))
+                    self.servers[1][1].ipv4, rcv_idx))
                 rcv_count[rcv_idx] += 1
 
             print(rcv_count)
@@ -432,16 +432,16 @@ class DisableEgressTest(T0TestBase):
             for i in range(0, pkts_num):
                 src_port = begin_port + i
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                        eth_src=self.servers[1][0].mac,
-                                        ip_dst=self.servers[11][0].ipv4,
-                                        ip_src=self.servers[1][0].ipv4,
+                                        eth_src=self.servers[1][1].mac,
+                                        ip_dst=self.servers[11][1].ipv4,
+                                        ip_src=self.servers[1][1].ipv4,
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
                                             eth_src=ROUTER_MAC,
-                                            ip_dst=self.servers[11][0].ipv4,
-                                            ip_src=self.servers[1][0].ipv4,
+                                            ip_dst=self.servers[11][1].ipv4,
+                                            ip_src=self.servers[1][1].ipv4,
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
@@ -461,16 +461,16 @@ class DisableEgressTest(T0TestBase):
             for i in range(0, pkts_num):
                 src_port = begin_port + i
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                        eth_src=self.servers[1][0].mac,
-                                        ip_dst=self.servers[11][0].ipv4,
-                                        ip_src=self.servers[1][0].ipv4,
+                                        eth_src=self.servers[1][1].mac,
+                                        ip_dst=self.servers[11][1].ipv4,
+                                        ip_src=self.servers[1][1].ipv4,
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
                                             eth_src=ROUTER_MAC,
-                                            ip_dst=self.servers[11][0].ipv4,
-                                            ip_src=self.servers[1][0].ipv4,
+                                            ip_dst=self.servers[11][1].ipv4,
+                                            ip_src=self.servers[1][1].ipv4,
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
@@ -528,15 +528,15 @@ class DisableIngressTest(T0TestBase):
                 src_port = begin_port + i
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                         eth_src=self.t1_list[1][0].mac,
-                                        ip_dst=self.servers[1][0].ipv4,
-                                        ip_src=self.servers[11][0].ipv4,
+                                        ip_dst=self.servers[1][1].ipv4,
+                                        ip_src=self.servers[11][1].ipv4,
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.servers[1][0].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[1][1].mac,
                                             eth_src=ROUTER_MAC,
-                                            ip_dst=self.servers[1][0].ipv4,
-                                            ip_src=self.servers[11][0].ipv4,
+                                            ip_dst=self.servers[1][1].ipv4,
+                                            ip_src=self.servers[11][1].ipv4,
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
@@ -552,15 +552,15 @@ class DisableIngressTest(T0TestBase):
                 src_port = begin_port + i
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                         eth_src=self.t1_list[1][0].mac,
-                                        ip_dst=self.servers[1][0].ipv4,
-                                        ip_src=self.servers[11][0].ipv4,
+                                        ip_dst=self.servers[1][1].ipv4,
+                                        ip_src=self.servers[11][1].ipv4,
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.servers[1][0].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[1][1].mac,
                                             eth_src=ROUTER_MAC,
-                                            ip_dst=self.servers[1][0].ipv4,
-                                            ip_src=self.servers[11][0].ipv4,
+                                            ip_dst=self.servers[1][1].ipv4,
+                                            ip_src=self.servers[11][1].ipv4,
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
@@ -608,16 +608,16 @@ class RemoveLagMemberTest(T0TestBase):
             for i in range(0, pkts_num):
                 src_port = begin_port + i
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                        eth_src=self.servers[1][0].mac,
-                                        ip_dst=self.servers[11][0].ipv4,
-                                        ip_src=self.servers[1][0].ipv4,
+                                        eth_src=self.servers[1][1].mac,
+                                        ip_dst=self.servers[11][1].ipv4,
+                                        ip_src=self.servers[1][1].ipv4,
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
                                             eth_src=ROUTER_MAC,
-                                            ip_dst=self.servers[11][0].ipv4,
-                                            ip_src=self.servers[1][0].ipv4,
+                                            ip_dst=self.servers[11][1].ipv4,
+                                            ip_src=self.servers[1][1].ipv4,
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
@@ -631,16 +631,16 @@ class RemoveLagMemberTest(T0TestBase):
             for i in range(0, pkts_num):
                 src_port = begin_port + i
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                        eth_src=self.servers[1][0].mac,
-                                        ip_dst=self.servers[11][0].ipv4,
-                                        ip_src=self.servers[1][0].ipv4,
+                                        eth_src=self.servers[1][1].mac,
+                                        ip_dst=self.servers[11][1].ipv4,
+                                        ip_src=self.servers[1][1].ipv4,
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
                                             eth_src=ROUTER_MAC,
-                                            ip_dst=self.servers[11][0].ipv4,
-                                            ip_src=self.servers[1][0].ipv4,
+                                            ip_dst=self.servers[11][1].ipv4,
+                                            ip_src=self.servers[1][1].ipv4,
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
@@ -690,16 +690,16 @@ class AddLagMemberTest(T0TestBase):
             for i in range(0, pkts_num):
                 src_port = begin_port + i
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                        eth_src=self.servers[1][0].mac,
-                                        ip_dst=self.servers[11][0].ipv4,
-                                        ip_src=self.servers[1][0].ipv4,
+                                        eth_src=self.servers[1][1].mac,
+                                        ip_dst=self.servers[11][1].ipv4,
+                                        ip_src=self.servers[1][1].ipv4,
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
                                             eth_src=ROUTER_MAC,
-                                            ip_dst=self.servers[11][0].ipv4,
-                                            ip_src=self.servers[1][0].ipv4,
+                                            ip_dst=self.servers[11][1].ipv4,
+                                            ip_src=self.servers[1][1].ipv4,
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
@@ -712,16 +712,16 @@ class AddLagMemberTest(T0TestBase):
             for i in range(0, pkts_num):
                 src_port = begin_port + i
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                        eth_src=self.servers[1][0].mac,
-                                        ip_dst=self.servers[11][0].ipv4,
-                                        ip_src=self.servers[1][0].ipv4,
+                                        eth_src=self.servers[1][1].mac,
+                                        ip_dst=self.servers[11][1].ipv4,
+                                        ip_src=self.servers[1][1].ipv4,
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
                 exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
                                             eth_src=ROUTER_MAC,
-                                            ip_dst=self.servers[11][0].ipv4,
-                                            ip_src=self.servers[1][0].ipv4,
+                                            ip_dst=self.servers[11][1].ipv4,
+                                            ip_src=self.servers[1][1].ipv4,
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
@@ -760,15 +760,15 @@ class IndifferenceIngressPortTest(T0TestBase):
                                                                 type=SAI_ROUTER_INTERFACE_TYPE_VLAN,
                                                                 vlan_id=10)
             pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                    eth_src=self.servers[1][0].mac,
-                                    ip_dst=self.servers[11][0].ipv4,
-                                    ip_src=self.servers[1][0].ipv4,
+                                    eth_src=self.servers[1][1].mac,
+                                    ip_dst=self.servers[11][1].ipv4,
+                                    ip_src=self.servers[1][1].ipv4,
                                     ip_id=105,
                                     ip_ttl=64)
             exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
                                         eth_src=ROUTER_MAC,
-                                        ip_dst=self.servers[11][0].ipv4,
-                                        ip_src=self.servers[1][0].ipv4,
+                                        ip_dst=self.servers[11][1].ipv4,
+                                        ip_src=self.servers[1][1].ipv4,
                                         ip_id=105,
                                         ip_ttl=63)
 

--- a/test/sai_test/sai_lag_test.py
+++ b/test/sai_test/sai_lag_test.py
@@ -51,13 +51,13 @@ class LagConfigTest(T0TestBase):
                                  ip_src=self.servers[2][1].ipv4,
                                  ip_id=105,
                                  ip_ttl=64)
-        exp_pkt1 = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+        exp_pkt1 = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                      eth_src=ROUTER_MAC,
                                      ip_dst=ip_dst,
                                      ip_src=self.servers[1][1].ipv4,
                                      ip_id=105,
                                      ip_ttl=63)
-        exp_pkt2 = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+        exp_pkt2 = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                      eth_src=ROUTER_MAC,
                                      ip_dst=ip_dst,
                                      ip_src=self.servers[2][1].ipv4,
@@ -117,7 +117,7 @@ class LoadbalanceOnSrcPortTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -177,7 +177,7 @@ class LoadbalanceOnDesPortTest(T0TestBase):
                                         tcp_dport=des_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -235,7 +235,7 @@ class LoadbalanceOnSrcIPTest(T0TestBase):
                                         ip_src=self.servers[1][i].ipv4,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][i].ipv4,
@@ -293,7 +293,7 @@ class LoadbalanceOnDesIPTest(T0TestBase):
                                         ip_src=self.servers[1][1].ipv4,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][i].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -359,7 +359,7 @@ class LoadbalanceOnProtocolTest(T0TestBase):
                                             ip_src=self.servers[1][1].ipv4,
                                             ip_id=105,
                                             ip_ttl=64)
-                    exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+                    exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                                 eth_src=ROUTER_MAC,
                                                 ip_dst=self.servers[11][1].ipv4,
                                                 ip_src=self.servers[1][1].ipv4,
@@ -373,7 +373,7 @@ class LoadbalanceOnProtocolTest(T0TestBase):
                                              ip_src=self.servers[1][1].ipv4,
                                              ip_id=105,
                                              ip_ttl=64)
-                    exp_pkt = simple_icmp_packet(eth_dst=self.t1_list[1][0].mac,
+                    exp_pkt = simple_icmp_packet(eth_dst=self.t1_list[1][100].mac,
                                                  eth_src=ROUTER_MAC,
                                                  ip_dst=self.servers[11][1].ipv4,
                                                  ip_src=self.servers[1][1].ipv4,
@@ -438,7 +438,7 @@ class DisableEgressTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -467,7 +467,7 @@ class DisableEgressTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -527,7 +527,7 @@ class DisableIngressTest(T0TestBase):
             for i in range(0, pkts_num):
                 src_port = begin_port + i
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                        eth_src=self.t1_list[1][0].mac,
+                                        eth_src=self.t1_list[1][100].mac,
                                         ip_dst=self.servers[1][1].ipv4,
                                         ip_src=self.servers[11][1].ipv4,
                                         tcp_sport=src_port,
@@ -551,7 +551,7 @@ class DisableIngressTest(T0TestBase):
             for i in range(0, pkts_num):
                 src_port = begin_port + i
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                        eth_src=self.t1_list[1][0].mac,
+                                        eth_src=self.t1_list[1][100].mac,
                                         ip_dst=self.servers[1][1].ipv4,
                                         ip_src=self.servers[11][1].ipv4,
                                         tcp_sport=src_port,
@@ -614,7 +614,7 @@ class RemoveLagMemberTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -637,7 +637,7 @@ class RemoveLagMemberTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -696,7 +696,7 @@ class AddLagMemberTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -718,7 +718,7 @@ class AddLagMemberTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -765,7 +765,7 @@ class IndifferenceIngressPortTest(T0TestBase):
                                     ip_src=self.servers[1][1].ipv4,
                                     ip_id=105,
                                     ip_ttl=64)
-            exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+            exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                         eth_src=ROUTER_MAC,
                                         ip_dst=self.servers[11][1].ipv4,
                                         ip_src=self.servers[1][1].ipv4,

--- a/test/sai_test/sai_neighbor_test.py
+++ b/test/sai_test/sai_neighbor_test.py
@@ -14,6 +14,10 @@ class NoHostRouteTest(T0TestBase):
         """
         T0TestBase.setUp(self)
 
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_list[1])
         self.dev_port1 = self.dut.dev_port_list[1]
         self.ipv4_addr = "10.1.1.10"
         self.mac_addr = "00:10:10:10:10:10"
@@ -30,7 +34,7 @@ class NoHostRouteTest(T0TestBase):
     def noHostRouteNeighborTest(self):
         '''
         Add a neighbor for IP 10.1.1.10 on the LAG1 Route interface and a new MACX
-        Send packet on port5 with DMAC: SWITCH_MAC DIP:10.1.1.10
+        Send packet on port1 with DMAC: SWITCH_MAC DIP:10.1.1.10
         verify packet received on one of LAG1 member
         '''
         print("\nnoHostRouteNeighborTest()")
@@ -53,6 +57,8 @@ class NoHostRouteTest(T0TestBase):
 
     def tearDown(self):
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v4)
+        sai_thrift_remove_router_interface(self.client, self.port1_rif)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -68,6 +74,10 @@ class NoHostRouteTestV6(T0TestBase):
         """
         T0TestBase.setUp(self)
 
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_list[1])
         self.dev_port1 = self.dut.dev_port_list[1]
         self.ipv6_addr = "2001:0db8::1:10"
         self.mac_addr = "00:10:10:10:10:10"
@@ -107,6 +117,8 @@ class NoHostRouteTestV6(T0TestBase):
 
     def tearDown(self):
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v6)
+        sai_thrift_remove_router_interface(self.client, self.port1_rif)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -122,6 +134,10 @@ class AddHostRouteTest(T0TestBase):
         """
         T0TestBase.setUp(self)
 
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_list[1])
         self.dev_port1 = self.dut.dev_port_list[1]
         self.ipv4_addr = "10.1.1.10"
         self.mac_addr = "00:10:10:10:10:10"
@@ -165,6 +181,8 @@ class AddHostRouteTest(T0TestBase):
 
     def tearDown(self):
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v4)
+        sai_thrift_remove_router_interface(self.client, self.port1_rif)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -180,6 +198,10 @@ class AddHostRouteTestV6(T0TestBase):
         """
         T0TestBase.setUp(self)
 
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_list[1])
         self.dev_port1 = self.dut.dev_port_list[1]
         self.ipv6_addr = "2001:0db8::1:10"
         self.mac_addr = "00:10:10:10:10:10"
@@ -224,6 +246,8 @@ class AddHostRouteTestV6(T0TestBase):
 
     def tearDown(self):
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v6)
+        sai_thrift_remove_router_interface(self.client, self.port1_rif)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -239,6 +263,10 @@ class RemoveAddNeighborTestIPV4(T0TestBase):
         """
         T0TestBase.setUp(self)
 
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_list[1])
         self.dev_port1 = self.dut.dev_port_list[1]
         self.ipv4_addr = "10.1.1.10"
         self.mac_addr = "00:10:10:10:10:10"
@@ -250,7 +278,7 @@ class RemoveAddNeighborTestIPV4(T0TestBase):
             self.client,
             self.nbr_entry_v4,
             dst_mac_address=self.mac_addr)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.assertEqual(status, SAI_STATUS_SUCCESS)
 
         self.net_route = sai_thrift_route_entry_t(
             vr_id=self.dut.default_vrf, destination=sai_ipprefix(self.ipv4_addr+'/32'))
@@ -318,6 +346,8 @@ class RemoveAddNeighborTestIPV4(T0TestBase):
     def tearDown(self):
         sai_thrift_remove_route_entry(self.client, self.net_route)
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v4)
+        sai_thrift_remove_router_interface(self.client, self.port1_rif)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -332,6 +362,10 @@ class RemoveAddNeighborTestIPV6(T0TestBase):
         """
         T0TestBase.setUp(self)
 
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_list[1])
         self.dev_port1 = self.dut.dev_port_list[1]
         self.ipv6_addr = "2001:0db8::1:10"
         self.mac_addr = "00:10:10:10:10:10"
@@ -343,7 +377,7 @@ class RemoveAddNeighborTestIPV6(T0TestBase):
             self.client,
             self.nbr_entry_v6,
             dst_mac_address=self.mac_addr)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        self.assertEqual(status, SAI_STATUS_SUCCESS)
 
         self.net_route = sai_thrift_route_entry_t(
             vr_id=self.dut.default_vrf, destination=sai_ipprefix(self.ipv6_addr+'/128'))
@@ -411,6 +445,8 @@ class RemoveAddNeighborTestIPV6(T0TestBase):
     def tearDown(self):
         sai_thrift_remove_route_entry(self.client, self.net_route)
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v6)
+        sai_thrift_remove_router_interface(self.client, self.port1_rif)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -425,7 +461,6 @@ class NhopDiffPrefixRemoveLonger(T0TestBase):
         """
         T0TestBase.setUp(self)
 
-        self.dev_port1 = self.dut.dev_port_list[1]
         self.ipv4_addr = "10.1.1.10"
         self.mac_addr1 = "00:10:10:10:10:10"
         self.mac_addr2 = "00:20:20:20:20:20"
@@ -483,7 +518,6 @@ class NhopDiffPrefixRemoveLongerV6(T0TestBase):
         """
         T0TestBase.setUp(self)
 
-        self.dev_port1 = self.dut.dev_port_list[1]
         self.ipv6_addr = "2001:0db8::1:10"
         self.mac_addr1 = "00:10:10:10:10:10"
         self.mac_addr2 = "00:20:20:20:20:20"
@@ -540,7 +574,6 @@ class NhopDiffPrefixRemoveShorter(T0TestBase):
         """
         T0TestBase.setUp(self)
 
-        self.dev_port1 = self.dut.dev_port_list[1]
         self.ipv4_addr = "10.1.1.10"
         self.mac_addr1 = "00:10:10:10:10:10"
         self.mac_addr2 = "00:20:20:20:20:20"
@@ -598,7 +631,7 @@ class NhopDiffPrefixRemoveShorterV6(T0TestBase):
         Test the basic setup process.
         """
         T0TestBase.setUp(self)
-        self.dev_port1 = self.dut.dev_port_list[1]
+
         self.ipv6_addr = "2001:0db8::1:10"
         self.mac_addr1 = "00:10:10:10:10:10"
         self.mac_addr2 = "00:20:20:20:20:20"

--- a/test/sai_test/sai_rif_test.py
+++ b/test/sai_test/sai_rif_test.py
@@ -49,6 +49,11 @@ class IngressMacUpdateTest(T0TestBase):
         new_router_mac = "00:77:66:55:44:44"
         ip_dst = self.servers[11][1].ipv4
 
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_list[1])
+
         pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                 eth_src=self.servers[0][1].mac,
                                 ip_dst=ip_dst,
@@ -87,6 +92,8 @@ class IngressMacUpdateTest(T0TestBase):
         attrs = sai_thrift_get_router_interface_attribute(
             self.client, self.dut.port_rif_list[0], src_mac_address=True)
         self.assertEqual(attrs["src_mac_address"], ROUTER_MAC)
+        sai_thrift_remove_router_interface(self.client, self.port1_rif)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -114,6 +121,11 @@ class IngressMacUpdateTestV6(T0TestBase):
 
         new_router_mac = "00:10:10:10:10:10"
         ip_dst = self.servers[11][1].ipv6
+
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_list[1])
 
         pkt = simple_tcpv6_packet(eth_dst=ROUTER_MAC,
                                   eth_src=self.servers[0][1].mac,
@@ -151,6 +163,8 @@ class IngressMacUpdateTestV6(T0TestBase):
         attrs = sai_thrift_get_router_interface_attribute(
             self.client, self.dut.port_rif_list[0], src_mac_address=True)
         self.assertEqual(attrs["src_mac_address"], ROUTER_MAC)
+        sai_thrift_remove_router_interface(self.client, self.port1_rif)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -181,6 +195,11 @@ class IngressDisableTestV4(T0TestBase):
         print("\ntest_ingress_disable_ipv4()")
 
         ip_dst = self.servers[11][1].ipv4
+
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_list[1])
 
         pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                 eth_src=self.servers[0][1].mac,
@@ -217,6 +236,8 @@ class IngressDisableTestV4(T0TestBase):
         self.test_ingress_disable_ipv4()
 
     def tearDown(self):
+        sai_thrift_remove_router_interface(self.client, self.port1_rif)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -247,6 +268,11 @@ class IngressDisableTestV6(T0TestBase):
         print("\ntest_ingress_disable_ipv6()")
 
         ip_dst = self.servers[11][1].ipv6
+
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_list[1])
 
         pkt = simple_tcpv6_packet(eth_dst=ROUTER_MAC,
                                   eth_src=self.servers[0][1].mac,
@@ -281,6 +307,8 @@ class IngressDisableTestV6(T0TestBase):
         self.test_ingress_disable_ipv6()
 
     def tearDown(self):
+        sai_thrift_remove_router_interface(self.client, self.port1_rif)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -308,6 +336,11 @@ class IngressMtuTestV4(T0TestBase):
         Verify no packet was received on any LAG1 member
         """
         print("\ntest_ingress_mtu_v4()")
+
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_list[1])
 
         # set MTU to 200 for port1
         mtu_port10_rif = sai_thrift_get_router_interface_attribute(
@@ -368,6 +401,8 @@ class IngressMtuTestV4(T0TestBase):
         self.test_ingress_mtu()
 
     def tearDown(self):
+        sai_thrift_remove_router_interface(self.client, self.port1_rif)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -395,6 +430,11 @@ class IngressMtuTestV6(T0TestBase):
         Verify no packet was received on any LAG1 member
         """
         print("\ntest_ingress_mtu_v6()")
+
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_list[1])
 
         # set MTU to 200 for port1
         mtu_port10_rif = sai_thrift_get_router_interface_attribute(
@@ -451,4 +491,6 @@ class IngressMtuTestV6(T0TestBase):
         self.test_ingress_mtu_v6()
 
     def tearDown(self):
+        sai_thrift_remove_router_interface(self.client, self.port1_rif)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()

--- a/test/sai_test/sai_rif_test.py
+++ b/test/sai_test/sai_rif_test.py
@@ -37,7 +37,7 @@ class IngressMacUpdateTest(T0TestBase):
 
     def test_ingress_mac_update(self):
         """
-        Generate Packets, with SIP:192.168.0.1 DIP:10.1.1.101 DMAC:SWITCH_MAC
+        Generate Packets, with SIP:192.168.0.1 DIP:192.168.11.1 DMAC:SWITCH_MAC
         Send packet on Port1
         Verify packet received on one of the LAG1's member
         Set RIF mac to MacX, the RIF related to Port1
@@ -47,16 +47,16 @@ class IngressMacUpdateTest(T0TestBase):
         print("\nmacUpdateTest()")
 
         new_router_mac = "00:77:66:55:44:44"
-        ip_dst = self.servers[11][0].ipv4
+        ip_dst = self.servers[11][1].ipv4
 
         pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                eth_src=self.servers[1][0].mac,
+                                eth_src=self.servers[0][1].mac,
                                 ip_dst=ip_dst,
-                                ip_src=self.servers[1][0].ipv4,
+                                ip_src=self.servers[0][1].ipv4,
                                 ip_id=105,
                                 ip_ttl=64)
 
-        exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+        exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                     eth_src=ROUTER_MAC,
                                     ip_dst=ip_dst,
                                     ip_src=self.servers[1][0].ipv4,
@@ -103,7 +103,7 @@ class IngressMacUpdateTestV6(T0TestBase):
 
     def test_ingress_mac_update(self):
         """
-        Generate Packets, with SIP fc02::1:1 DIP:fc02::1:11 DMAC:SWITCH_MAC
+        Generate Packets, with SIP fc02::0:1 DIP:fc02::11:1 DMAC:SWITCH_MAC
         Send packet on Port1
         Verify packet received on one of the LAG1's member
         Set RIF mac to MacX, the RIF related to Port1
@@ -113,18 +113,18 @@ class IngressMacUpdateTestV6(T0TestBase):
         print("\nmacUpdateTest()")
 
         new_router_mac = "00:10:10:10:10:10"
-        ip_dst = self.servers[11][0].ipv6
+        ip_dst = self.servers[11][1].ipv6
 
         pkt = simple_tcpv6_packet(eth_dst=ROUTER_MAC,
-                                  eth_src=self.servers[1][0].mac,
+                                  eth_src=self.servers[0][1].mac,
                                   ipv6_dst=ip_dst,
-                                  ipv6_src=self.servers[1][0].ipv6,
+                                  ipv6_src=self.servers[0][1].ipv6,
                                   ipv6_hlim=64)
 
-        exp_pkt = simple_tcpv6_packet(eth_dst=self.t1_list[1][0].mac,
+        exp_pkt = simple_tcpv6_packet(eth_dst=self.t1_list[1][100].mac,
                                       eth_src=ROUTER_MAC,
                                       ipv6_dst=ip_dst,
-                                      ipv6_src=self.servers[1][0].ipv6,
+                                      ipv6_src=self.servers[0][1].ipv6,
                                       ipv6_hlim=63)
 
         send_packet(self, 1, pkt)
@@ -169,7 +169,7 @@ class IngressDisableTestV4(T0TestBase):
 
     def test_ingress_disable_ipv4(self):
         """
-        Generate Packets, with SIP:192.168.0.1 DIP:10.1.1.101 DMAC:SWITCH_MAC
+        Generate Packets, with SIP:192.168.0.1 DIP:192.168.11.1 DMAC:SWITCH_MAC
         Send packet on Port1
         Verify packet received on one of the LAG1's member
         Set RIF mac to MacX, the RIF related to Port1
@@ -180,19 +180,19 @@ class IngressDisableTestV4(T0TestBase):
 
         print("\ntest_ingress_disable_ipv4()")
 
-        ip_dst = self.servers[11][0].ipv4
+        ip_dst = self.servers[11][1].ipv4
 
         pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                eth_src=self.servers[1][0].mac,
+                                eth_src=self.servers[0][1].mac,
                                 ip_dst=ip_dst,
-                                ip_src=self.servers[1][0].ipv4,
+                                ip_src=self.servers[0][1].ipv4,
                                 ip_id=105,
                                 ip_ttl=64)
 
-        exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+        exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                     eth_src=ROUTER_MAC,
                                     ip_dst=ip_dst,
-                                    ip_src=self.servers[1][0].ipv4,
+                                    ip_src=self.servers[0][1].ipv4,
                                     ip_id=105,
                                     ip_ttl=63)
 
@@ -246,18 +246,18 @@ class IngressDisableTestV6(T0TestBase):
 
         print("\ntest_ingress_disable_ipv6()")
 
-        ip_dst = self.servers[11][0].ipv6
+        ip_dst = self.servers[11][1].ipv6
 
         pkt = simple_tcpv6_packet(eth_dst=ROUTER_MAC,
-                                  eth_src=self.servers[1][0].mac,
+                                  eth_src=self.servers[0][1].mac,
                                   ipv6_dst=ip_dst,
-                                  ipv6_src=self.servers[1][0].ipv6,
+                                  ipv6_src=self.servers[0][1].ipv6,
                                   ipv6_hlim=64)
 
-        exp_pkt = simple_tcpv6_packet(eth_dst=self.t1_list[1][0].mac,
+        exp_pkt = simple_tcpv6_packet(eth_dst=self.t1_list[1][100].mac,
                                       eth_src=ROUTER_MAC,
                                       ipv6_dst=ip_dst,
-                                      ipv6_src=self.servers[1][0].ipv6,
+                                      ipv6_src=self.servers[0][1].ipv6,
                                       ipv6_hlim=63)
 
         send_packet(self, 1, pkt)
@@ -318,20 +318,20 @@ class IngressMtuTestV4(T0TestBase):
 
         try:
             print("Max MTU is 200, send pkt size 200, send to port/lag")
-            ip_dst = self.servers[11][0].ipv4
+            ip_dst = self.servers[11][1].ipv4
 
             pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                    eth_src=self.servers[1][0].mac,
+                                    eth_src=self.servers[0][1].mac,
                                     ip_dst=ip_dst,
-                                    ip_src=self.servers[1][0].ipv4,
+                                    ip_src=self.servers[0][1].ipv4,
                                     ip_id=105,
                                     ip_ttl=64,
                                     pktlen=200 + 14)
 
-            exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+            exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                         eth_src=ROUTER_MAC,
                                         ip_dst=ip_dst,
-                                        ip_src=self.servers[1][0].ipv4,
+                                        ip_src=self.servers[0][1].ipv4,
                                         ip_id=105,
                                         ip_ttl=63,
                                         pktlen=200 + 14)
@@ -342,17 +342,17 @@ class IngressMtuTestV4(T0TestBase):
 
             print("Max MTU is 200, send pkt size 201, dropped")
             pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                    eth_src=self.servers[1][0].mac,
+                                    eth_src=self.servers[0][1].mac,
                                     ip_dst=ip_dst,
-                                    ip_src=self.servers[1][0].ipv4,
+                                    ip_src=self.servers[0][1].ipv4,
                                     ip_id=105,
                                     ip_ttl=64,
                                     pktlen=201 + 14)
 
-            exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][0].mac,
+            exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                         eth_src=ROUTER_MAC,
                                         ip_dst=ip_dst,
-                                        ip_src=self.servers[1][0].ipv4,
+                                        ip_src=self.servers[0][1].ipv4,
                                         ip_id=105,
                                         ip_ttl=63,
                                         pktlen=201 + 14)
@@ -405,19 +405,19 @@ class IngressMtuTestV6(T0TestBase):
 
         try:
             print("Max MTU is 200, send pkt size 200, send to port/lag")
-            ip_dst = self.servers[11][0].ipv6
+            ip_dst = self.servers[11][1].ipv6
 
             pkt = simple_tcpv6_packet(eth_dst=ROUTER_MAC,
-                                      eth_src=self.servers[1][0].mac,
+                                      eth_src=self.servers[0][1].mac,
                                       ipv6_dst=ip_dst,
-                                      ipv6_src=self.servers[1][0].ipv6,
+                                      ipv6_src=self.servers[0][1].ipv6,
                                       ipv6_hlim=64,
                                       pktlen=200 + 14)
 
-            exp_pkt = simple_tcpv6_packet(eth_dst=self.t1_list[1][0].mac,
+            exp_pkt = simple_tcpv6_packet(eth_dst=self.t1_list[1][100].mac,
                                           eth_src=ROUTER_MAC,
                                           ipv6_dst=ip_dst,
-                                          ipv6_src=self.servers[1][0].ipv6,
+                                          ipv6_src=self.servers[0][1].ipv6,
                                           ipv6_hlim=63,
                                           pktlen=200 + 14)
 
@@ -427,16 +427,16 @@ class IngressMtuTestV6(T0TestBase):
 
             print("Max MTU is 200, send pkt size 201, dropped")
             pkt = simple_tcpv6_packet(eth_dst=ROUTER_MAC,
-                                      eth_src=self.servers[1][0].mac,
+                                      eth_src=self.servers[0][1].mac,
                                       ipv6_dst=ip_dst,
-                                      ipv6_src=self.servers[1][0].ipv6,
+                                      ipv6_src=self.servers[0][1].ipv6,
                                       ipv6_hlim=64,
                                       pktlen=201 + 14)
 
-            exp_pkt = simple_tcpv6_packet(eth_dst=self.t1_list[1][0].mac,
+            exp_pkt = simple_tcpv6_packet(eth_dst=self.t1_list[1][100].mac,
                                           eth_src=ROUTER_MAC,
                                           ipv6_dst=ip_dst,
-                                          ipv6_src=self.servers[1][0].ipv6,
+                                          ipv6_src=self.servers[0][1].ipv6,
                                           ipv6_hlim=63,
                                           pktlen=201 + 14)
 

--- a/test/sai_test/sai_rif_test.py
+++ b/test/sai_test/sai_rif_test.py
@@ -64,7 +64,7 @@ class IngressMacUpdateTest(T0TestBase):
         exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
                                     eth_src=ROUTER_MAC,
                                     ip_dst=ip_dst,
-                                    ip_src=self.servers[1][0].ipv4,
+                                    ip_src=self.servers[0][1].ipv4,
                                     ip_id=105,
                                     ip_ttl=63)
 

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -353,6 +353,7 @@ class T0TestBase(ThriftInterfaceDataPlane):
               is_create_vlan=True,
               is_create_fdb=True,
               is_create_default_route=True,
+              is_create_default_loopback_interface=False,
               is_create_lag=True,
               is_create_route_for_lag=True,
               wait_sec=5):
@@ -391,6 +392,7 @@ class T0TestBase(ThriftInterfaceDataPlane):
             t0_route_config_helper(
                 test_obj=self,
                 is_create_default_route=is_create_default_route,
+                is_create_default_loopback_interface=is_create_default_loopback_interface,
                 is_create_route_for_lag=is_create_route_for_lag)
 
         print("Waiting for switch to get ready before test, {} seconds ...".format(

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -327,7 +327,7 @@ class T0TestBase(ThriftInterfaceDataPlane):
         Group numbers for server
         """
 
-        self.num_device_each_group = 99
+        self.num_device_each_group = 101
         """
         Device numbers in each group
         """

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -443,15 +443,15 @@ class T0TestBase(ThriftInterfaceDataPlane):
         Server in format 192.168.[group_id].[nums_index]
         T1 in format 10.1.[[group_id].[nums_index]]
         group_id: group id for the server
-        nums_index: index number among nums, start from 1
+        nums_index: index number among nums, start from 0
         """
 
         for srv_grp_idx in self.server_groups:
             self.servers[srv_grp_idx] = [Device(DeviceType.server, index, srv_grp_idx)
-                                         for index in range(1, self.num_device_each_group+1)]
+                                         for index in range(0, self.num_device_each_group)]
         for t1_grp_idx in self.t1_groups:
             self.t1_list[t1_grp_idx] = [Device(DeviceType.t1, index, t1_grp_idx)
-                                        for index in range(1, self.num_device_each_group+1)]
+                                        for index in range(0, self.num_device_each_group)]
 
     def create_vlan_interface(self, vlan: Vlan):
         """

--- a/test/sai_test/sai_vlan_test.py
+++ b/test/sai_test/sai_vlan_test.py
@@ -52,8 +52,8 @@ class Vlan_Domain_Forwarding_Test(T0TestBase):
                     10,
                     self.dut.dev_port_list[1],
                     self.dut.dev_port_list[index]))
-                pkt = simple_udp_packet(eth_dst=self.servers[1][index-1].mac,
-                                        eth_src=self.servers[1][0].mac,
+                pkt = simple_udp_packet(eth_dst=self.servers[1][index].mac,
+                                        eth_src=self.servers[1][1].mac,
                                         vlan_vid=10,
                                         ip_id=101,
                                         ip_ttl=64)
@@ -67,8 +67,8 @@ class Vlan_Domain_Forwarding_Test(T0TestBase):
                     20,
                     self.dut.dev_port_list[9],
                     self.dut.dev_port_list[index]))
-                pkt = simple_udp_packet(eth_dst=self.servers[1][index-1].mac,
-                                        eth_src=self.servers[1][8].mac,
+                pkt = simple_udp_packet(eth_dst=self.servers[1][index].mac,
+                                        eth_src=self.servers[1][9].mac,
                                         vlan_vid=20,
                                         ip_id=101,
                                         ip_ttl=64)
@@ -100,8 +100,8 @@ class UntagAccessToAccessTest(T0TestBase):
                 print("Sending untagged packet from vlan10 tagged port {} to vlan10 tagged port: {}".format(
                     self.dut.dev_port_list[1],
                     self.dut.dev_port_list[index]))
-                pkt = simple_udp_packet(eth_dst=self.servers[1][index-1].mac,
-                                        eth_src=self.servers[1][0].mac,
+                pkt = simple_udp_packet(eth_dst=self.servers[1][index].mac,
+                                        eth_src=self.servers[1][1].mac,
                                         ip_id=101,
                                         ip_ttl=64)
                 send_packet(self, self.dut.dev_port_list[1], pkt)
@@ -111,8 +111,8 @@ class UntagAccessToAccessTest(T0TestBase):
                 print("Sending untagged packet from vlan20 tagged port {} to vlan20 tagged port: {}".format(
                     self.dut.dev_port_list[9],
                     self.dut.dev_port_list[index]))
-                pkt = simple_udp_packet(eth_dst=self.servers[1][index-1].mac,
-                                        eth_src=self.servers[1][8].mac,
+                pkt = simple_udp_packet(eth_dst=self.servers[1][index].mac,
+                                        eth_src=self.servers[1][9].mac,
                                         ip_id=101,
                                         ip_ttl=64)
                 send_packet(self, self.dut.dev_port_list[9], pkt)
@@ -143,8 +143,8 @@ class MismatchDropTest(T0TestBase):
                 print("Sending vlan20 tagged packet from vlan20 tagged port {} to vlan10 tagged port: {}".format(
                     self.dut.dev_port_list[9],
                     self.dut.dev_port_list[index]))
-                pkt = simple_udp_packet(eth_dst=self.servers[1][index-1].mac,
-                                        eth_src=self.servers[1][8].mac,
+                pkt = simple_udp_packet(eth_dst=self.servers[1][index].mac,
+                                        eth_src=self.servers[1][9].mac,
                                         vlan_vid=20,
                                         ip_id=101,
                                         ip_ttl=64)
@@ -154,8 +154,8 @@ class MismatchDropTest(T0TestBase):
                 print("Sending vlan10 tagged packet from {} to vlan20 tagged port: {}".format(
                     self.dut.dev_port_list[1],
                     self.dut.dev_port_list[index]))
-                pkt = simple_udp_packet(eth_dst=self.servers[1][index-1].mac,
-                                        eth_src=self.servers[1][0].mac,
+                pkt = simple_udp_packet(eth_dst=self.servers[1][index].mac,
+                                        eth_src=self.servers[1][1].mac,
                                         vlan_vid=10,
                                         ip_id=101,
                                         ip_ttl=64)
@@ -177,7 +177,7 @@ class TaggedFrameFilteringTest(T0TestBase):
         super().setUp()
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)
-        self.tmp_server_list = [self.servers[1][i] for i in [0, 4]]
+        self.tmp_server_list = [self.servers[1][i] for i in [1, 5]]
         self.mac_action = SAI_PACKET_ACTION_FORWARD
         self.fdb_configer.create_fdb_entries(
             switch_id=self.dut.switch_id,
@@ -190,7 +190,7 @@ class TaggedFrameFilteringTest(T0TestBase):
         try:
             for tmp_server in self.tmp_server_list:
                 pkt = simple_udp_packet(eth_dst=tmp_server.mac,
-                                        eth_src=self.servers[1][0].mac,
+                                        eth_src=self.servers[1][1].mac,
                                         vlan_vid=10,
                                         ip_id=101,
                                         ip_ttl=64)
@@ -213,7 +213,7 @@ class UnTaggedFrameFilteringTest(T0TestBase):
         super().setUp()
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)
-        self.tmp_server_list = [self.servers[1][i] for i in [0, 4]]
+        self.tmp_server_list = [self.servers[1][i] for i in [1, 5]]
         self.mac_action = SAI_PACKET_ACTION_FORWARD
         self.fdb_configer.create_fdb_entries(
             switch_id=self.dut.switch_id,
@@ -226,7 +226,7 @@ class UnTaggedFrameFilteringTest(T0TestBase):
         try:
             for tmp_server in self.tmp_server_list:
                 pkt = simple_udp_packet(eth_dst=tmp_server.mac,
-                                        eth_src=self.servers[1][0].mac,
+                                        eth_src=self.servers[1][1].mac,
                                         ip_id=101,
                                         ip_ttl=64)
                 send_packet(self, self.dut.dev_port_list[1], pkt)
@@ -253,7 +253,7 @@ class TaggedVlanFloodingTest(T0TestBase):
         try:
             macX = 'EE:EE:EE:EE:EE:EE'
             pkt = simple_udp_packet(eth_dst=macX,
-                                    eth_src=self.servers[1][0].mac,
+                                    eth_src=self.servers[1][1].mac,
                                     vlan_vid=10,
                                     ip_id=101,
                                     ip_ttl=64)
@@ -283,7 +283,7 @@ class UnTaggedVlanFloodingTest(T0TestBase):
         try:
             macX = 'EE:EE:EE:EE:EE:EE'
             pkt = simple_udp_packet(eth_dst=macX,
-                                    eth_src=self.servers[1][0].mac,
+                                    eth_src=self.servers[1][1].mac,
                                     ip_id=101,
                                     ip_ttl=64)
             send_packet(self, self.dut.dev_port_list[1], pkt)
@@ -311,7 +311,7 @@ class BroadcastTest(T0TestBase):
             macX = 'FF:FF:FF:FF:FF:FF'
             # untag
             untagged_pkt = simple_udp_packet(eth_dst=macX,
-                                             eth_src=self.servers[1][0].mac,
+                                             eth_src=self.servers[1][1].mac,
                                              ip_id=101,
                                              ip_ttl=64)
             send_packet(self, self.dut.dev_port_list[1], untagged_pkt)
@@ -319,7 +319,7 @@ class BroadcastTest(T0TestBase):
             verify_packet_any_port(self, untagged_pkt, other_ports)
             # tag
             tagged_pkt = simple_udp_packet(eth_dst=macX,
-                                           eth_src=self.servers[1][0].mac,
+                                           eth_src=self.servers[1][1].mac,
                                            vlan_vid=10,
                                            ip_id=101,
                                            ip_ttl=64)
@@ -351,7 +351,7 @@ class UntaggedMacLearningTest(T0TestBase):
                 available_fdb_entry=True)['available_fdb_entry']
             macX = '00:01:01:99:01:99'
             # untag
-            untagged_pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
+            untagged_pkt = simple_udp_packet(eth_dst=self.servers[1][2].mac,
                                              eth_src=macX,
                                              ip_id=101,
                                              ip_ttl=64)
@@ -388,7 +388,7 @@ class TaggedMacLearningTest(T0TestBase):
                 self.client,
                 available_fdb_entry=True)['available_fdb_entry']
             macX = '00:01:01:99:01:99'
-            tagged_pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
+            tagged_pkt = simple_udp_packet(eth_dst=self.servers[1][2].mac,
                                            eth_src=macX,
                                            vlan_vid=10,
                                            ip_id=101,
@@ -517,8 +517,8 @@ class DisableMacLearningTaggedTest(T0TestBase):
             self.client, available_fdb_entry=True)
         current_fdb_entry = attr["available_fdb_entry"]
 
-        pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
-                                eth_src=self.servers[1][0].mac,
+        pkt = simple_udp_packet(eth_dst=self.servers[1][2].mac,
+                                eth_src=self.servers[1][1].mac,
                                 vlan_vid=10,
                                 ip_id=101,
                                 ip_ttl=64)
@@ -550,8 +550,8 @@ class DisableMacLearningUntaggedTest(T0TestBase):
             self.client, available_fdb_entry=True)
         current_fdb_entry = attr["available_fdb_entry"]
 
-        pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
-                                eth_src=self.servers[1][0].mac,
+        pkt = simple_udp_packet(eth_dst=self.servers[1][2].mac,
+                                eth_src=self.servers[1][1].mac,
                                 ip_id=101,
                                 ip_ttl=64)
         send_packet(self, self.dut.dev_port_list[1], pkt)
@@ -573,10 +573,10 @@ class ArpRequestFloodingTest(T0TestBase):
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         ip2 = "192.168.0.2"
         self.arp_request = simple_arp_packet(
-            eth_dst=self.servers[1][1].mac,
+            eth_dst=self.servers[1][2].mac,
             arp_op=1,
             ip_tgt=ip2,
-            hw_tgt=self.servers[1][1].mac)
+            hw_tgt=self.servers[1][2].mac)
 
     def runTest(self):
         print("ArpRequestFloodingTest")
@@ -599,13 +599,13 @@ class ArpRequestLearningTest(T0TestBase):
         ip1 = "192.168.0.1"
         ip2 = "192.168.0.2"
         self.arp_response = simple_arp_packet(
-            eth_dst=self.servers[1][0].mac,
-            eth_src=self.servers[1][1].mac,
+            eth_dst=self.servers[1][1].mac,
+            eth_src=self.servers[1][2].mac,
             arp_op=2,
             ip_tgt=ip2,
             ip_snd=ip1,
-            hw_snd=self.servers[1][1].mac,
-            hw_tgt=self.servers[1][0].mac)
+            hw_snd=self.servers[1][2].mac,
+            hw_tgt=self.servers[1][1].mac)
 
     def runTest(self):
         print("ArpRequestLearningTest")
@@ -624,8 +624,8 @@ class TaggedVlanStatusTest(T0TestBase):
 
     def setUp(self):
         T0TestBase.setUp(self, is_reset_default_vlan=False)
-        self.tagged_pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
-                                            eth_src=self.servers[1][0].mac,
+        self.tagged_pkt = simple_udp_packet(eth_dst=self.servers[1][2].mac,
+                                            eth_src=self.servers[1][1].mac,
                                             vlan_vid=10,
                                             ip_id=101,
                                             ip_ttl=64)
@@ -713,8 +713,8 @@ class UntaggedVlanStatusTest(T0TestBase):
     def setUp(self):
         T0TestBase.setUp(self, is_reset_default_vlan=False)
 
-        self.untagged_pkt = simple_udp_packet(eth_dst=self.servers[1][1].mac,
-                                              eth_src=self.servers[1][0].mac,
+        self.untagged_pkt = simple_udp_packet(eth_dst=self.servers[1][2].mac,
+                                              eth_src=self.servers[1][1].mac,
                                               ip_id=101,
                                               ip_ttl=64)
 


### PR DESCRIPTION
## Description of PR
1. When creating device data, init start from 0 instead of 1 so that index matches its content.
  eg. after change, servers[x][y].ipv4 means 192.168.x.y instead of 192.168.x.y+1
2. Create 101 servers and t1 devices.
3. Change lag neighbor ip according to config.
4. Change some ip and mac addresses according to this config.
5. Separate the config of default route and default loopback, make create_default_loopback default false.

## Test
Run all sanity, fdb, vlan, neighbor, lag and rif cases and passed.

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>