### PR TITLE
use skip mark to skip unsupported test case

### DIFF
--- a/test/sai_test/sai_fdb_test.py
+++ b/test/sai_test/sai_fdb_test.py
@@ -76,13 +76,11 @@ Skip test for broadcom, learn_disable, report error code -196608, no error log.
 Item: 15000933
 """
 
-
-@skip
 class VlanLearnDisableTest(T0TestBase):
     """
     Verify if MAC addresses are not learned on the port when bridge port learning is disabled
     """
-
+    @skip("skip for broadcom")
     def setUp(self):
         """
         Test the basic setup process
@@ -239,13 +237,11 @@ class BridgePortLearnDisableTest(T0TestBase):
 Skip test for broadcom, non bridge port still can learn.
 """
 
-
-@skip
 class NonBridgePortNoLearnTest(T0TestBase):
     """
     Verify if MAC addresses are not learned on the non-bridge port
     """
-
+    @skip("Skip test for broadcom, non bridge port still can learn.")
     def setUp(self):
         """
         Test the basic setup process
@@ -888,13 +884,11 @@ class FdbMacMovingAfterAgingTest(T0TestBase):
 SKIP: Static flush Not support by broadcom
 """
 
-
-@skip
 class FdbFlushVlanStaticTest(T0TestBase):
     '''
     Verify flushing of static MAC entries on VLAN
     '''
-
+    @skip("Static flush Not support by broadcom")
     def setUp(self):
         """
         Test the basic setup process
@@ -937,13 +931,11 @@ class FdbFlushVlanStaticTest(T0TestBase):
 SKIP: Static flush Not support by broadcom
 """
 
-
-@skip
 class FdbFlushPortStaticTest(T0TestBase):
     '''
     Verify flushing of static MAC entries on Port
     '''
-
+    @skip("Static flush Not support by broadcom")
     def setUp(self):
         """
         Test the basic setup process
@@ -984,13 +976,12 @@ class FdbFlushPortStaticTest(T0TestBase):
 SKIP: Static flush Not support by broadcom
 """
 
-
-@skip
 class FdbFlushAllStaticTest(T0TestBase):
     '''
     Verify flushing all of the static MAC entries.
     '''
-
+    
+    @skip("Static flush Not support by broadcom")
     def setUp(self):
         """
         Test the basic setup process
@@ -1253,13 +1244,11 @@ class FdbFlushAllDynamicTest(T0TestBase):
 SKIP: static not support
 """
 
-
-@skip
 class FdbFlushAllTest(T0TestBase):
     '''
     Verify flushing all  MAC entries.
     '''
-
+    @skip("static not support")
     def setUp(self):
         """
         Test the basic setup process

--- a/test/sai_test/sai_lag_test.py
+++ b/test/sai_test/sai_lag_test.py
@@ -324,13 +324,11 @@ Skip test for broadcom, can't load balance on protocol such as tcp and udp
 Item: 15023123
 """
 
-
-@skip
 class LoadbalanceOnProtocolTest(T0TestBase):
     """
     Test load balance of l3 by protocol.
     """
-
+    @skip("skip for broadcom")
     def setUp(self):
         """
         Test the basic setup process
@@ -344,7 +342,7 @@ class LoadbalanceOnProtocolTest(T0TestBase):
         3. Check if packets are received on ports of lag1 equally
         """
         try:
-            print("Lag l3 load balancing test based on protocal")
+            print("Lag l3 load balancing test based on protocol")
             self.port1_rif = sai_thrift_create_router_interface(self.client,
                                                                 virtual_router_id=self.dut.default_vrf,
                                                                 type=SAI_ROUTER_INTERFACE_TYPE_PORT,
@@ -491,15 +489,11 @@ class DisableEgressTest(T0TestBase):
 Skip test for broadcom, can't disable ingress of lag member
 Item: 14988584
 """
-
-
-@skip
 class DisableIngressTest(T0TestBase):
-
     """
     When disable ingress on a lag member, we expect traffic drop on the disabled lag member.
     """
-
+    @skip("skip test for broadcom")
     def setUp(self):
         """
         Test the basic setup process


### PR DESCRIPTION
Signed-off-by: zitingguo <zitingguo@microsoft.com>

## Description of PR
Use unittest.skip mark to skip some test cases that are not supported at this time.

## Test
Run all cases in our nightly test pipeline and specific cases are skipped.