### PR TITLE
[SAI-PTF]Data module for warm reboot persist and load the data

### DIFF
--- a/test/sai_test/config/fdb_configer.py
+++ b/test/sai_test/config/fdb_configer.py
@@ -50,12 +50,12 @@ def t0_fdb_config_helper(test_obj: 'T0TestBase', is_create_fdb=True):
             switch_id=test_obj.dut.switch_id,
             server_list=test_obj.servers[1][1:9],
             port_idxs=range(1, 9),
-            vlan_oid=test_obj.dut.vlans[10].vlan_oid)
+            vlan_oid=test_obj.dut.vlans[10].oid)
         test_obj.dut.vlan_20_fdb_list = configer.create_fdb_entries(
             switch_id=test_obj.dut.switch_id,
             server_list=test_obj.servers[2][1:9],
             port_idxs=range(9, 17),
-            vlan_oid=test_obj.dut.vlans[20].vlan_oid)
+            vlan_oid=test_obj.dut.vlans[20].oid)
     # Todo dynamic use the vlan_member_port_map to add data to fdb
 
 

--- a/test/sai_test/config/fdb_configer.py
+++ b/test/sai_test/config/fdb_configer.py
@@ -66,10 +66,13 @@ def t0_fdb_tear_down_helper(test_obj: 'T0TestBase'):
     '''
     for e in test_obj.dut.default_vlan_fdb_list:
         sai_thrift_remove_fdb_entry(test_obj.client, e)
+        test_obj.dut.default_vlan_fdb_list.remove(e)
     for e in test_obj.dut.vlan_10_fdb_list:
         sai_thrift_remove_fdb_entry(test_obj.client, e)
+        test_obj.dut.vlan_10_fdb_list.remove(e)
     for e in test_obj.dut.vlan_20_fdb_list:
         sai_thrift_remove_fdb_entry(test_obj.client, e)
+        test_obj.dut.vlan_20_fdb_list.remove(e)
 
 
 class FdbConfiger(object):
@@ -117,16 +120,17 @@ class FdbConfiger(object):
                 mac_address=srv.mac,
                 bv_id=vlan_oid)
             port_index = port_idxs[index]
-            sai_thrift_create_fdb_entry(
+            status = sai_thrift_create_fdb_entry(
                 self.client,
                 fdb_entry,
                 type=type,
-                bridge_port_id=self.test_obj.dut.bridge_port_list[port_index],
+                bridge_port_id=self.test_obj.dut.port_obj_list[port_index].bridge_port_oid,
                 packet_action=packet_action,
                 allow_mac_move=allow_mac_move)
+            self.test_obj.assertEqual(status, SAI_STATUS_SUCCESS)
             fdb_list.append(fdb_entry)
             srv.l2_egress_port_idx = port_index
-            srv.l2_egress_port_id = self.test_obj.dut.bridge_port_list[port_index]
+            srv.l2_egress_port_id = self.test_obj.dut.port_obj_list[port_index].bridge_port_oid
             srv.fdb_entry = fdb_entry
         print("Waiting for FDB to get refreshed, {} seconds ...".format(
             wait_sec))

--- a/test/sai_test/config/fdb_configer.py
+++ b/test/sai_test/config/fdb_configer.py
@@ -41,17 +41,17 @@ def t0_fdb_config_helper(test_obj: 'T0TestBase', is_create_fdb=True):
     configer = FdbConfiger(test_obj)
 
     if is_create_fdb:
-        test_obj.dut.default_vlan_fdb_list = configer.create_fdb_entries(
+        configer.create_fdb_entries(
             switch_id=test_obj.dut.switch_id,
             server_list=test_obj.servers[0][0:1],
             port_idxs=range(0, 1),
             vlan_oid=test_obj.dut.default_vlan_id)
-        test_obj.dut.vlan_10_fdb_list = configer.create_fdb_entries(
+        configer.create_fdb_entries(
             switch_id=test_obj.dut.switch_id,
             server_list=test_obj.servers[1][1:9],
             port_idxs=range(1, 9),
             vlan_oid=test_obj.dut.vlans[10].oid)
-        test_obj.dut.vlan_20_fdb_list = configer.create_fdb_entries(
+        configer.create_fdb_entries(
             switch_id=test_obj.dut.switch_id,
             server_list=test_obj.servers[2][1:9],
             port_idxs=range(9, 17),
@@ -64,15 +64,9 @@ def t0_fdb_tear_down_helper(test_obj: 'T0TestBase'):
     Args:
         test_obj: test object
     '''
-    for e in test_obj.dut.default_vlan_fdb_list:
-        sai_thrift_remove_fdb_entry(test_obj.client, e)
-        test_obj.dut.default_vlan_fdb_list.remove(e)
-    for e in test_obj.dut.vlan_10_fdb_list:
-        sai_thrift_remove_fdb_entry(test_obj.client, e)
-        test_obj.dut.vlan_10_fdb_list.remove(e)
-    for e in test_obj.dut.vlan_20_fdb_list:
-        sai_thrift_remove_fdb_entry(test_obj.client, e)
-        test_obj.dut.vlan_20_fdb_list.remove(e)
+    for item in test_obj.dut.fdb_entry_list:
+        sai_thrift_remove_fdb_entry(test_obj.client, item)
+        test_obj.dut.fdb_entry_list.remove(item)
 
 
 class FdbConfiger(object):
@@ -130,8 +124,7 @@ class FdbConfiger(object):
             self.test_obj.assertEqual(status, SAI_STATUS_SUCCESS)
             fdb_list.append(fdb_entry)
             srv.l2_egress_port_idx = port_index
-            srv.l2_egress_port_id = self.test_obj.dut.port_obj_list[port_index].bridge_port_oid
-            srv.fdb_entry = fdb_entry
+            self.test_obj.dut.fdb_entry_list.append(fdb_entry)
         print("Waiting for FDB to get refreshed, {} seconds ...".format(
             wait_sec))
         time.sleep(wait_sec)

--- a/test/sai_test/config/lag_configer.py
+++ b/test/sai_test/config/lag_configer.py
@@ -97,8 +97,8 @@ class LagConfiger(object):
         lag_members = []
         for port_index in lag_port_idxs:
             lag_member = sai_thrift_create_lag_member(self.client,
-                                                      lag_oid=lag.oid,
-                                                      port_id=self.test_obj.dut.port_list[port_index])
+                                                      lag_id=lag.oid,
+                                                      port_id=self.test_obj.dut.port_obj_list[port_index].oid)
             self.test_obj.assertEqual(
                 self.test_obj.status(), SAI_STATUS_SUCCESS)
             lag_members.append(lag_member)

--- a/test/sai_test/config/lag_configer.py
+++ b/test/sai_test/config/lag_configer.py
@@ -76,8 +76,8 @@ class LagConfiger(object):
             Lag: lag object
         """
         lag: Lag = Lag(None, [], [])
-        lag_id = sai_thrift_create_lag(self.client)
-        lag.lag_id = lag_id
+        lag_oid = sai_thrift_create_lag(self.client)
+        lag.oid = lag_oid
         self.create_lag_member(lag, lag_port_idxs)
         return lag
 
@@ -97,7 +97,7 @@ class LagConfiger(object):
         lag_members = []
         for port_index in lag_port_idxs:
             lag_member = sai_thrift_create_lag_member(self.client,
-                                                      lag_id=lag.lag_id,
+                                                      lag_oid=lag.oid,
                                                       port_id=self.test_obj.dut.port_list[port_index])
             self.test_obj.assertEqual(
                 self.test_obj.status(), SAI_STATUS_SUCCESS)
@@ -181,8 +181,8 @@ class LagConfiger(object):
         lag.lag_members.remove(lag.lag_members[index])
         lag.member_port_indexs.remove(port_idx)
 
-    def remove_lag(self, lag_id):
+    def remove_lag(self, lag_oid):
         """
         Remove lag.
         """
-        sai_thrift_remove_lag(self.client, lag_id)
+        sai_thrift_remove_lag(self.client, lag_oid)

--- a/test/sai_test/config/lag_configer.py
+++ b/test/sai_test/config/lag_configer.py
@@ -40,8 +40,8 @@ def t0_lag_config_helper(test_obj: 'T0TestBase', is_create_lag=True):
     lag_configer = LagConfiger(test_obj)
 
     if is_create_lag:
-        test_obj.dut.lag1 = lag_configer.create_lag([17, 18])
-        test_obj.dut.lag2 = lag_configer.create_lag([19, 20])
+        test_obj.dut.lag_list.append(lag_configer.create_lag([17, 18]))
+        test_obj.dut.lag_list.append(lag_configer.create_lag([19, 20]))
 
     """
     lag_configer.set_lag_hash_algorithm()

--- a/test/sai_test/config/port_configer.py
+++ b/test/sai_test/config/port_configer.py
@@ -443,15 +443,15 @@ class PortConfiger(object):
     def get_cpu_port_queue(self):
 
         attr = sai_thrift_get_switch_attribute(self.client, cpu_port=True)
-        self.test_obj.cpu_port = attr['cpu_port']
+        self.test_obj.dut.cpu_port = attr['cpu_port']
 
         attr = sai_thrift_get_port_attribute(self.client,
-                                             self.test_obj.cpu_port,
+                                             self.test_obj.dut.cpu_port,
                                              qos_number_of_queues=True)
         num_queues = attr['qos_number_of_queues']
         q_list = sai_thrift_object_list_t(count=num_queues)
         attr = sai_thrift_get_port_attribute(self.client,
-                                             self.test_obj.cpu_port,
+                                             self.test_obj.dut.cpu_port,
                                              qos_queue_list=q_list)
         for queue in range(0, num_queues):
             queue_id = attr['qos_queue_list'].idlist[queue]

--- a/test/sai_test/config/route_configer.py
+++ b/test/sai_test/config/route_configer.py
@@ -22,11 +22,13 @@
 from sai_thrift.sai_adapter import *
 from sai_utils import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 from constant import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
 
 from data_module.device import Device
 from data_module.vlan import Vlan
 from data_module.lag import Lag
+from data_module.port import Port
+from data_module.routable_item import route_item
 from typing import Dict, List
 
 from data_module.nexthop import Nexthop
@@ -50,7 +52,7 @@ def t0_route_config_helper(test_obj: 'T0TestBase', is_create_default_route=True,
     route_configer = RouteConfiger(test_obj)
     if is_create_default_route:
         route_configer.create_default_route()
-        route_configer.create_router_interface_by_port_idx(port_idx=0)
+        route_configer.create_router_interface(port_idx=0)
 
     if is_create_default_loopback_interface:
         route_configer.create_default_loopback_interface()
@@ -58,22 +60,27 @@ def t0_route_config_helper(test_obj: 'T0TestBase', is_create_default_route=True,
     if is_create_route_for_lag:
         test_obj.servers[11][0].ip_prefix = '24'
         test_obj.servers[11][0].ip_prefix_v6 = '112'
-        route_configer.create_neighbor_by_lag(
-            nexthop_device=test_obj.t1_list[1][100], lag=test_obj.dut.lag1)
-        route_configer.create_route_path_by_nexthop_from_lag(
+        rif = route_configer.create_router_interface(netItf=test_obj.dut.lag1)
+        route_configer.create_neighbor_by_rif(rif=rif,
+            nexthop_device=test_obj.t1_list[1][100])
+        nhv4, nhv6 = route_configer.create_nexthop_by_rif(rif=rif, 
+            nexthop_device=test_obj.t1_list[1][100])
+        route_configer.create_route_by_nexthop(
             dest_device=test_obj.servers[11][0],
-            nexthop_device=test_obj.t1_list[1][100],
-            lag=test_obj.dut.lag1)
+            nexthopv4=nhv4,
+            nexthopv6=nhv6)
 
         test_obj.servers[12][0].ip_prefix = '24'
         test_obj.servers[12][0].ip_prefix_v6 = '112'
-        route_configer.create_neighbor_by_lag(
-            nexthop_device=test_obj.t1_list[2][100], lag=test_obj.dut.lag2)
-        route_configer.create_route_path_by_nexthop_from_lag(
+        rif = route_configer.create_router_interface(netItf=test_obj.dut.lag2)
+        route_configer.create_neighbor_by_rif(rif=rif,
+            nexthop_device=test_obj.t1_list[2][100])
+        nhv4, nhv6 = route_configer.create_nexthop_by_rif(rif=rif, 
+            nexthop_device=test_obj.t1_list[2][100])
+        route_configer.create_route_by_nexthop(
             dest_device=test_obj.servers[12][0],
-            nexthop_device=test_obj.t1_list[2][100],
-            lag=test_obj.dut.lag2)
-
+            nexthopv4=nhv4,
+            nexthopv6=nhv6)
 
 class RouteConfiger(object):
     """
@@ -138,158 +145,8 @@ class RouteConfiger(object):
             packet_action=SAI_PACKET_ACTION_DROP)
         self.test_obj.assertEqual(self.test_obj.status(), SAI_STATUS_SUCCESS)
 
-    def create_route_path_by_nexthop_from_vlan(
-            self, dest_device: Device, nexthop_device: Device, vlan: Vlan, virtual_router=None):
-        """
-        Create a complete route path to a dest_device device, via from nexthop.
-        Set vlan attribute: nexthopv4, nexthopv6
-        Set device attribute: nexthopv4, nexthopv6
-        Set Device attribute: routev4, routev6
 
-        Attrs:
-            dest_device: Simulating the destinate device that this dut direct connect to.
-            nexthop_device: Simulating the bypass device that the packet will be forwarded to.
-            vlan: Vlan in the path
-            virtual_router_id: virtual route id, if not defined, will use default route
-
-        Return: routev4, routev6, nhopv4, nhopv6
-        """
-        nhopv4, nhopv6 = self.create_nexthop_by_vlan(
-            vlan, nexthop_device, virtual_router)
-        routev4, routev6 = self.create_route_path_by_nexthop(
-            dest_device, nhopv4, nhopv6, virtual_router)
-        return routev4, routev6, nhopv4, nhopv6
-
-    def create_route_path_by_nexthop_from_lag(
-            self, dest_device: Device, nexthop_device: Device, lag: Lag, virtual_router=None):
-        """
-        Create a complete route path to a dest_device device, via from nexthop.
-        Set dut attribute: nexthopv4_list, nexthopv6_list
-        Set vlan attribute: nexthopv4, nexthopv6
-        Set device attribute: nexthopv4, nexthopv6
-        Set Device attribute: routev4, routev6
-
-        Attrs:
-            dest_device: Simulating the destinate device that this dut direct connect to.
-            nexthop_device: Simulating the bypass device that the packet will be forwarded to.
-            lag: lag in the path
-            virtual_router_id: virtual route id, if not defined, will use default route
-
-        Return: routev4, routev6, nhopv4, nhopv6
-        """
-        nhopv4, nhopv6 = self.create_nexthop_by_lag(
-            lag, nexthop_device, virtual_router)
-        routev4, routev6 = self.create_route_path_by_nexthop(
-            dest_device, nhopv4, nhopv6, virtual_router)
-        return routev4, routev6, nhopv4, nhopv6
-
-    def create_route_path_by_nexthop_from_port(
-            self, dest_device: Device, nexthop_device: Device, port_idx, virtual_router=None):
-        """
-        Create a complete route path to a dest_device device, via from nexthop.
-        Set dut attribute: nexthopv4_list, nexthopv6_list, port_nhop_v4_list, port_nhop_v6_list
-        Set vlan attribute: nexthopv4, nexthopv6
-        Set device attribute: nexthopv4, nexthopv6
-        Set Device attribute: routev4, routev6
-
-        Attrs:
-            dest_device: Simulating the destinate device that this dut direct connect to.
-            nexthop_device: Simulating the bypass device that the packet will be forwarded to.
-            port_idx: port_idx in the path
-            virtual_router_id: virtual route id, if not defined, will use default route
-
-        Return: routev4, routev6, nhopv4, nhopv6
-        """
-        nhopv4, nhopv6 = self.create_nexthop_by_port_idx(
-            port_idx, nexthop_device, virtual_router)
-        routev4, routev6 = self.create_route_path_by_nexthop(
-            dest_device, nhopv4, nhopv6, virtual_router)
-        return routev4, routev6, nhopv4, nhopv6
-
-    def create_route_path_by_nexthop_from_bridge_port(
-            self, dest_device: Device, nexthop_device: Device, bridge_port_idx, virtual_router=None):
-        """
-        Create a complete route path to a dest_device device, via from nexthop.
-        Set dut attribute: nexthopv4_list, nexthopv6_list, bridge_port_nhop_v4_list, bridge_port_nhop_v6_list
-        Set vlan attribute: nexthopv4, nexthopv6
-        Set device attribute: nexthopv4, nexthopv6
-        Set Device attribute: routev4, routev6
-
-        Attrs:
-            dest_device: Simulating the destinate device that this dut direct connect to.
-            nexthop_device: Simulating the bypass device that the packet will be forwarded to.
-            bridge_port_idx: bridge_port_idx in the path
-            virtual_router_id: virtual route id, if not defined, will use default route
-
-        Return: routev4, routev6, nhopv4, nhopv6
-        """
-        nhopv4, nhopv6 = self.create_nexthop_by_bridge_port_idx(
-            bridge_port_idx, nexthop_device, virtual_router)
-        routev4, routev6 = self.create_route_path_by_nexthop(
-            dest_device, nhopv4, nhopv6, virtual_router)
-        return routev4, routev6, nhopv4, nhopv6
-
-    def create_route_path_by_rif_from_lag(
-            self, dest_device: Device, lag: Lag, virtual_router=None):
-        """
-        Create a complete route path from a port device to a dest_device device, via port from route interface.
-
-        Set Device attribute: routev4, routev6
-
-        Attrs:
-            dest_device: Simulating the destinate device that this dut direct connect to.
-            lag: Lag interface for the route
-            virtual_router_id: virtual route id, if not defined, will use default route
-
-        Return: routev4, routev6, rif
-        """
-        rif = self.create_router_interface_by_lag(
-            lag, virtual_router=virtual_router)
-        routev4, routev6 = self.create_route_path_by_rif(
-            dest_device=dest_device, rif=rif, virtual_router=virtual_router)
-        return routev4, routev6, rif
-
-    def create_route_path_by_rif_from_port(
-            self, dest_device: Device, port_idx, virtual_router=None):
-        """
-        Create a complete route path from a port device to a dest_device device, via port from route interface.
-
-        Set Device attribute: routev4, routev6
-
-        Attrs:
-            dest_device: Simulating the destinate device that this dut direct connect to.
-            port_idx: port_idx
-            virtual_router_id: virtual route id, if not defined, will use default route
-
-        Return: routev4, routev6, rif
-        """
-        rif = self.create_router_interface_by_port_idx(
-            port_idx, virtual_router=virtual_router)
-        routev4, routev6 = self.create_route_path_by_rif(
-            dest_device=dest_device, rif=rif, virtual_router=virtual_router)
-        return routev4, routev6, rif
-
-    def create_route_path_by_rif_from_bridge_port(
-            self, dest_device: Device, bridge_port_idx, virtual_router=None):
-        """
-        Create a complete route path from a port device to a dest_device device, via port from route interface.
-
-        Set Device attribute: routev4, routev6
-
-        Attrs:
-            dest_device: Simulating the destinate device that this dut direct connect to.
-            bridge_port_idx: bridge_port_idx
-            virtual_router_id: virtual route id, if not defined, will use default route
-
-        Return: routev4, routev6, rif
-        """
-        rif = self.create_router_interface_by_bridge_port_idx(
-            bridge_port_idx, virtual_router=virtual_router)
-        routev4, routev6 = self.create_route_path_by_rif(
-            dest_device=dest_device, rif=rif, virtual_router=virtual_router)
-        return routev4, routev6, rif
-
-    def create_route_path_by_rif(
+    def create_route_by_rif(
             self, dest_device: Device, rif, virtual_router=None):
         """
         Create a complete route path to a dest_device device, via route interface.
@@ -332,7 +189,7 @@ class RouteConfiger(object):
 
         return net_routev4, net_routev6
 
-    def create_route_path_by_nexthop(
+    def create_route_by_nexthop(
             self, dest_device: Device, nexthopv4: Nexthop, nexthopv6: Nexthop, virtual_router=None):
         """
         Create a complete route path to a dest_device device, via from nexthop.
@@ -356,7 +213,7 @@ class RouteConfiger(object):
             net_routev4 = sai_thrift_route_entry_t(
                 vr_id=vr_id, destination=sai_ipprefix(dest_device.ipv4+'/32'))
         status = sai_thrift_create_route_entry(
-            self.client, net_routev4, next_hop_id=nexthopv4.nexthop_id)
+            self.client, net_routev4, next_hop_id=nexthopv4.oid)
         self.test_obj.assertEqual(status, SAI_STATUS_SUCCESS)
 
         if dest_device.ip_prefix_v6:
@@ -367,7 +224,7 @@ class RouteConfiger(object):
             net_routev6 = sai_thrift_route_entry_t(
                 vr_id=vr_id, destination=sai_ipprefix(dest_device.ipv6+'/128'))
         status = sai_thrift_create_route_entry(
-            self.client, net_routev6, next_hop_id=nexthopv6.nexthop_id)
+            self.client, net_routev6, next_hop_id=nexthopv6.oid)
         self.test_obj.assertEqual(status, SAI_STATUS_SUCCESS)
 
         dest_device.routev4 = net_routev4
@@ -377,109 +234,33 @@ class RouteConfiger(object):
 
         return net_routev4, net_routev6
 
-    def create_neighbor_by_vlan(self, nexthop_device: Device, vlan: Vlan, virtual_router=None, no_host=True):
+
+    def create_neighbor_by_rif(self, nexthop_device: Device, rif, no_host=True):
         """
-        Create host neighbor vlan route interface, those neighbor are host neighbor.
-
-        Set Device attribtue: local_neighborv4_id, local_neighborv6_id
-        Set Dut attribute: neighborv4_list, neighborv6_list
-
-        Attrs:
-            nexthop_device: Simulating the bypass device that the packet will be forwarded to.
-            vlan: The vlan which will be used as the egress.
-            port_idx: The index of the port which will be used as the egress port.
-            no_host: Neighbor in no_host (neighbor direct) mode
-
-        return neighborv4, neighborv6
-        """
-        rif = self.create_router_interface_by_vlan(vlan, virtual_router)
-        v4, v6 = self.create_neighbor_by_rif(nexthop_device, rif, no_host)
-        return v4, v6
-
-    def create_neighbor_by_lag(self, nexthop_device: Device, lag: Lag, virtual_router=None, no_host=True):
-        """
-        Create host neighbor lag route interface, those neighbor are host neighbor.
-
-        Set Device attribtue: local_neighborv4_id, local_neighborv6_id
-        Set Dut attribute: neighborv4_list, neighborv6_list
-
-        Attrs:
-            nexthop_device: Simulating the bypass device that the packet will be forwarded to.
-            lag: The lag which will be used as the egress.
-            virtual_router_id: virtual route id, if not defined, will use default route
-            no_host: Neighbor in no_host (neighbor direct) mode
-
-        return neighborv4, neighborv6
-        """
-        rif = self.create_router_interface_by_lag(lag, virtual_router)
-        v4, v6 = self.create_neighbor_by_rif(nexthop_device, rif, no_host)
-        return v4, v6
-
-    def create_neighbor_by_port_idx(self, nexthop_device: Device, port_idx, virtual_router=None, no_host=True):
-        """
-        Create host neighbor port, those neighbor are host neighbor.
-
-        Set Device attribtue: local_neighborv4_id, local_neighborv6_id
-        Set Dut attribute: neighborv4_list, neighborv6_list
-
-        Attrs:
-            nexthop_device: Simulating the bypass device that the packet will be forwarded to.
-            port_idx: The index of the port which will be used as the egress port.
-            virtual_router_id: virtual route id, if not defined, will use default route
-            no_host: Neighbor in no_host (neighbor direct) mode
-
-        return neighborv4, neighborv6
-        """
-        rif = self.create_router_interface_by_port_idx(
-            port_idx, virtual_router)
-        v4, v6 = self.create_neighbor_by_rif(nexthop_device, rif, no_host)
-        return v4, v6
-
-    def create_neighbor_by_bridge_port_idx(self, nexthop_device: Device, bridge_port_idx, virtual_router=None, no_host=True):
-        """
-        Create host neighbor bridge port, those neighbor are host neighbor.
-
-        Set Device attribtue: local_neighborv4_id, local_neighborv6_id
-        Set Dut attribute: neighborv4_list, neighborv6_list
-
-        Attrs:
-            nexthop_device: Simulating the bypass device that the packet will be forwarded to.
-            bridge_port_idx: The index of the port which will be used as the egress port.
-            virtual_router_id: virtual route id, if not defined, will use default route
-            no_host: Neighbor in no_host (neighbor direct) mode
-
-        return neighborv4, neighborv6
-        """
-        rif = self.create_router_interface_by_bridge_port_idx(
-            bridge_port_idx, virtual_router)
-        v4, v6 = self.create_neighbor_by_rif(nexthop_device, rif, no_host)
-        return v4, v6
-
-    def create_neighbor_by_rif(self, nexthop_device: Device, rif, virtual_router=None, no_host=True):
-        """
-        Create neighbor(no_host, for in-direct route).
+        Create neighbor.
 
         Set Device attribtue: neighborv4_id, neighborv6_id
         Set Dut attribute: neighborv4_list, neighborv6_list
 
         Attrs:
             nexthop_device: Simulating the bypass device that the packet will be forwarded to.
-            port_idx: The index of the port which will be used as the egress port.
-            virtual_router_id: virtual route id, if not defined, will use default route
+            rif: the router interface this neighbor mapping.
             no_host: Neighbor in no_host (neighbor direct) mode
 
         return neighborv4, neighborv6
         """
-        vr_id = self.choice_virtual_route(virtual_router)
-        nbr_entry_v4 = sai_thrift_neighbor_entry_t(
-            rif_id=rif,
-            ip_address=sai_ipaddress(nexthop_device.ipv4))
-        status = sai_thrift_create_neighbor_entry(
-            self.client,
-            nbr_entry_v4,
-            dst_mac_address=nexthop_device.mac,
-            no_host_route=no_host)
-        self.test_obj.assertEqual(status, SAI_STATUS_SUCCESS)
+        if nexthop_device.ipv4:
+            nbr_entry_v4 = sai_thrift_neighbor_entry_t(
+                rif_id=rif,
+                ip_address=sai_ipaddress(nexthop_device.ipv4))
+            status = sai_thrift_create_neighbor_entry(
+                self.client,
+                nbr_entry_v4,
+                dst_mac_address=nexthop_device.mac,
+                no_host_route=no_host)
+            self.test_obj.assertEqual(status, SAI_STATUS_SUCCESS)
+        else:
+            nbr_entry_v4 = None
 
         if nexthop_device.ipv6:
             nbr_entry_v6 = sai_thrift_neighbor_entry_t(
@@ -506,200 +287,58 @@ class RouteConfiger(object):
             self.test_obj.dut.neighborv6_list.append(nbr_entry_v6)
         return nbr_entry_v4, nbr_entry_v6
 
-    def create_router_interface_by_vlan(self, vlan: Vlan, virtual_router=None):
-        """
-        Create vlan intreface.
-        It will check if the vlan already created a route interface
 
-        Set vlan attribute rif
+    def create_router_interface(self, netItf: route_item, virtual_router=None, reuse=True, is_bridge=False):
+        """
+        Create intreface.
+        It will check if the net interface already created on a route interface. If 'reuse',
+        it will return the last one created for this net interface, if not 'reuse', it will create a new one,
+        and store it with this net interface and dut object.
+
+        If netItf is None, then will create a loopback rif.
+
+        Set netItf attribute oid.
 
         Attrs:
-            vlan: vlan object that this vlan interface mapping
+            netItf: route_item object that this interface mapping
             virtual_router_id: virtual route id, if not defined, will use default route
             virtual_router_id: virtual route id, if not defined, will use default route
-
-        return vlan interface id
-        """
-        if not vlan.rif:
-            vr_id = self.choice_virtual_route(virtual_router)
-            rif = sai_thrift_create_router_interface(self.client,
-                                                     virtual_router_id=vr_id,
-                                                     type=SAI_ROUTER_INTERFACE_TYPE_VLAN,
-                                                     port_id=vlan.vlan_id)
-            self.test_obj.assertEqual(
-                self.test_obj.status(), SAI_STATUS_SUCCESS)
-            vlan.rif = rif
-        return vlan.rif
-
-    def create_router_interface_by_lag(self, lag: Lag, virtual_router=None):
-        """
-        Create lag intreface.
-        It will check if the lag already created a route interface
-
-        Set lag attribute lag_id
-
-        Attrs:
-            lag: Lag object that this lag interface mapping
-            virtual_router_id: virtual route id, if not defined, will use default route
-            virtual_router_id: virtual route id, if not defined, will use default route
-
+            reuse: reuse the existing rif which is binding to the net interfaces
+            is_bridge: is a bridge port, only used for port
         return rif
         """
-        if not lag.rif:
+        if not reuse or not netItf.rif_list or len(netItf.rif_list)==0:
             vr_id = self.choice_virtual_route(virtual_router)
-            rif = sai_thrift_create_router_interface(self.client,
-                                                     virtual_router_id=vr_id,
-                                                     type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                     port_id=lag.lag_id)
-            lag.rif = rif
+            if not netItf:
+                rif = sai_thrift_create_router_interface(self.client,
+                                                        virtual_router_id=vr_id,
+                                                        type=SAI_ROUTER_INTERFACE_TYPE_LOOPBACK)
+            else:
+                if is_bridge:
+                    if not isinstance(netItf, Vlan):
+                        raise ValueError('is bridge attribute can only be True when net interface is a Port!')
+                import pdb
+                pdb.set_trace()
+                if isinstance(netItf, Vlan):
+                    rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=vr_id,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_VLAN,
+                                                            vlan_id=netItf.oid)
+                if isinstance(netItf, Port):
+                    #Set the defaule rif type
+                    rif_type = SAI_ROUTER_INTERFACE_TYPE_PORT
+                    if is_bridge:
+                        rif_type = SAI_ROUTER_INTERFACE_TYPE_BRIDGE
+                    rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=vr_id,
+                                                            type=rif_type,
+                                                            vlan_id=netItf.oid)
             self.test_obj.assertEqual(
-                self.test_obj.status(), SAI_STATUS_SUCCESS)
-        return lag.rif
+                self.test_obj.status(), SAI_STATUS_SUCCESS)     
+            netItf.rif_list.append(rif)
+            self.test_obj.dut.rif_list.append(rif)
+        return netItf.rif_list[-1]
 
-    def create_router_interface_by_port_idx(self, port_idx, virtual_router=None):
-        """
-        Create route interface by port index for a port.
-        It will check if the port already created a route interface
-
-        Set dut attribute port_rif_list
-
-        Attrs:
-            port_idx: port index
-            virtual_router_id: virtual route id, if not defined, will use default route
-
-        return: route interface
-        """
-        if not self.test_obj.dut.port_rif_list[port_idx]:
-            vr_id = self.choice_virtual_route(virtual_router)
-            port_id = self.test_obj.dut.port_list[port_idx]
-            rif_id = sai_thrift_create_router_interface(
-                self.client, virtual_router_id=vr_id, type=SAI_ROUTER_INTERFACE_TYPE_PORT, port_id=port_id)
-            self.test_obj.dut.port_rif_list[port_idx] = rif_id
-            self.test_obj.assertEqual(
-                self.test_obj.status(), SAI_STATUS_SUCCESS)
-
-        return self.test_obj.dut.port_rif_list[port_idx]
-
-    def create_router_interface_by_bridge_port_idx(self, bridge_port_idx, virtual_router=None):
-        """
-        Create route interface by bridge port index for a port.
-        It will check if the bridge port already created a route interface
-
-        Set dut attribute bridge_port_rif_list
-
-        Attrs:
-            bridge_port_idx: bridge port index
-            virtual_router_id: virtual route id, if not defined, will use default route
-
-        return: route interface
-        """
-        if not self.test_obj.dut.bridge_port_rif_list[bridge_port_idx]:
-            vr_id = self.choice_virtual_route(virtual_router)
-            bridge_port_id = self.test_obj.dut.port_list[bridge_port_idx]
-            rif_id = sai_thrift_create_router_interface(
-                self.client, virtual_router_id=vr_id, type=SAI_ROUTER_INTERFACE_TYPE_BRIDGE, port_id=bridge_port_id)
-            self.test_obj.dut.bridge_port_rif_list[bridge_port_idx] = rif_id
-            self.test_obj.assertEqual(
-                self.test_obj.status(), SAI_STATUS_SUCCESS)
-
-        return self.test_obj.dut.bridge_port_rif_list[bridge_port_idx]
-
-    def create_nexthop_by_vlan(self, vlan: Vlan, nexthop_device: Device, virtual_router=None):
-        """
-        Create nexthop by vlan.
-
-        Set dut attribute: nexthopv4_list, nexthopv6_list
-        Set vlan attribute: nexthopv4, nexthopv6
-        Set device attribute: nexthopv4, nexthopv6
-
-        Attrs:
-            port_idx: bridge port index
-            nexthop_device: Simulating the bypass device, use this device to get the ipaddress, ipprefix_v4 and ipprefix_v6
-            virtual_router_id: virtual route id, if not defined, will use default route
-
-        return nexthop id
-        """
-        rif = self.create_router_interface_by_vlan(vlan, virtual_router)
-        v4, v6 = self.create_nexthop_by_rif(rif, nexthop_device)
-        v4.rif_id = rif
-        v6.rif_id = rif
-        vlan.nexthopv4 = v4
-        vlan.nexthopv6 = v6
-
-        return v4, v6
-
-    def create_nexthop_by_lag(self, lag: Lag, nexthop_device: Device, virtual_router=None):
-        """
-        Create nexthop by lag.
-
-        Set dut attribute: nexthopv4_list, nexthopv6_list
-        Set lag attribute: nexthopv4, nexthopv6
-        Set device attribute: nexthopv4, nexthopv6
-
-        Attrs:
-            port_idx: bridge port index
-            nexthop_device: Simulating the bypass device, use this device to get the ipaddress, ipprefix_v4 and ipprefix_v6
-            virtual_router_id: virtual route id, if not defined, will use default route
-
-        return nexthop id
-        """
-        rif = self.create_router_interface_by_lag(lag, virtual_router)
-        v4, v6 = self.create_nexthop_by_rif(rif, nexthop_device)
-        v4.rif_id = rif
-        v6.rif_id = rif
-        v4.lag = lag
-        v6.lag = lag
-        lag.nexthopv4 = v4
-        lag.nexthopv6 = v6
-        return v4, v6
-
-    def create_nexthop_by_port_idx(self, port_idx, nexthop_device: Device, ipprefix_v4=None, ipprefix_v6=None, virtual_router=None):
-        """
-        Create nexthop by port index for a port.
-
-        Set dut attribute: nexthopv4_list, nexthopv6_list, port_nhop_v4_list, port_nhop_v6_list
-        Set device attribute: nexthopv4, nexthopv6
-
-        Attrs:
-            port_idx: bridge port index
-            nexthop_device: Simulating the bypass device, use this device to get the ipaddress, ipprefix_v4 and ipprefix_v6
-            virtual_router_id: virtual route id, if not defined, will use default route
-
-        return nexthop id
-        """
-        rif = self.create_router_interface_by_port_idx(
-            port_idx, virtual_router)
-        v4, v6 = self.create_nexthop_by_rif(rif, nexthop_device)
-        v4.rif_id = rif
-        v6.rif_id = rif
-        v4.port_idx = port_idx
-        v6.port_idx = port_idx
-        self.test_obj.dut.port_nhop_v4_list.append(v4)
-        self.test_obj.dut.port_nhop_v6_list.append(v6)
-        return v4, v6
-
-    def create_nexthop_by_bridge_port_idx(self, bridge_port_idx, nexthop_device: Device, ipprefix_v4=None, ipprefix_v6=None, virtual_router=None):
-        """
-        Create nexthop by bridge port index for a port.
-
-        Set dut attribute: nexthopv4_list, nexthopv6_list, bridge_port_nhop_v4_list, bridge_port_nhop_v6_list
-        Set device attribute: nexthopv4, nexthopv6
-
-        Attrs:
-            bridge_port_idx: bridge port index
-            nexthop_device: Simulating the bypass device, use this device to get the ipaddress, ipprefix_v4 and ipprefix_v6
-            virtual_router_id: virtual route id, if not defined, will use default route
-
-        return nexthop id
-        """
-        rif = self.create_router_interface_by_bridge_port_idx(
-            bridge_port_idx, virtual_router)
-        v4, v6 = self.create_nexthop_by_rif(rif, nexthop_device)
-        v4.rif_id = rif
-        v6.rif_id = rif
-        self.test_obj.dut.bridge_port_nhop_v4_list.append(v4)
-        self.test_obj.dut.bridge_port_nhop_v6_list.append(v6)
-        return v4, v6
 
     def create_nexthop_by_rif(self, rif, nexthop_device: Device):
         """
@@ -713,7 +352,7 @@ class RouteConfiger(object):
             nexthop_device: Simulating the bypass device, use this device to get the ipaddress, ipprefix_v4 and ipprefix_v6
             virtual_router_id: virtual route id, if not defined, will use default route
 
-        return nexthop_v4 and nexthop_v6 id
+        return nexthop object for v4 and nexthop object for v6 
         """
         if nexthop_device.ip_prefix:
             nhopv4_id = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
@@ -730,8 +369,8 @@ class RouteConfiger(object):
             nhopv6_id = sai_thrift_create_next_hop(self.client, ip=sai_ipaddress(
                 nexthop_device.ipv6), router_interface_id=rif, type=SAI_NEXT_HOP_TYPE_IP)
         self.test_obj.assertEqual(self.test_obj.status(), SAI_STATUS_SUCCESS)
-        nhopv4: Nexthop = Nexthop(nhopv4_id, nexthop_device)
-        nhopv6: Nexthop = Nexthop(nhopv6_id, nexthop_device)
+        nhopv4: Nexthop = Nexthop(oid=nhopv4_id, nexthop_device=nexthop_device, rif=rif)
+        nhopv6: Nexthop = Nexthop(oid=nhopv6_id, nexthop_device=nexthop_device, rif=rif)
         self.test_obj.dut.nexthopv4_list.append(nhopv4)
         self.test_obj.dut.nexthopv6_list.append(nhopv6)
         nexthop_device.nexthopv4 = nhopv4
@@ -739,23 +378,6 @@ class RouteConfiger(object):
 
         return nhopv4, nhopv6
 
-    def create_ecmp_by_lags(self, lags: List[Lag]):
-        """
-        Create ecmp(next hop group) by lags, each lag will be binding to a nexthop
-        """
-        pass
-
-    def create_ecmp_by_nexthops(self, nhops: List[Nexthop]):
-        """
-        Create ecmp(next hop group) by Nexthop, each lag will be binding to a nexthop
-        """
-        pass
-
-    def create_ecmp_by_ports(self, port_idx: List):
-        """
-        Create ecmp(next hop group) by ports.
-        """
-        pass
 
     def choice_virtual_route(self, virtual_router=None):
         """
@@ -769,3 +391,5 @@ class RouteConfiger(object):
             return self.test_obj.dut.default_vrf
 
         return virtual_router
+
+

--- a/test/sai_test/config/route_configer.py
+++ b/test/sai_test/config/route_configer.py
@@ -52,7 +52,7 @@ def t0_route_config_helper(test_obj: 'T0TestBase', is_create_default_route=True,
     route_configer = RouteConfiger(test_obj)
     if is_create_default_route:
         route_configer.create_default_route()
-        route_configer.create_router_interface(port_idx=0)
+        route_configer.create_router_interface_by_port_idx(port_idx=0)
 
     if is_create_default_loopback_interface:
         route_configer.create_default_loopback_interface()
@@ -287,6 +287,25 @@ class RouteConfiger(object):
             self.test_obj.dut.neighborv6_list.append(nbr_entry_v6)
         return nbr_entry_v4, nbr_entry_v6
 
+    def create_router_interface_by_port_idx(self, port_idx, virtual_router=None, reuse=True, is_bridge=False):
+        """
+        Create route interface by port index for a port.
+        It will check if the port already created on a route interface. If 'reuse',
+        it will return the last one created for this port, if not 'reuse', it will create a new one,
+        and store it with this port and dut object.
+        
+        Attrs:
+            port_idx: port index
+            virtual_router_id: virtual route id, if not defined, will use default route
+            reuse: reuse the existing rif which is binding to the port
+            is_bridge: is a bridge port, only used for port
+        return: route interface
+        """
+        if not self.test_obj.dut.port_rif_list[port_idx]:
+            vr_id = self.choice_virtual_route(virtual_router)
+            port = self.test_obj.dut.port_obj_list[port_idx]
+            self.create_router_interface(port, virtual_router=vr_id, reuse=reuse, is_bridge=is_bridge)
+        return self.test_obj.dut.port_obj_list[port_idx].rif_list[-1]
 
     def create_router_interface(self, netItf: route_item, virtual_router=None, reuse=True, is_bridge=False):
         """
@@ -301,7 +320,6 @@ class RouteConfiger(object):
 
         Attrs:
             netItf: route_item object that this interface mapping
-            virtual_router_id: virtual route id, if not defined, will use default route
             virtual_router_id: virtual route id, if not defined, will use default route
             reuse: reuse the existing rif which is binding to the net interfaces
             is_bridge: is a bridge port, only used for port

--- a/test/sai_test/config/vlan_configer.py
+++ b/test/sai_test/config/vlan_configer.py
@@ -120,6 +120,7 @@ class VlanConfiger(object):
         vlan.vlan_id = vlan_id
         vlan.vlan_mport_oids = members
         vlan.oid = vlan_oid
+        vlan.port_idx_list = vlan_port_idxs
         return vlan
 
     def create_vlan_member(self, vlan_oid, vlan_ports, vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED):

--- a/test/sai_test/config/vlan_configer.py
+++ b/test/sai_test/config/vlan_configer.py
@@ -76,9 +76,9 @@ def t0_vlan_tear_down_helper(test_obj: 'T0TestBase'):
    # configer.remove_vlan(default_vlan_id)
 
     for _, vlan in test_obj.dut.vlans.items():
-        members = configer.get_vlan_member(vlan.vlan_oid)
+        members = configer.get_vlan_member(vlan.oid)
         configer.remove_vlan_members(members)
-        configer.remove_vlan(vlan.vlan_oid)
+        configer.remove_vlan(vlan.oid)
     test_obj.dut.vlans.clear()
 
 
@@ -119,7 +119,7 @@ class VlanConfiger(object):
             vlan_oid, vlan_port_idxs, vlan_tagging_mode)
         vlan.vlan_id = vlan_id
         vlan.vlan_mport_oids = members
-        vlan.vlan_oid = vlan_oid
+        vlan.oid = vlan_oid
         return vlan
 
     def create_vlan_member(self, vlan_oid, vlan_ports, vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED):

--- a/test/sai_test/config/vlan_configer.py
+++ b/test/sai_test/config/vlan_configer.py
@@ -141,12 +141,11 @@ class VlanConfiger(object):
         for port_index in vlan_ports:
             vlan_member = sai_thrift_create_vlan_member(self.client,
                                                         vlan_id=vlan_oid,
-                                                        bridge_port_id=self.test_obj.dut.bridge_port_list[
-                                                            port_index],
+                                                        bridge_port_id=self.test_obj.dut.port_obj_list[port_index].bridge_port_oid,
                                                         vlan_tagging_mode=vlan_tagging_mode)
             vlan_members.append(vlan_member)
             sai_thrift_set_port_attribute(
-                self.client, self.test_obj.dut.port_list[port_index], port_vlan_id=vlan_id)
+                self.client, self.test_obj.dut.port_obj_list[port_index].oid, port_vlan_id=vlan_id)
         return vlan_members
 
     def get_default_vlan(self):

--- a/test/sai_test/data_module/data_obj.py
+++ b/test/sai_test/data_module/data_obj.py
@@ -19,39 +19,26 @@
 #
 
 from typing import List
-from data_module.routable_item import route_item
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
+    from sai_test_base import T0TestBase
     from data_module.nexthop import Nexthop
 
 
-class Ecmp(object):
+class data_item():
     """
-    Represent the ecmp(next hop group) object.
+    Represent the basic data object.
     Attrs:
-        ecmp_id: ecmp id(nexthop group id)
-        ecmp_members: ecmp members(next hops)
-        member_port_indexs: ecmp port member indexes
+        oid: object id
     """
 
-    def __init__(self, ecmp_id=None, ecmp_members: List['Nexthop'] = [], member_port_indexs: List = []):
+    def __init__(self, oid = None):
         """
-        Init ecmp Object
+        Init data item Object
         Init following attrs:
-            ecmp_id
-            ecmp_members
-            member_port_indexs
-            lags
+            oid: object id
         """
-        self.ecmp_id = None
+        self.oid = oid
         """
-        ecmp id (nexthop group id)
-        """
-        self.ecmp_members: List[Nexthop] = ecmp_members
-        """
-        ecmp members(next hop ids)
-        """
-        self.member_port_indexs: List = member_port_indexs
-        """
-        ecmp port member indexes
+        object id
         """

--- a/test/sai_test/data_module/device.py
+++ b/test/sai_test/data_module/device.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from data_module.nexthop import Nexthop
     from data_module.ecmp import Ecmp
+    from data_module.lag import Lag
 
 
 class DeviceType(Enum):
@@ -42,13 +43,10 @@ class Device(object):
             ipv4: ip v4
             ipv6: ip v6
             l2_egress_port_idx: L2 destination port index, defined in fdb configer
-            l2_egress_port_id: L2 destination port object id, defined in fdb configer
-            l3_egress_port_idx: L3 destination port index, defined in route configer
-            l3_egress_port_id: L3 destination port object id, defined in route configer
-            l3_egress_lag_obj: L3 destination port object, defined in route configer
+            l3_port_idx: L3 destination port index, defined in route configer
+            l3_lag_obj: L3 destination port object, defined in route configer
             route_id
             nexthop
-            ecmp_egress: ecmp object for egress
             neighbor_id
             fdb_entry
     """
@@ -65,19 +63,9 @@ class Device(object):
             ipv4: ip v4
             ipv6: ip v6
             l2_egress_port_idx
-            l2_egress_port_id
-            l3_egress_port_idx
-            l3_egress_port_id
-            l3_egress_lag_obj
-            routev4
-            nexthoproutev4
-            nexthopv6
-            nexthoproutev6
-            neighborv6_id
-            local_neighborv6_id            
-            neighborv4_id
-            local_neighborv4_id
-            fdb_entry
+            l3_port_idx
+            l3_lag_obj
+            ecmp
 
         Server:
             self.ip_pattern: SERVER_IPV4_PATTERN
@@ -132,51 +120,21 @@ class Device(object):
         """
         L2 destination port index, defined in fdb configer
         """
-        self.l2_egress_port_id = None
-        """
-        L2 destination port object id, defined in fdb configer
-        """
 
         # L3 route info
-        self.l3_egress_port_idx = None
+        self.l3_port_idx = None
         """
         L3 destination port index, defined in route configer
         """
-        self.l3_egress_port_id = None
+        self.l3_lag_obj: Lag = None
         """
-        L3 destination port object id, defined in route configer
+        L3 destination lag object, defined in route configer
         """
-        self.l3_egress_lag_obj = None
+        self.ecmp : Ecmp = None
         """
-        L3 destination port object, defined in route configer
-        """
-        self.ecmp_egress: Ecmp = None
-        """
-        Ecmp object.
+        L3 destination ecmp object, defined in route configer
         """
 
-        self.routev4 = None
-        self.nexthopv4: Nexthop = None
-        self.routev6 = None
-        self.nexthopv6: Nexthop = None
-
-        self.neighborv4_id = None
-        """
-        No host neighbor
-        """
-        self.local_neighborv4_id = None
-        """
-        Host, direct neighbor
-        """
-        self.neighborv6_id = None
-        """
-        No host neighbor
-        """
-        self.local_neighborv6_id = None
-        """
-        Host, direct neighbor
-        """
-        self.fdb_entry = None
 
     def _generate_ipv4_address(self):
         """

--- a/test/sai_test/data_module/dut.py
+++ b/test/sai_test/data_module/dut.py
@@ -22,7 +22,9 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from data_module.vlan import Vlan
     from data_module.lag import Lag
+    from data_module.nexthop import Nexthop
     from data_module.ecmp import Ecmp
+    from data_module.port import Port
 
 
 class Dut(object):
@@ -60,8 +62,7 @@ class Dut(object):
             port_list 
             port_to_hostif_map 
             hostif_list 
-            port_rif_list 
-            bridge_rif_list
+            port_rif_list
             rif_list       
 
             # lag
@@ -70,11 +71,7 @@ class Dut(object):
 
             #L3
             nexthopv4_list: next hop id list
-            port_nhop_v4_list 
-            bridge_nhop_v4_list 
             nexthopv6_list: next hop id list
-            port_nhop_v6_list 
-            bridge_nhop_v6_list
             neighborv4_list
             neighborv6_list
 
@@ -126,6 +123,7 @@ class Dut(object):
         self.host_intf_table_id = None
         self.portConfigs = None
         self.port_list: List = None
+        self.port_obj_list: List[Port] = []
         """
         Port object list
         """
@@ -137,11 +135,6 @@ class Dut(object):
         self.port_rif_list: List = []
         """
         Port rif list. Size of the rif equals to the ports size, value will be None if not mapping to a rif
-        """
-
-        self.bridge_port_rif_list: List = []
-        """
-        Bridge Port rif list. Size of the rif equals to the bridge ports size, value will be None if not mapping to a rif
         """
         self.rif_list: List = []
         """
@@ -159,30 +152,13 @@ class Dut(object):
         """
 
         # nexthop
-        self.nexthopv4_list: List = []
+        self.nexthopv4_list: List[Nexthop] = []
         """
         nexthop list, contains nexthop objects
         """
-        self.nexthopv6_list: List = []
+        self.nexthopv6_list: List[Nexthop] = []
         """
         nexthop list, contains nexthop objects
-        """
-        self.port_nhop_v4_list: List = []
-        """
-        Port nhop list. Size of the nhop equals to the ports size, value will be None if not mapping to a nhop
-        """
-        self.port_nhop_v6_list: List = []
-        """
-        Port nhop list. Size of the nhop equals to the ports size, value will be None if not mapping to a nhop
-        """
-
-        self.bridge_port_nhop_v4_list: List = []
-        """
-        Bridge Port nhop list. Size of the nhop equals to the bridge ports size, value will be None if not mapping to a nhop
-        """
-        self.bridge_port_nhop_v6_list: List = []
-        """
-        Bridge Port nhop list. Size of the nhop equals to the bridge ports size, value will be None if not mapping to a nhop
         """
 
         self.neighborv4_list = []

--- a/test/sai_test/data_module/dut.py
+++ b/test/sai_test/data_module/dut.py
@@ -53,14 +53,10 @@ class Dut(object):
             vlan_20_fdb_list 
 
             # port
-            bridge_port_list 
             default_1q_bridge_id 
             default_trap_group 
-            dev_port_list 
             host_intf_table_id 
-            portConfigs 
-            port_list 
-            port_to_hostif_map 
+            port_list
             hostif_list 
             port_rif_list
             rif_list       
@@ -110,24 +106,16 @@ class Dut(object):
         self.vlan_20_fdb_list: List = None
 
         # port
-        self.bridge_port_list: List = None
-        """
-        bridge port id list
-        """
         self.default_1q_bridge_id = None
         self.default_trap_group = None
-        self.dev_port_list: List = None
         """
         Local device port index list, 0, 1, ...
         """
         self.host_intf_table_id = None
-        self.portConfigs = None
-        self.port_list: List = None
-        self.port_obj_list: List[Port] = []
+        self.port_obj_list: List['Port'] = []
         """
         Port object list
         """
-        self.port_to_hostif_map = None
         self.hostif_list = None
         """
         Host interface list

--- a/test/sai_test/data_module/dut.py
+++ b/test/sai_test/data_module/dut.py
@@ -58,7 +58,6 @@ class Dut(object):
             host_intf_table_id 
             port_list
             hostif_list 
-            port_rif_list
             rif_list       
 
             # lag
@@ -80,6 +79,8 @@ class Dut(object):
         Init all of the class attributes
         """
 
+        self.cpu_port = None
+
         # router
         self.default_vrf = None
         self.default_ipv6_route_entry = None
@@ -89,6 +90,17 @@ class Dut(object):
         self.local_128v6_route_entry = None
         self.routev4_list: List = []
         self.routev6_list: List = []
+        # nexthop
+        self.nexthopv4_list: List[Nexthop] = []
+        """
+        nexthop list, contains nexthop objects
+        """
+        self.nexthopv6_list: List[Nexthop] = []
+        """
+        nexthop list, contains nexthop objects
+        """
+        self.neighborv4_list = []
+        self.neighborv6_list = []
 
         # vlan
         self.default_vlan_id = None
@@ -101,9 +113,10 @@ class Dut(object):
         self.switch_id = None
 
         # fdb
-        self.default_vlan_fdb_list: List = None
-        self.vlan_10_fdb_list: List = None
-        self.vlan_20_fdb_list: List = None
+        self.fdb_entry_list: List = []
+        """
+        FDB entry list
+        """
 
         # port
         self.default_1q_bridge_id = None
@@ -120,34 +133,16 @@ class Dut(object):
         """
         Host interface list
         """
-        self.port_rif_list: List = []
-        """
-        Port rif list. Size of the rif equals to the ports size, value will be None if not mapping to a rif
-        """
         self.rif_list: List = []
         """
         Rif list. save the rif object id.
         """
 
         # lag
-        self.lag1: Lag = None
-        self.lag2: Lag = None
+        self.lag_list: List[Lag] = []
 
         # ecmp
         self.ecmp_list: List[Ecmp] = []
         """
         Ecmp list, contains ecmp objects
         """
-
-        # nexthop
-        self.nexthopv4_list: List[Nexthop] = []
-        """
-        nexthop list, contains nexthop objects
-        """
-        self.nexthopv6_list: List[Nexthop] = []
-        """
-        nexthop list, contains nexthop objects
-        """
-
-        self.neighborv4_list = []
-        self.neighborv6_list = []

--- a/test/sai_test/data_module/dut.py
+++ b/test/sai_test/data_module/dut.py
@@ -61,7 +61,8 @@ class Dut(object):
             port_to_hostif_map 
             hostif_list 
             port_rif_list 
-            bridge_rif_list            
+            bridge_rif_list
+            rif_list       
 
             # lag
             lag1 
@@ -141,6 +142,10 @@ class Dut(object):
         self.bridge_port_rif_list: List = []
         """
         Bridge Port rif list. Size of the rif equals to the bridge ports size, value will be None if not mapping to a rif
+        """
+        self.rif_list: List = []
+        """
+        Rif list. save the rif object id.
         """
 
         # lag

--- a/test/sai_test/data_module/lag.py
+++ b/test/sai_test/data_module/lag.py
@@ -33,7 +33,7 @@ class Lag(route_item):
         member_port_indexs: lag port member indexes
     Attrs from super:
         oid: object id
-        rif: lag related route interface
+        rif_list: lag related route interface
         nexthopv4: related nexthop list
         nexthopv6: related nexthop list
     """

--- a/test/sai_test/data_module/nexthop.py
+++ b/test/sai_test/data_module/nexthop.py
@@ -23,50 +23,36 @@ from enum import Enum
 from typing import List
 
 from typing import TYPE_CHECKING
+from data_module.routable_item import data_item
 if TYPE_CHECKING:
     from data_module.device import Device
 
 
-class Nexthop(object):
+class Nexthop(data_item):
     """
     Represent the Nexthopobject.
     Attrs:
-        nexthop_id: Nexthop id
+        oid: Nexthop object id
         nexthop_device: nexthop_device
-        rif_id: router interface id
-        port_idx: related port idx (optional, need to check if None)
-        lag: related lag (optional, need to check if None)
-        tunnel_idx: related tunnel idx (optional, need to check if None)
+        rif_id: router referenced rif object id
     """
 
-    def __init__(self, nexthop_id=None, nexthop_device: 'Device' = None, rif_id=None, port_idx=None, lag=None, tunnel_idx=None):
+    def __init__(self, oid=None, nexthop_device: 'Device' = None, rif_id=None):
         """
         Init Nexthop Object
         Init following attrs:
-            nexthop_id
+            oid
             nexthop_device
             rif_id
-            port_idx
-            lag
-            tunnel_idx
         """
-        self.nexthop_id = nexthop_id
-        """
-        Nexthop id
-        """
+        super().__init__(oid=oid)
         self.nexthop_device = nexthop_device
-        self.port_idx = port_idx
         """
-        related port idx (optional, need to check if None)
+        nexthop_device
         """
         self.rif_id = rif_id
-        self.lag = lag
         """
-        related lag (optional, need to check if None)
-        """
-        self.tunnel_idx = tunnel_idx
-        """
-        related tunnel idx (optional, need to check if None)
+        referenced rif object id
         """
 
 

--- a/test/sai_test/data_module/port.py
+++ b/test/sai_test/data_module/port.py
@@ -18,12 +18,13 @@
 #
 #
 
-from typing import List
+from typing import List, Dict
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from sai_test_base import T0TestBase
     from data_module.nexthop import Nexthop
 from data_module.routable_item import route_item
+
 
 class Port(route_item):
     """
@@ -39,19 +40,30 @@ class Port(route_item):
         nexthopv6: related nexthop list
     """
 
-    def __init__(self, port_index=None, dev_port_index = None, port_oid = None, bridge_port_oid = None, rif_list:List=[], nexthopv4_list:List['Nexthop'] = [], nexthopv6_list:List['Nexthop'] = []):
+    def __init__(
+            self,
+            oid=None,
+            port_index=None,
+            dev_port_index=None,
+            dev_port_eth=None,
+            bridge_port_oid=None,
+            rif_list: List = [],
+            nexthopv4_list: List['Nexthop'] = [],
+            nexthopv6_list: List['Nexthop'] = []):
         """
         Init Port Object
         Init following attrs:
+            oid: port object id        
             port_index: port index
             dev_port_index: device port, local device port index
-            port_oid: port object id
+            dev_port_eth: local device port eth name
             bridge_port_oid: bridge port object id
             rif
             nexthopv4
             nexthopv6
         """
-        super().__init__(rif_list=rif_list, nexthopv4_list=nexthopv4_list, nexthopv6_list=nexthopv6_list)
+        super().__init__(oid=oid, rif_list=rif_list, nexthopv4_list=nexthopv4_list,
+                         nexthopv6_list=nexthopv6_list)
         self.port_index = port_index
         """
         port index
@@ -60,12 +72,16 @@ class Port(route_item):
         """
         device port, local device port index
         """
-        self.port_oid = port_oid
+        self.dev_port_eth = dev_port_eth
         """
-        port object id
+        local device port eth name
         """
         self.bridge_port_oid = bridge_port_oid
         """
         bridge port object id
         """
-
+        self.port_config:Dict = {}
+        self.host_itf = None
+        """
+        Port binded host interface
+        """

--- a/test/sai_test/data_module/port.py
+++ b/test/sai_test/data_module/port.py
@@ -25,45 +25,47 @@ if TYPE_CHECKING:
     from data_module.nexthop import Nexthop
 from data_module.routable_item import route_item
 
-class Lag(route_item):
+class Port(route_item):
     """
-    Represent the lag object.
-    Attrs:        
-        lag_members: lag members
-        member_port_indexs: lag port member indexes
+    Represent the port object.
+    Attrs:
+        port_index: port index
+        dev_port_index: device port, local device port index
+        port_oid: port object id
+        bridge_port_oid: bridge port object id
     Attrs from super:
-        oid: object id
-        rif: lag related route interface
+        rif: port related route interface
         nexthopv4: related nexthop list
         nexthopv6: related nexthop list
     """
 
-    def __init__(self, oid=None, lag_members: List = [], member_port_indexs: List = [], rif_list:List=[], nexthopv4_list:List['Nexthop'] = [], nexthopv6_list:List['Nexthop'] = []):
+    def __init__(self, port_index=None, dev_port_index = None, port_oid = None, bridge_port_oid = None, rif_list:List=[], nexthopv4_list:List['Nexthop'] = [], nexthopv6_list:List['Nexthop'] = []):
         """
-        Init Lag Object
+        Init Port Object
         Init following attrs:
-            oid
-            lag_members
-            member_port_indexs
+            port_index: port index
+            dev_port_index: device port, local device port index
+            port_oid: port object id
+            bridge_port_oid: bridge port object id
             rif
             nexthopv4
             nexthopv6
         """
-        super().__init__(oid=oid, rif_list=rif_list, nexthopv4_list=nexthopv4_list, nexthopv6_list=nexthopv6_list)
-        self.lag_members: List = lag_members
+        super().__init__(rif_list=rif_list, nexthopv4_list=nexthopv4_list, nexthopv6_list=nexthopv6_list)
+        self.port_index = port_index
         """
-        lag members
+        port index
         """
-        self.member_port_indexs: List = member_port_indexs
+        self.dev_port_index = dev_port_index
         """
-        lag port member indexes
+        device port, local device port index
+        """
+        self.port_oid = port_oid
+        """
+        port object id
+        """
+        self.bridge_port_oid = bridge_port_oid
+        """
+        bridge port object id
         """
 
-    def create_lag_interface(self, test_object: 'T0TestBase', reuse=True):
-        """
-        Create vlan interface for this vlan object
-
-        Attrs:
-            test_object: test object contains the method for creating the interface
-        """
-        test_object.create_lag_interface(self, reuse)

--- a/test/sai_test/data_module/routable_item.py
+++ b/test/sai_test/data_module/routable_item.py
@@ -42,5 +42,14 @@ class route_item(data_item):
         super().__init__(oid=oid)
         self.rif_list = rif_list
         self.nexthopv4_list = nexthopv4_list
+        """
+        Next hop device for v4 ip, use to retrieve the nexthop ipv4
+        """
         self.nexthopv6_list = nexthopv6_list
-        self.neighbor_mac_list = []
+        """
+        Next hop device for v6 ip, use to retrieve the nexthop ipv6
+        """
+        self.neighbor_mac = None
+        """
+        Next hop device mac, expect it should be a unique one
+        """

--- a/test/sai_test/data_module/routable_item.py
+++ b/test/sai_test/data_module/routable_item.py
@@ -19,39 +19,25 @@
 #
 
 from typing import List
-from data_module.routable_item import route_item
 from typing import TYPE_CHECKING
+from data_module.data_obj import data_item
 if TYPE_CHECKING:
+    from sai_test_base import T0TestBase
     from data_module.nexthop import Nexthop
 
 
-class Ecmp(object):
+class route_item(data_item):
     """
-    Represent the ecmp(next hop group) object.
+    Represent the route item data object.
     Attrs:
-        ecmp_id: ecmp id(nexthop group id)
-        ecmp_members: ecmp members(next hops)
-        member_port_indexs: ecmp port member indexes
+        rif: related route interface
     """
 
-    def __init__(self, ecmp_id=None, ecmp_members: List['Nexthop'] = [], member_port_indexs: List = []):
+    def __init__(self, oid=None, rif_list:List=[], nexthopv4_list:List['Nexthop'] = [], nexthopv6_list:List['Nexthop'] = []):
         """
-        Init ecmp Object
+        Init Lag Object
         Init following attrs:
-            ecmp_id
-            ecmp_members
-            member_port_indexs
-            lags
+            rif
         """
-        self.ecmp_id = None
-        """
-        ecmp id (nexthop group id)
-        """
-        self.ecmp_members: List[Nexthop] = ecmp_members
-        """
-        ecmp members(next hop ids)
-        """
-        self.member_port_indexs: List = member_port_indexs
-        """
-        ecmp port member indexes
-        """
+        super().__init__(oid=oid)
+        self.rif_list = rif_list

--- a/test/sai_test/data_module/routable_item.py
+++ b/test/sai_test/data_module/routable_item.py
@@ -41,3 +41,6 @@ class route_item(data_item):
         """
         super().__init__(oid=oid)
         self.rif_list = rif_list
+        self.nexthopv4_list = nexthopv4_list
+        self.nexthopv6_list = nexthopv6_list
+        self.neighbor_mac_list = []

--- a/test/sai_test/data_module/vlan.py
+++ b/test/sai_test/data_module/vlan.py
@@ -25,41 +25,50 @@ if TYPE_CHECKING:
     from sai_test_base import T0TestBase
     from data_module.nexthop import Nexthop
 
+from data_module.routable_item import route_item
 
-class Vlan(object):
+class Vlan(route_item):
     """
     Represent the vlan object
 
     Attrs:
-        vlan_id: vlan id
-        vlan_oid: vlan ojbect id
+        oid: vlan ojbect id
         vlan_moids: vlan member object ids
-        rif: vlan related route interface
-        nexthopv4: vlan related nexthop
-        nexthopv6: vlan related nexthop
+    Attrs from super:
+        oid: object id
+        rif: lag related route interface
+        nexthopv4: related nexthop list
+        nexthopv6: related nexthop list
 
     """
 
-    def __init__(self, vlan_id=None, vlan_oid=None, vlan_moids: List = [], rif=None, nexthopv4: 'Nexthop' = None, nexthopv6: 'Nexthop' = None):
+    def __init__(self, vlan_id=None, oid=None, vlan_moids: List = [], rif_list:List=[], nexthopv4_list:List['Nexthop'] = [], nexthopv6_list:List['Nexthop'] = []):
         """
         Init Vlan object.
 
         Init following attrs:
             vlan_id
-            vlan_oid
+            oid
             vlan_mport_oids
-            rif
-            nexthopv4
-            nexthopv6
+            rif_list
+            nexthopv4_list
+            nexthopv6_list
         """
+        super().__init__(oid=oid, rif_list=rif_list, nexthopv4_list=nexthopv4_list, nexthopv6_list=nexthopv6_list)
         self.vlan_id = vlan_id
-        self.vlan_oid = vlan_oid
+        """
+        vlan id
+        """
+        self.oid = oid
+        """
+        vlan ojbect id
+        """
         self.vlan_mport_oids: List = vlan_moids
-        self.rif = rif
-        self.nexthopv4 = nexthopv4
-        self.nexthopv6 = nexthopv6
+        """
+        vlan member object ids
+        """
 
-    def create_vlan_interface(self, test_object: 'T0TestBase'):
+    def create_vlan_interface(self, test_object: 'T0TestBase', reuse=True):
         """
         Create vlan interface for this vlan object
 
@@ -67,4 +76,4 @@ class Vlan(object):
             test_object: test object contains the method for creating the interface
         """
 
-        self.rif = test_object.create_vlan_interface(self)
+        test_object.create_vlan_interface(self)

--- a/test/sai_test/data_module/vlan.py
+++ b/test/sai_test/data_module/vlan.py
@@ -67,6 +67,8 @@ class Vlan(route_item):
         """
         vlan member object ids
         """
+        self.port_idx_list = []
+
 
     def create_vlan_interface(self, test_object: 'T0TestBase', reuse=True):
         """

--- a/test/sai_test/sai_fdb_test.py
+++ b/test/sai_test/sai_fdb_test.py
@@ -90,7 +90,7 @@ class VlanLearnDisableTest(T0TestBase):
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
         status = sai_thrift_set_vlan_attribute(
-            self.client, self.dut.vlans[10].vlan_oid, learn_disable=True)
+            self.client, self.dut.vlans[10].oid, learn_disable=True)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
         status = sai_thrift_set_switch_attribute(
             self.client,
@@ -142,7 +142,7 @@ class VlanLearnDisableTest(T0TestBase):
 
         # restore initial VLAN Learning state
         sai_thrift_set_vlan_attribute(
-            self.client, self.dut.vlans[10].vlan_oid, learn_disable=False)
+            self.client, self.dut.vlans[10].oid, learn_disable=False)
 
 
 class BridgePortLearnDisableTest(T0TestBase):
@@ -340,7 +340,7 @@ class NewVlanmemberLearnTest(T0TestBase):
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         self.new_vlan10_member = sai_thrift_create_vlan_member(self.client,
-                                                               vlan_id=self.dut.vlans[10].vlan_oid,
+                                                               vlan_id=self.dut.vlans[10].oid,
                                                                bridge_port_id=self.dut.bridge_port_list[24])
 
         sai_thrift_set_port_attribute(
@@ -443,7 +443,7 @@ class RemoveVlanmemberLearnTest(T0TestBase):
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)
         self.dut.vlans[10].vlan_mport_oids[1] = sai_thrift_create_vlan_member(self.client,
-                                                                              vlan_id=self.dut.vlans[10].vlan_oid,
+                                                                              vlan_id=self.dut.vlans[10].oid,
                                                                               bridge_port_id=self.dut.bridge_port_list[1])
 
 
@@ -1072,7 +1072,7 @@ class FdbFlushVlanDynamicTest(T0TestBase):
         verify_packets(self, chk_pkt, [self.dut.dev_port_list[9]])
 
         status = sai_thrift_flush_fdb_entries(
-            self.client, bv_id=self.dut.vlans[20].vlan_oid, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC)
+            self.client, bv_id=self.dut.vlans[20].oid, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
         attr = sai_thrift_get_switch_attribute(
             self.client, available_fdb_entry=True)
@@ -1330,7 +1330,7 @@ class FdbDisableMacMoveDropTest(T0TestBase):
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         self.fdb_entry = sai_thrift_fdb_entry_t(switch_id=self.dut.switch_id,
                                                 mac_address=self.servers[1][1].mac,
-                                                bv_id=self.dut.vlans[10].vlan_oid)
+                                                bv_id=self.dut.vlans[10].oid)
         status = sai_thrift_create_fdb_entry(self.client,
                                              self.fdb_entry,
                                              type=SAI_FDB_ENTRY_TYPE_DYNAMIC,
@@ -1441,7 +1441,7 @@ class FdbStaticMacMoveTest(T0TestBase):
             entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)
         self.fdb_entry1 = sai_thrift_fdb_entry_t(switch_id=self.dut.switch_id,
                                                  mac_address=self.servers[1][2].mac,
-                                                 bv_id=self.dut.vlans[10].vlan_oid)
+                                                 bv_id=self.dut.vlans[10].oid)
         status = sai_thrift_create_fdb_entry(self.client,
                                              self.fdb_entry1,
                                              type=SAI_FDB_ENTRY_TYPE_STATIC,
@@ -1450,7 +1450,7 @@ class FdbStaticMacMoveTest(T0TestBase):
 
         self.fdb_entry2 = sai_thrift_fdb_entry_t(switch_id=self.dut.switch_id,
                                                  mac_address=self.servers[1][1].mac,
-                                                 bv_id=self.dut.vlans[10].vlan_oid)
+                                                 bv_id=self.dut.vlans[10].oid)
         status = sai_thrift_create_fdb_entry(self.client,
                                              self.fdb_entry2,
                                              type=SAI_FDB_ENTRY_TYPE_DYNAMIC,

--- a/test/sai_test/sai_fdb_test.py
+++ b/test/sai_test/sai_fdb_test.py
@@ -36,7 +36,7 @@ class L2PortForwardingTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
 
@@ -66,7 +66,7 @@ class L2PortForwardingTest(T0TestBase):
 
     def tearDown(self):
         """
-        Test the basic tearDown process
+        TearDown process
         """
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)
@@ -85,7 +85,7 @@ class VlanLearnDisableTest(T0TestBase):
     @skip("skip for broadcom")
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         status = sai_thrift_flush_fdb_entries(
@@ -140,6 +140,9 @@ class VlanLearnDisableTest(T0TestBase):
         print("Verification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)
 
@@ -155,7 +158,7 @@ class BridgePortLearnDisableTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         status = sai_thrift_flush_fdb_entries(
@@ -226,6 +229,9 @@ class BridgePortLearnDisableTest(T0TestBase):
         print("Verification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)
 
@@ -248,7 +254,7 @@ class NonBridgePortNoLearnTest(T0TestBase):
     @skip("Skip test for broadcom, non bridge port still can learn.")
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         status = sai_thrift_flush_fdb_entries(
@@ -310,6 +316,9 @@ class NonBridgePortNoLearnTest(T0TestBase):
         print("Verification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)
         
@@ -341,7 +350,7 @@ class NewVlanmemberLearnTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         self.new_vlan10_member = sai_thrift_create_vlan_member(self.client,
@@ -390,6 +399,9 @@ class NewVlanmemberLearnTest(T0TestBase):
         print("Verification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)
         sai_thrift_remove_vlan_member(self.client, self.new_vlan10_member)
@@ -402,7 +414,7 @@ class RemoveVlanmemberLearnTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         sai_thrift_remove_vlan_member(
@@ -446,6 +458,9 @@ class RemoveVlanmemberLearnTest(T0TestBase):
         print("Verification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)
         self.dut.vlans[10].vlan_mport_oids[1] = sai_thrift_create_vlan_member(self.client,
@@ -460,7 +475,7 @@ class InvalidateVlanmemberNoLearnTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
@@ -499,6 +514,9 @@ class InvalidateVlanmemberNoLearnTest(T0TestBase):
         print("Verification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         pass
 
 
@@ -509,7 +527,7 @@ class BroadcastNoLearnTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
 
@@ -546,6 +564,9 @@ class BroadcastNoLearnTest(T0TestBase):
         print("Verification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         pass
 
 
@@ -556,7 +577,7 @@ class MulticastNoLearnTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
 
@@ -596,6 +617,9 @@ class MulticastNoLearnTest(T0TestBase):
         print("Verification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         pass
 
 
@@ -606,7 +630,7 @@ class FdbAgingTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         sw_attr = sai_thrift_get_switch_attribute(
@@ -675,6 +699,9 @@ class FdbAgingTest(T0TestBase):
         print("\tVerification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC)
         status = sai_thrift_set_switch_attribute(
@@ -689,7 +716,7 @@ class FdbAgingAfterMoveTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         sw_attr = sai_thrift_get_switch_attribute(
@@ -786,6 +813,9 @@ class FdbAgingAfterMoveTest(T0TestBase):
         print("\tVerification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC)
         status = sai_thrift_set_switch_attribute(
@@ -800,7 +830,7 @@ class FdbMacMovingAfterAgingTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         sw_attr = sai_thrift_get_switch_attribute(
@@ -884,6 +914,9 @@ class FdbMacMovingAfterAgingTest(T0TestBase):
         print("\tVerification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC)
         status = sai_thrift_set_switch_attribute(
@@ -903,7 +936,7 @@ class FdbFlushVlanStaticTest(T0TestBase):
     @skip("Static flush Not support by broadcom")
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         status = sai_thrift_flush_fdb_entries(
@@ -935,6 +968,9 @@ class FdbFlushVlanStaticTest(T0TestBase):
         print("\tVerification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         self.t0_fdb_tear_down_helper()
         self.t0_fdb_config_helper()
 
@@ -951,7 +987,7 @@ class FdbFlushPortStaticTest(T0TestBase):
     @skip("Static flush Not support by broadcom")
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         sai_thrift_flush_fdb_entries(
@@ -982,6 +1018,9 @@ class FdbFlushPortStaticTest(T0TestBase):
         print("\tVerification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         self.restore_fdb_config()
 
 
@@ -998,7 +1037,7 @@ class FdbFlushAllStaticTest(T0TestBase):
     @skip("Static flush Not support by broadcom")
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         sai_thrift_flush_fdb_entries(
@@ -1029,6 +1068,9 @@ class FdbFlushAllStaticTest(T0TestBase):
         print("\tVerification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         self.restore_fdb_config()
 
 
@@ -1039,7 +1081,7 @@ class FdbFlushVlanDynamicTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
 
@@ -1104,6 +1146,9 @@ class FdbFlushVlanDynamicTest(T0TestBase):
         print("\tVerification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         pass
 
 
@@ -1114,7 +1159,7 @@ class FdbFlushPortDynamicTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
 
@@ -1179,6 +1224,9 @@ class FdbFlushPortDynamicTest(T0TestBase):
         print("\tVerification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         pass
 
 
@@ -1189,7 +1237,7 @@ class FdbFlushAllDynamicTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
 
@@ -1254,6 +1302,9 @@ class FdbFlushAllDynamicTest(T0TestBase):
         print("\tVerification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         pass
 
 
@@ -1269,7 +1320,7 @@ class FdbFlushAllTest(T0TestBase):
     @skip("static not support")
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
 
@@ -1334,6 +1385,9 @@ class FdbFlushAllTest(T0TestBase):
         print("\tVerification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         self.restore_fdb_config()
 
 
@@ -1344,7 +1398,7 @@ class FdbDisableMacMoveDropTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         self.fdb_entry = sai_thrift_fdb_entry_t(switch_id=self.dut.switch_id,
@@ -1377,6 +1431,9 @@ class FdbDisableMacMoveDropTest(T0TestBase):
         print("\tVerification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_remove_fdb_entry(self.client, self.fdb_entry)
         status = sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC)
@@ -1390,7 +1447,7 @@ class FdbDynamicMacMoveTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         sai_thrift_flush_fdb_entries(
@@ -1439,6 +1496,9 @@ class FdbDynamicMacMoveTest(T0TestBase):
         print("\tVerification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_remove_fdb_entry(self.client, self.moving_fdb_entry)
         status = sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC)
@@ -1452,7 +1512,7 @@ class FdbStaticMacMoveTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         sai_thrift_flush_fdb_entries(
@@ -1513,6 +1573,9 @@ class FdbStaticMacMoveTest(T0TestBase):
         print("\tVerification complete")
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_remove_fdb_entry(self.client, self.fdb_entry1)
         sai_thrift_remove_fdb_entry(self.client, self.fdb_entry2)
         sai_thrift_remove_fdb_entry(self.client, self.moving_fdb_entry)

--- a/test/sai_test/sai_lag_test.py
+++ b/test/sai_test/sai_lag_test.py
@@ -32,12 +32,13 @@ class LagConfigTest(T0TestBase):
         Test the basic setup process.
         """
         T0TestBase.setUp(self)
-
-    def load_balance_on_src_ip(self):
         self.port1_rif = sai_thrift_create_router_interface(self.client,
                                                             virtual_router_id=self.dut.default_vrf,
                                                             type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_list[1])
+                                                            port_id=self.dut.port_obj_list[1].oid)
+
+    def load_balance_on_src_ip(self):
+        
         ip_dst = self.servers[11][1].ipv4
         pkt1 = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                  eth_src=self.servers[1][1].mac,
@@ -92,6 +93,10 @@ class LoadbalanceOnSrcPortTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                                virtual_router_id=self.dut.default_vrf,
+                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                                port_id=self.dut.port_obj_list[1].oid)
 
     def runTest(self):
         """
@@ -101,10 +106,7 @@ class LoadbalanceOnSrcPortTest(T0TestBase):
         """
         try:
             print("Lag l3 load balancing test based on src port")
-            self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.port_list[1])
+            
             max_itrs = 99
             begin_port = 2000
             rcv_count = [0, 0]
@@ -152,6 +154,10 @@ class LoadbalanceOnDesPortTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                                virtual_router_id=self.dut.default_vrf,
+                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                                port_id=self.dut.port_obj_list[1].oid)
 
     def runTest(self):
         """
@@ -161,10 +167,7 @@ class LoadbalanceOnDesPortTest(T0TestBase):
         """
         try:
             print("Lag l3 load balancing test based on des port")
-            self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.port_list[1])
+            
             max_itrs = 99
             begin_port = 2000
             rcv_count = [0, 0]
@@ -213,6 +216,10 @@ class LoadbalanceOnSrcIPTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                                virtual_router_id=self.dut.default_vrf,
+                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                                port_id=self.dut.port_obj_list[1].oid)
 
     def runTest(self):
         """
@@ -222,10 +229,7 @@ class LoadbalanceOnSrcIPTest(T0TestBase):
         """
         try:
             print("Lag l3 load balancing test based on src IP")
-            self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.port_list[1])
+            
             max_itrs = 99
             rcv_count = [0, 0]
             for i in range(1, max_itrs):
@@ -271,6 +275,10 @@ class LoadbalanceOnDesIPTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                                virtual_router_id=self.dut.default_vrf,
+                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                                port_id=self.dut.port_obj_list[1].oid)
 
     def runTest(self):
         """
@@ -280,10 +288,7 @@ class LoadbalanceOnDesIPTest(T0TestBase):
         """
         try:
             print("Lag l3 load balancing test based on des IP")
-            self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.port_list[1])
+            
             max_itrs = 99
             rcv_count = [0, 0]
             for i in range(1, max_itrs):
@@ -334,6 +339,10 @@ class LoadbalanceOnProtocolTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                                virtual_router_id=self.dut.default_vrf,
+                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                                port_id=self.dut.port_obj_list[1].oid)
 
     def runTest(self):
         """
@@ -343,10 +352,7 @@ class LoadbalanceOnProtocolTest(T0TestBase):
         """
         try:
             print("Lag l3 load balancing test based on protocol")
-            self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.port_list[1])
+            
             max_itrs = 99
             rcv_count = [0, 0]
             for i in range(0, max_itrs):
@@ -407,6 +413,10 @@ class DisableEgressTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                                virtual_router_id=self.dut.default_vrf,
+                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                                port_id=self.dut.port_obj_list[1].oid)
 
     def runTest(self):
         """
@@ -420,10 +430,7 @@ class DisableEgressTest(T0TestBase):
         """
         try:
             print("Lag disable egress lag member test")
-            self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.port_list[1])
+            
             pkts_num = 10
             begin_port = 2000
             exp_drop = []
@@ -499,6 +506,10 @@ class DisableIngressTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                                virtual_router_id=self.dut.default_vrf,
+                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                                port_id=self.dut.lag1.oid)
 
     def runTest(self):
         """
@@ -512,10 +523,7 @@ class DisableIngressTest(T0TestBase):
         """
         try:
             print("Lag disable ingress lag member test")
-            self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.lag1.oid)
+            
             pkts_num = 10
             begin_port = 2000
             for i in range(0, pkts_num):
@@ -579,6 +587,10 @@ class RemoveLagMemberTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                                virtual_router_id=self.dut.default_vrf,
+                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                                port_id=self.dut.port_obj_list[1].oid)
 
     def runTest(self):
         """
@@ -592,10 +604,7 @@ class RemoveLagMemberTest(T0TestBase):
         """
         try:
             print("Lag remove lag member test")
-            self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.port_list[1])
+            
 
             pkts_num = 10
             begin_port = 2000
@@ -661,6 +670,10 @@ class AddLagMemberTest(T0TestBase):
         set up configurations
         """
         T0TestBase.setUp(self)
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                                virtual_router_id=self.dut.default_vrf,
+                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                                port_id=self.dut.port_obj_list[1].oid)
 
     def runTest(self):
         """
@@ -674,10 +687,7 @@ class AddLagMemberTest(T0TestBase):
         """
         try:
             print("Lag add lag member test")
-            self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.port_list[1])
+            
             pkts_num = 10
             begin_port = 2000
             rcv_count = [0, 0, 0]
@@ -746,13 +756,14 @@ class IndifferenceIngressPortTest(T0TestBase):
 
     def setUp(self):
         T0TestBase.setUp(self)
-
-    def runTest(self):
-        try:
-            self.vlan10_rif = sai_thrift_create_router_interface(self.client,
+        self.vlan10_rif = sai_thrift_create_router_interface(self.client,
                                                                 virtual_router_id=self.dut.default_vrf,
                                                                 type=SAI_ROUTER_INTERFACE_TYPE_VLAN,
                                                                 vlan_id=10)
+
+    def runTest(self):
+        try:
+            
             pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                     eth_src=self.servers[1][1].mac,
                                     ip_dst=self.servers[11][1].ipv4,

--- a/test/sai_test/sai_lag_test.py
+++ b/test/sai_test/sai_lag_test.py
@@ -515,7 +515,7 @@ class DisableIngressTest(T0TestBase):
             self.port1_rif = sai_thrift_create_router_interface(self.client,
                                                                 virtual_router_id=self.dut.default_vrf,
                                                                 type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.lag1.lag_id)
+                                                                port_id=self.dut.lag1.oid)
             pkts_num = 10
             begin_port = 2000
             for i in range(0, pkts_num):

--- a/test/sai_test/sai_lag_test.py
+++ b/test/sai_test/sai_lag_test.py
@@ -52,13 +52,13 @@ class LagConfigTest(T0TestBase):
                                  ip_src=self.servers[2][1].ipv4,
                                  ip_id=105,
                                  ip_ttl=64)
-        exp_pkt1 = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+        exp_pkt1 = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                      eth_src=ROUTER_MAC,
                                      ip_dst=ip_dst,
                                      ip_src=self.servers[1][1].ipv4,
                                      ip_id=105,
                                      ip_ttl=63)
-        exp_pkt2 = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+        exp_pkt2 = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                      eth_src=ROUTER_MAC,
                                      ip_dst=ip_dst,
                                      ip_src=self.servers[2][1].ipv4,
@@ -66,10 +66,10 @@ class LagConfigTest(T0TestBase):
                                      ip_ttl=63)
         send_packet(self, 1, pkt1)
         verify_packet_any_port(
-            self, exp_pkt1, self.dut.lag1.member_port_indexs)
+            self, exp_pkt1, self.servers[11][1].l3_lag_obj.member_port_indexs)
         send_packet(self, 1, pkt2)
         verify_packet_any_port(
-            self, exp_pkt2, self.dut.lag1.member_port_indexs)
+            self, exp_pkt2, self.servers[11][1].l3_lag_obj.member_port_indexs)
 
     def runTest(self):
         try:
@@ -119,7 +119,7 @@ class LoadbalanceOnSrcPortTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -128,7 +128,7 @@ class LoadbalanceOnSrcPortTest(T0TestBase):
                                             ip_ttl=63)
                 send_packet(self, 1, pkt)
                 rcv_idx, _ = verify_packet_any_port(
-                    self, exp_pkt, self.dut.lag1.member_port_indexs)
+                    self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
                 print('src_port={}, rcv_port={}'.format(src_port, rcv_idx))
                 rcv_count[rcv_idx] += 1
             print(rcv_count)
@@ -180,7 +180,7 @@ class LoadbalanceOnDesPortTest(T0TestBase):
                                         tcp_dport=des_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -189,7 +189,7 @@ class LoadbalanceOnDesPortTest(T0TestBase):
                                             ip_ttl=63)
                 send_packet(self, 1, pkt)
                 rcv_idx, _ = verify_packet_any_port(
-                    self, exp_pkt, self.dut.lag1.member_port_indexs)
+                    self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
                 print('des_port={}, rcv_port={}'.format(des_port, rcv_idx))
                 rcv_count[rcv_idx] += 1
 
@@ -239,7 +239,7 @@ class LoadbalanceOnSrcIPTest(T0TestBase):
                                         ip_src=self.servers[1][i].ipv4,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][i].ipv4,
@@ -247,7 +247,7 @@ class LoadbalanceOnSrcIPTest(T0TestBase):
                                             ip_ttl=63)
                 send_packet(self, 1, pkt)
                 rcv_idx, _ = verify_packet_any_port(
-                    self, exp_pkt, self.dut.lag1.member_port_indexs)
+                    self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
                 print('ip_src={}, rcv_port={}'.format(
                     self.servers[1][i].ipv4, rcv_idx))
                 rcv_count[rcv_idx] += 1
@@ -298,7 +298,7 @@ class LoadbalanceOnDesIPTest(T0TestBase):
                                         ip_src=self.servers[1][1].ipv4,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][i].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -306,7 +306,7 @@ class LoadbalanceOnDesIPTest(T0TestBase):
                                             ip_ttl=63)
                 send_packet(self, 1, pkt)
                 rcv_idx, _ = verify_packet_any_port(
-                    self, exp_pkt, self.dut.lag1.member_port_indexs)
+                    self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
                 print('des_src={}, rcv_port={}'.format(
                     self.servers[1][1].ipv4, rcv_idx))
                 rcv_count[rcv_idx] += 1
@@ -363,7 +363,7 @@ class LoadbalanceOnProtocolTest(T0TestBase):
                                             ip_src=self.servers[1][1].ipv4,
                                             ip_id=105,
                                             ip_ttl=64)
-                    exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+                    exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                                 eth_src=ROUTER_MAC,
                                                 ip_dst=self.servers[11][1].ipv4,
                                                 ip_src=self.servers[1][1].ipv4,
@@ -377,7 +377,7 @@ class LoadbalanceOnProtocolTest(T0TestBase):
                                              ip_src=self.servers[1][1].ipv4,
                                              ip_id=105,
                                              ip_ttl=64)
-                    exp_pkt = simple_icmp_packet(eth_dst=self.t1_list[1][100].mac,
+                    exp_pkt = simple_icmp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                                  eth_src=ROUTER_MAC,
                                                  ip_dst=self.servers[11][1].ipv4,
                                                  ip_src=self.servers[1][1].ipv4,
@@ -385,7 +385,7 @@ class LoadbalanceOnProtocolTest(T0TestBase):
                                                  ip_ttl=63)
                 send_packet(self, 1, pkt)
                 rcv_idx, _ = verify_packet_any_port(
-                    self, exp_pkt, self.dut.lag1.member_port_indexs)
+                    self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
                 print('des_src={}, rcv_port={}'.format(
                     self.servers[1][1].ipv4, rcv_idx))
                 rcv_count[rcv_idx] += 1
@@ -443,7 +443,7 @@ class DisableEgressTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -452,14 +452,14 @@ class DisableEgressTest(T0TestBase):
                                             ip_ttl=63)
                 send_packet(self, 1, pkt)
                 rcv_idx, _ = verify_packet_any_port(
-                    self, exp_pkt, self.dut.lag1.member_port_indexs)
+                    self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
                 if rcv_idx == 18:
                     exp_drop.append(src_port)
 
             # disable egress of lag member: port18
             print("disable port18 egress")
             status = sai_thrift_set_lag_member_attribute(self.client,
-                                                         self.dut.lag1.lag_members[1],
+                                                         self.servers[11][1].l3_lag_obj.lag_members[1],
                                                          egress_disable=True)
             self.assertEqual(status, SAI_STATUS_SUCCESS)
 
@@ -472,7 +472,7 @@ class DisableEgressTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -509,7 +509,7 @@ class DisableIngressTest(T0TestBase):
         self.port1_rif = sai_thrift_create_router_interface(self.client,
                                                                 virtual_router_id=self.dut.default_vrf,
                                                                 type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.lag1.oid)
+                                                                port_id=self.servers[11][1].l3_lag_obj.oid)
 
     def runTest(self):
         """
@@ -529,7 +529,7 @@ class DisableIngressTest(T0TestBase):
             for i in range(0, pkts_num):
                 src_port = begin_port + i
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                        eth_src=self.t1_list[1][100].mac,
+                                        eth_src=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                         ip_dst=self.servers[1][1].ipv4,
                                         ip_src=self.servers[11][1].ipv4,
                                         tcp_sport=src_port,
@@ -547,13 +547,13 @@ class DisableIngressTest(T0TestBase):
             # git disable ingress of lag member: port18
             print("disable port18 ingress")
             status = sai_thrift_set_lag_member_attribute(
-                self.client, self.lag1.lag_members[1], ingress_disable=True)
+                self.client, self.lag_list[0].lag_members[1], ingress_disable=True)
             self.assertEqual(status, SAI_STATUS_SUCCESS)
 
             for i in range(0, pkts_num):
                 src_port = begin_port + i
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                        eth_src=self.t1_list[1][100].mac,
+                                        eth_src=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                         ip_dst=self.servers[1][1].ipv4,
                                         ip_src=self.servers[11][1].ipv4,
                                         tcp_sport=src_port,
@@ -617,7 +617,7 @@ class RemoveLagMemberTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -626,10 +626,10 @@ class RemoveLagMemberTest(T0TestBase):
                                             ip_ttl=63)
                 send_packet(self, 1, pkt)
                 verify_packet_any_port(
-                    self, exp_pkt, self.dut.lag1.member_port_indexs)
+                    self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
 
             self.lag_configer.remove_lag_member_by_port_idx(
-                lag_obj=self.dut.lag1, port_idx=18)
+                lag_obj=self.servers[11][1].l3_lag_obj, port_idx=18)
 
             for i in range(0, pkts_num):
                 src_port = begin_port + i
@@ -640,7 +640,7 @@ class RemoveLagMemberTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -649,7 +649,7 @@ class RemoveLagMemberTest(T0TestBase):
                                             ip_ttl=63)
                 send_packet(self, 1, pkt)
                 verify_no_packet(self, exp_pkt, 18)
-            self.lag_configer.create_lag_member(lag_obj=self.dut.lag1,
+            self.lag_configer.create_lag_member(lag_obj=self.servers[11][1].l3_lag_obj,
                                                 lag_port_idxs=range(18, 19))
         finally:
             pass
@@ -700,7 +700,7 @@ class AddLagMemberTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -709,9 +709,9 @@ class AddLagMemberTest(T0TestBase):
                                             ip_ttl=63)
                 send_packet(self, 1, pkt)
                 verify_packet_any_port(
-                    self, exp_pkt, self.dut.lag1.member_port_indexs)
+                    self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
             print("add port21 into lag1")
-            self.lag_configer.create_lag_member(lag_obj=self.dut.lag1,
+            self.lag_configer.create_lag_member(lag_obj=self.servers[11][1].l3_lag_obj,
                                                 lag_port_idxs=range(21, 22))
             for i in range(0, pkts_num):
                 src_port = begin_port + i
@@ -722,7 +722,7 @@ class AddLagMemberTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -731,13 +731,13 @@ class AddLagMemberTest(T0TestBase):
                                             ip_ttl=63)
                 send_packet(self, 1, pkt)
                 rcv_idx, _ = verify_packet_any_port(
-                    self, exp_pkt, self.dut.lag1.member_port_indexs)
+                    self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
                 rcv_count[rcv_idx] += 1
             for cnt in rcv_count:
                 self.assertGreater(
                     cnt, 0, "each member in lag1 should receive pkt")
             self.lag_configer.remove_lag_member_by_port_idx(
-                lag_obj=self.dut.lag1, port_idx=21)
+                lag_obj=self.servers[11][1].l3_lag_obj, port_idx=21)
         finally:
             pass
 
@@ -770,7 +770,7 @@ class IndifferenceIngressPortTest(T0TestBase):
                                     ip_src=self.servers[1][1].ipv4,
                                     ip_id=105,
                                     ip_ttl=64)
-            exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+            exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                         eth_src=ROUTER_MAC,
                                         ip_dst=self.servers[11][1].ipv4,
                                         ip_src=self.servers[1][1].ipv4,
@@ -778,7 +778,7 @@ class IndifferenceIngressPortTest(T0TestBase):
                                         ip_ttl=63)
 
             exp_port_idx = -1
-            exp_port_list = self.dut.lag1.member_port_indexs
+            exp_port_list = self.servers[11][1].l3_lag_obj.member_port_indexs
             for i in range(1, 9):
                 send_packet(self, i, pkt)
                 if exp_port_idx == -1:

--- a/test/sai_test/sai_lag_test.py
+++ b/test/sai_test/sai_lag_test.py
@@ -32,10 +32,6 @@ class LagConfigTest(T0TestBase):
         Test the basic setup process.
         """
         T0TestBase.setUp(self)
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_obj_list[1].oid)
 
     def load_balance_on_src_ip(self):
         
@@ -52,13 +48,13 @@ class LagConfigTest(T0TestBase):
                                  ip_src=self.servers[2][1].ipv4,
                                  ip_id=105,
                                  ip_ttl=64)
-        exp_pkt1 = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+        exp_pkt1 = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                      eth_src=ROUTER_MAC,
                                      ip_dst=ip_dst,
                                      ip_src=self.servers[1][1].ipv4,
                                      ip_id=105,
                                      ip_ttl=63)
-        exp_pkt2 = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+        exp_pkt2 = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                      eth_src=ROUTER_MAC,
                                      ip_dst=ip_dst,
                                      ip_src=self.servers[2][1].ipv4,
@@ -78,8 +74,6 @@ class LagConfigTest(T0TestBase):
             pass
 
     def tearDown(self):
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -93,10 +87,6 @@ class LoadbalanceOnSrcPortTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.port_obj_list[1].oid)
 
     def runTest(self):
         """
@@ -119,7 +109,7 @@ class LoadbalanceOnSrcPortTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -139,8 +129,6 @@ class LoadbalanceOnSrcPortTest(T0TestBase):
             pass
 
     def tearDown(self):
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -154,10 +142,6 @@ class LoadbalanceOnDesPortTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.port_obj_list[1].oid)
 
     def runTest(self):
         """
@@ -180,7 +164,7 @@ class LoadbalanceOnDesPortTest(T0TestBase):
                                         tcp_dport=des_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -201,8 +185,6 @@ class LoadbalanceOnDesPortTest(T0TestBase):
             pass
 
     def tearDown(self):
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -216,10 +198,6 @@ class LoadbalanceOnSrcIPTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.port_obj_list[1].oid)
 
     def runTest(self):
         """
@@ -239,7 +217,7 @@ class LoadbalanceOnSrcIPTest(T0TestBase):
                                         ip_src=self.servers[1][i].ipv4,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][i].ipv4,
@@ -260,8 +238,6 @@ class LoadbalanceOnSrcIPTest(T0TestBase):
             pass
 
     def tearDown(self):
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -275,10 +251,6 @@ class LoadbalanceOnDesIPTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.port_obj_list[1].oid)
 
     def runTest(self):
         """
@@ -298,7 +270,7 @@ class LoadbalanceOnDesIPTest(T0TestBase):
                                         ip_src=self.servers[1][1].ipv4,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][i].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -319,8 +291,6 @@ class LoadbalanceOnDesIPTest(T0TestBase):
             pass
 
     def tearDown(self):
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -339,10 +309,6 @@ class LoadbalanceOnProtocolTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.port_obj_list[1].oid)
 
     def runTest(self):
         """
@@ -363,7 +329,7 @@ class LoadbalanceOnProtocolTest(T0TestBase):
                                             ip_src=self.servers[1][1].ipv4,
                                             ip_id=105,
                                             ip_ttl=64)
-                    exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+                    exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                                 eth_src=ROUTER_MAC,
                                                 ip_dst=self.servers[11][1].ipv4,
                                                 ip_src=self.servers[1][1].ipv4,
@@ -377,7 +343,7 @@ class LoadbalanceOnProtocolTest(T0TestBase):
                                              ip_src=self.servers[1][1].ipv4,
                                              ip_id=105,
                                              ip_ttl=64)
-                    exp_pkt = simple_icmp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+                    exp_pkt = simple_icmp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                                  eth_src=ROUTER_MAC,
                                                  ip_dst=self.servers[11][1].ipv4,
                                                  ip_src=self.servers[1][1].ipv4,
@@ -398,8 +364,6 @@ class LoadbalanceOnProtocolTest(T0TestBase):
             pass
 
     def tearDown(self):
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -413,10 +377,6 @@ class DisableEgressTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.port_obj_list[1].oid)
 
     def runTest(self):
         """
@@ -443,7 +403,7 @@ class DisableEgressTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -472,7 +432,7 @@ class DisableEgressTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -487,8 +447,6 @@ class DisableEgressTest(T0TestBase):
             pass
 
     def tearDown(self):
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -506,10 +464,6 @@ class DisableIngressTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.servers[11][1].l3_lag_obj.oid)
 
     def runTest(self):
         """
@@ -529,7 +483,7 @@ class DisableIngressTest(T0TestBase):
             for i in range(0, pkts_num):
                 src_port = begin_port + i
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                        eth_src=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+                                        eth_src=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                         ip_dst=self.servers[1][1].ipv4,
                                         ip_src=self.servers[11][1].ipv4,
                                         tcp_sport=src_port,
@@ -553,7 +507,7 @@ class DisableIngressTest(T0TestBase):
             for i in range(0, pkts_num):
                 src_port = begin_port + i
                 pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                        eth_src=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+                                        eth_src=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                         ip_dst=self.servers[1][1].ipv4,
                                         ip_src=self.servers[11][1].ipv4,
                                         tcp_sport=src_port,
@@ -572,8 +526,6 @@ class DisableIngressTest(T0TestBase):
             pass
 
     def tearDown(self):
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -587,10 +539,6 @@ class RemoveLagMemberTest(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self)
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.port_obj_list[1].oid)
 
     def runTest(self):
         """
@@ -617,7 +565,7 @@ class RemoveLagMemberTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -640,7 +588,7 @@ class RemoveLagMemberTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -655,8 +603,6 @@ class RemoveLagMemberTest(T0TestBase):
             pass
 
     def tearDown(self):
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -670,10 +616,6 @@ class AddLagMemberTest(T0TestBase):
         set up configurations
         """
         T0TestBase.setUp(self)
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                                virtual_router_id=self.dut.default_vrf,
-                                                                type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                                port_id=self.dut.port_obj_list[1].oid)
 
     def runTest(self):
         """
@@ -700,7 +642,7 @@ class AddLagMemberTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -722,7 +664,7 @@ class AddLagMemberTest(T0TestBase):
                                         tcp_sport=src_port,
                                         ip_id=105,
                                         ip_ttl=64)
-                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+                exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                             eth_src=ROUTER_MAC,
                                             ip_dst=self.servers[11][1].ipv4,
                                             ip_src=self.servers[1][1].ipv4,
@@ -742,8 +684,6 @@ class AddLagMemberTest(T0TestBase):
             pass
 
     def tearDown(self):
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -770,7 +710,7 @@ class IndifferenceIngressPortTest(T0TestBase):
                                     ip_src=self.servers[1][1].ipv4,
                                     ip_id=105,
                                     ip_ttl=64)
-            exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+            exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                         eth_src=ROUTER_MAC,
                                         ip_dst=self.servers[11][1].ipv4,
                                         ip_src=self.servers[1][1].ipv4,

--- a/test/sai_test/sai_neighbor_test.py
+++ b/test/sai_test/sai_neighbor_test.py
@@ -4,42 +4,29 @@ from sai_utils import *
 
 class NoHostRouteTest(T0TestBase):
     """
-    Verifies if IPv4 host route is not created according to
-    SAI_NEIGHBOR_ENTRY_ATTR_NO_HOST_ROUTE attribute value
+    Verify if no_host is false, neighbor can be used directly for forwarding.
     """
 
     def setUp(self):
         """
-        Test the basic setup process.
+        Set up test.
         """
         T0TestBase.setUp(self)
-
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_obj_list[1].oid)
-        self.dev_port1 = self.dut.port_obj_list[1].dev_port_index
-        self.ipv4_addr = "10.1.1.10"
-        self.mac_addr = "00:10:10:10:10:10"
-        self.nbr_entry_v4 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag_list[0].rif_list[0],
-            ip_address=sai_ipaddress(self.ipv4_addr))
-        status = sai_thrift_create_neighbor_entry(
-            self.client,
-            self.nbr_entry_v4,
-            dst_mac_address=self.mac_addr,
-            no_host_route=True)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
-    def noHostRouteNeighborTest(self):
+    def runTest(self):
         '''
-        Add a neighbor for IP 10.1.1.10 on the LAG1 Route interface and a new MACX
-        Send packet on port1 with DMAC: SWITCH_MAC DIP:10.1.1.10
-        verify packet received on one of LAG1 member
+        1. Use existing LAG1 ``host`` (no_host = false) neighbor 
+        2. Check vlan interface(svi added)
+        3. Send packet on port5 with ``DMAC: SWITCH_MAC`` and using LAG1 neighbor IP as dest IP
+        4. verify packet received on one of LAG1 member
         '''
-        print("\nnoHostRouteNeighborTest()")
+        print("\nHostNeighborTest")
 
         print("Sending IPv4 packet when host route not exists")
+        self.ipv4_addr = self.t1_list[1][100].ipv4
+        self.mac_addr =  self.t1_list[1][100].mac
+        self.dev_port1 = self.dut.port_obj_list[5].dev_port_index
 
         pkt = simple_udp_packet(eth_dst=ROUTER_MAC,
                                 ip_dst=self.ipv4_addr,
@@ -49,16 +36,10 @@ class NoHostRouteTest(T0TestBase):
         verify_no_other_packets(self)
         print("Packet dropped")
 
-    def runTest(self):
-        try:
-            self.noHostRouteNeighborTest()
-        finally:
-            pass
-
     def tearDown(self):
-        sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v4)
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        """
+        TearDown process
+        """
         super().tearDown()
 
 
@@ -70,14 +51,10 @@ class NoHostRouteTestV6(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process.
+        Set up test.
         """
         T0TestBase.setUp(self)
 
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_obj_list[1].oid)
         self.dev_port1 = self.dut.port_obj_list[1].dev_port_index
         self.ipv6_addr = "2001:0db8::1:10"
         self.mac_addr = "00:10:10:10:10:10"
@@ -116,9 +93,10 @@ class NoHostRouteTestV6(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v6)
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -130,14 +108,10 @@ class AddHostRouteTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process.
+        Set up test.
         """
         T0TestBase.setUp(self)
 
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_obj_list[1].oid)
         self.dev_port1 = self.dut.port_obj_list[1].dev_port_index
         self.ipv4_addr = "10.1.1.10"
         self.mac_addr = "00:10:10:10:10:10"
@@ -158,6 +132,8 @@ class AddHostRouteTest(T0TestBase):
         Verify no packet was received on any port
         '''
         print("\naddHostRouteIpv4NeighborTest()")
+        self.ipv4_addr = self.t1_list[1][100].ipv4
+        self.mac_addr =  self.t1_list[1][100].mac
 
         pkt = simple_udp_packet(eth_dst=ROUTER_MAC,
                                 ip_dst=self.ipv4_addr,
@@ -180,9 +156,10 @@ class AddHostRouteTest(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v4)
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -194,14 +171,10 @@ class AddHostRouteTestV6(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process.
+        Set up test.
         """
         T0TestBase.setUp(self)
 
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_obj_list[1].oid)
         self.dev_port1 = self.dut.port_obj_list[1].dev_port_index
         self.ipv6_addr = "2001:0db8::1:10"
         self.mac_addr = "00:10:10:10:10:10"
@@ -245,9 +218,10 @@ class AddHostRouteTestV6(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v6)
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -259,14 +233,10 @@ class RemoveAddNeighborTestIPV4(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process.
+        Set up test.
         """
         T0TestBase.setUp(self)
 
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_obj_list[1].oid)
         self.dev_port1 = self.dut.port_obj_list[1].dev_port_index
         self.ipv4_addr = "10.1.1.10"
         self.mac_addr = "00:10:10:10:10:10"
@@ -344,10 +314,11 @@ class RemoveAddNeighborTestIPV4(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_remove_route_entry(self.client, self.net_route)
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v4)
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -358,14 +329,10 @@ class RemoveAddNeighborTestIPV6(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process.
+        Set up test.
         """
         T0TestBase.setUp(self)
 
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_obj_list[1].oid)
         self.dev_port1 = self.dut.port_obj_list[1].dev_port_index
         self.ipv6_addr = "2001:0db8::1:10"
         self.mac_addr = "00:10:10:10:10:10"
@@ -443,10 +410,11 @@ class RemoveAddNeighborTestIPV6(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_remove_route_entry(self.client, self.net_route)
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v6)
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -457,7 +425,7 @@ class NhopDiffPrefixRemoveLonger(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process.
+        Set up test.
         """
         T0TestBase.setUp(self)
 
@@ -503,6 +471,9 @@ class NhopDiffPrefixRemoveLonger(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v4)
         super().tearDown()
 
@@ -514,7 +485,7 @@ class NhopDiffPrefixRemoveLongerV6(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process.
+        Set up test.
         """
         T0TestBase.setUp(self)
 
@@ -559,6 +530,9 @@ class NhopDiffPrefixRemoveLongerV6(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_128)
         super().tearDown()
 
@@ -570,7 +544,7 @@ class NhopDiffPrefixRemoveShorter(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process.
+        Set up test.
         """
         T0TestBase.setUp(self)
 
@@ -617,6 +591,9 @@ class NhopDiffPrefixRemoveShorter(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry)
         super().tearDown()
 
@@ -628,7 +605,7 @@ class NhopDiffPrefixRemoveShorterV6(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process.
+        Set up test.
         """
         T0TestBase.setUp(self)
 
@@ -674,5 +651,8 @@ class NhopDiffPrefixRemoveShorterV6(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_128)
         super().tearDown()

--- a/test/sai_test/sai_neighbor_test.py
+++ b/test/sai_test/sai_neighbor_test.py
@@ -17,12 +17,12 @@ class NoHostRouteTest(T0TestBase):
         self.port1_rif = sai_thrift_create_router_interface(self.client,
                                                             virtual_router_id=self.dut.default_vrf,
                                                             type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_list[1])
-        self.dev_port1 = self.dut.dev_port_list[1]
+                                                            port_id=self.dut.port_obj_list[1].oid)
+        self.dev_port1 = self.dut.port_obj_list[1].dev_port_index
         self.ipv4_addr = "10.1.1.10"
         self.mac_addr = "00:10:10:10:10:10"
         self.nbr_entry_v4 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif,
+            rif_id=self.dut.lag1.rif_list[0],
             ip_address=sai_ipaddress(self.ipv4_addr))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -77,12 +77,12 @@ class NoHostRouteTestV6(T0TestBase):
         self.port1_rif = sai_thrift_create_router_interface(self.client,
                                                             virtual_router_id=self.dut.default_vrf,
                                                             type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_list[1])
-        self.dev_port1 = self.dut.dev_port_list[1]
+                                                            port_id=self.dut.port_obj_list[1].oid)
+        self.dev_port1 = self.dut.port_obj_list[1].dev_port_index
         self.ipv6_addr = "2001:0db8::1:10"
         self.mac_addr = "00:10:10:10:10:10"
         self.nbr_entry_v6 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif,
+            rif_id=self.dut.lag1.rif_list[0],
             ip_address=sai_ipaddress(self.ipv6_addr))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -137,12 +137,12 @@ class AddHostRouteTest(T0TestBase):
         self.port1_rif = sai_thrift_create_router_interface(self.client,
                                                             virtual_router_id=self.dut.default_vrf,
                                                             type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_list[1])
-        self.dev_port1 = self.dut.dev_port_list[1]
+                                                            port_id=self.dut.port_obj_list[1].oid)
+        self.dev_port1 = self.dut.port_obj_list[1].dev_port_index
         self.ipv4_addr = "10.1.1.10"
         self.mac_addr = "00:10:10:10:10:10"
         self.nbr_entry_v4 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif,
+            rif_id=self.dut.lag1.rif_list[0],
             ip_address=sai_ipaddress(self.ipv4_addr))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -201,12 +201,12 @@ class AddHostRouteTestV6(T0TestBase):
         self.port1_rif = sai_thrift_create_router_interface(self.client,
                                                             virtual_router_id=self.dut.default_vrf,
                                                             type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_list[1])
-        self.dev_port1 = self.dut.dev_port_list[1]
+                                                            port_id=self.dut.port_obj_list[1].oid)
+        self.dev_port1 = self.dut.port_obj_list[1].dev_port_index
         self.ipv6_addr = "2001:0db8::1:10"
         self.mac_addr = "00:10:10:10:10:10"
         self.nbr_entry_v6 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif,
+            rif_id=self.dut.lag1.rif_list[0],
             ip_address=sai_ipaddress(self.ipv6_addr))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -266,13 +266,13 @@ class RemoveAddNeighborTestIPV4(T0TestBase):
         self.port1_rif = sai_thrift_create_router_interface(self.client,
                                                             virtual_router_id=self.dut.default_vrf,
                                                             type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_list[1])
-        self.dev_port1 = self.dut.dev_port_list[1]
+                                                            port_id=self.dut.port_obj_list[1].oid)
+        self.dev_port1 = self.dut.port_obj_list[1].dev_port_index
         self.ipv4_addr = "10.1.1.10"
         self.mac_addr = "00:10:10:10:10:10"
 
         self.nbr_entry_v4 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif,
+            rif_id=self.dut.lag1.rif_list[0],
             ip_address=sai_ipaddress(self.ipv4_addr))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -283,7 +283,7 @@ class RemoveAddNeighborTestIPV4(T0TestBase):
         self.net_route = sai_thrift_route_entry_t(
             vr_id=self.dut.default_vrf, destination=sai_ipprefix(self.ipv4_addr+'/32'))
         sai_thrift_create_route_entry(
-            self.client, self.net_route, next_hop_id=self.dut.lag1.rif)
+            self.client, self.net_route, next_hop_id=self.dut.lag1.rif_list[0])
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
     def RemoveAddNeighborTestV4(self):
@@ -365,13 +365,13 @@ class RemoveAddNeighborTestIPV6(T0TestBase):
         self.port1_rif = sai_thrift_create_router_interface(self.client,
                                                             virtual_router_id=self.dut.default_vrf,
                                                             type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_list[1])
-        self.dev_port1 = self.dut.dev_port_list[1]
+                                                            port_id=self.dut.port_obj_list[1].oid)
+        self.dev_port1 = self.dut.port_obj_list[1].dev_port_index
         self.ipv6_addr = "2001:0db8::1:10"
         self.mac_addr = "00:10:10:10:10:10"
 
         self.nbr_entry_v6 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif,
+            rif_id=self.dut.lag1.rif_list[0],
             ip_address=sai_ipaddress(self.ipv6_addr))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -382,7 +382,7 @@ class RemoveAddNeighborTestIPV6(T0TestBase):
         self.net_route = sai_thrift_route_entry_t(
             vr_id=self.dut.default_vrf, destination=sai_ipprefix(self.ipv6_addr+'/128'))
         sai_thrift_create_route_entry(
-            self.client, self.net_route, next_hop_id=self.dut.lag1.rif)
+            self.client, self.net_route, next_hop_id=self.dut.lag1.rif_list[0])
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
     def RemoveAddNeighborTestV6(self):
@@ -473,7 +473,7 @@ class NhopDiffPrefixRemoveLonger(T0TestBase):
         Delete new created nhop with ipprefix length 16
         '''
         self.nbr_entry_v4 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif,
+            rif_id=self.dut.lag1.rif_list[0],
             ip_address=sai_ipaddress(self.ipv4_addr))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -483,11 +483,11 @@ class NhopDiffPrefixRemoveLonger(T0TestBase):
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
         self.subnet_nhop_16 = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
-            self.ipv4_addr + '/16'), router_interface_id=self.dut.lag1.rif, type=SAI_NEXT_HOP_TYPE_IP)
+            self.ipv4_addr + '/16'), router_interface_id=self.dut.lag1.rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         self.subnet_nhop_24 = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
-            self.ipv4_addr + '/24'), router_interface_id=self.dut.lag1.rif, type=SAI_NEXT_HOP_TYPE_IP)
+            self.ipv4_addr + '/24'), router_interface_id=self.dut.lag1.rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         sai_thrift_remove_next_hop(self.client, self.subnet_nhop_24)
@@ -530,7 +530,7 @@ class NhopDiffPrefixRemoveLongerV6(T0TestBase):
         Delete new created nhop with ipprefix length 64
         '''
         self.nbr_entry_128 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif,
+            rif_id=self.dut.lag1.rif_list[0],
             ip_address=sai_ipprefix(self.ipv6_addr + '/128'))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -539,11 +539,11 @@ class NhopDiffPrefixRemoveLongerV6(T0TestBase):
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
         self.subnet_nhop_64 = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
-            self.ipv6_addr + '/64'), router_interface_id=self.dut.lag1.rif, type=SAI_NEXT_HOP_TYPE_IP)
+            self.ipv6_addr + '/64'), router_interface_id=self.dut.lag1.rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         self.subnet_nhop_128 = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
-            self.ipv6_addr + '/128'), router_interface_id=self.dut.lag1.rif, type=SAI_NEXT_HOP_TYPE_IP)
+            self.ipv6_addr + '/128'), router_interface_id=self.dut.lag1.rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         sai_thrift_remove_next_hop(self.client, self.subnet_nhop_128)
@@ -587,7 +587,7 @@ class NhopDiffPrefixRemoveShorter(T0TestBase):
         '''
 
         self.nbr_entry = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif,
+            rif_id=self.dut.lag1.rif_list[0],
             ip_address=sai_ipaddress(self.ipv4_addr))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -597,11 +597,11 @@ class NhopDiffPrefixRemoveShorter(T0TestBase):
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
         self.subnet_nhop_24 = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
-            self.ipv4_addr + '/24'), router_interface_id=self.dut.lag1.rif, type=SAI_NEXT_HOP_TYPE_IP)
+            self.ipv4_addr + '/24'), router_interface_id=self.dut.lag1.rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         self.subnet_nhop_16 = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
-            self.ipv4_addr + '/16'), router_interface_id=self.dut.lag1.rif, type=SAI_NEXT_HOP_TYPE_IP)
+            self.ipv4_addr + '/16'), router_interface_id=self.dut.lag1.rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         sai_thrift_remove_next_hop(self.client, self.subnet_nhop_16)
@@ -645,7 +645,7 @@ class NhopDiffPrefixRemoveShorterV6(T0TestBase):
         '''
 
         self.nbr_entry_128 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif,
+            rif_id=self.dut.lag1.rif_list[0],
             ip_address=sai_ipprefix(self.ipv6_addr + '/128'))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -654,11 +654,11 @@ class NhopDiffPrefixRemoveShorterV6(T0TestBase):
             no_host_route=True)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
         self.subnet_nhop_128 = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
-            self.ipv6_addr + '/128'), router_interface_id=self.dut.lag1.rif, type=SAI_NEXT_HOP_TYPE_IP)
+            self.ipv6_addr + '/128'), router_interface_id=self.dut.lag1.rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         self.subnet_nhop_64 = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
-            self.ipv6_addr + '/64'), router_interface_id=self.dut.lag1.rif, type=SAI_NEXT_HOP_TYPE_IP)
+            self.ipv6_addr + '/64'), router_interface_id=self.dut.lag1.rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         sai_thrift_remove_next_hop(self.client, self.subnet_nhop_64)

--- a/test/sai_test/sai_neighbor_test.py
+++ b/test/sai_test/sai_neighbor_test.py
@@ -24,15 +24,14 @@ class NoHostRouteTest(T0TestBase):
         print("\nHostNeighborTest")
 
         print("Sending IPv4 packet when host route not exists")
-        self.ipv4_addr = self.t1_list[1][100].ipv4
-        self.mac_addr =  self.t1_list[1][100].mac
-        self.dev_port1 = self.dut.port_obj_list[5].dev_port_index
+        self.dest_dev = self.t1_list[1][100]
+        self.send_port = self.dut.port_obj_list[5].dev_port_index
 
         pkt = simple_udp_packet(eth_dst=ROUTER_MAC,
-                                ip_dst=self.ipv4_addr,
+                                ip_dst=self.dest_dev.ipv4,
                                 ip_ttl=64)
 
-        send_packet(self, self.dev_port1, pkt)
+        send_packet(self, self.send_port, pkt)
         verify_no_other_packets(self)
         print("Packet dropped")
 

--- a/test/sai_test/sai_neighbor_test.py
+++ b/test/sai_test/sai_neighbor_test.py
@@ -22,7 +22,7 @@ class NoHostRouteTest(T0TestBase):
         self.ipv4_addr = "10.1.1.10"
         self.mac_addr = "00:10:10:10:10:10"
         self.nbr_entry_v4 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif_list[0],
+            rif_id=self.dut.lag_list[0].rif_list[0],
             ip_address=sai_ipaddress(self.ipv4_addr))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -82,7 +82,7 @@ class NoHostRouteTestV6(T0TestBase):
         self.ipv6_addr = "2001:0db8::1:10"
         self.mac_addr = "00:10:10:10:10:10"
         self.nbr_entry_v6 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif_list[0],
+            rif_id=self.dut.lag_list[0].rif_list[0],
             ip_address=sai_ipaddress(self.ipv6_addr))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -142,7 +142,7 @@ class AddHostRouteTest(T0TestBase):
         self.ipv4_addr = "10.1.1.10"
         self.mac_addr = "00:10:10:10:10:10"
         self.nbr_entry_v4 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif_list[0],
+            rif_id=self.dut.lag_list[0].rif_list[0],
             ip_address=sai_ipaddress(self.ipv4_addr))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -170,7 +170,7 @@ class AddHostRouteTest(T0TestBase):
 
         print("Sending IPv4 packet when host route exists")
         send_packet(self, self.dev_port1, pkt)
-        verify_packet_any_port(self, exp_pkt, self.dut.lag1.member_port_indexs)
+        verify_packet_any_port(self, exp_pkt, self.dut.lag_list[0].member_port_indexs)
         print("Packet forwarded")
 
     def runTest(self):
@@ -206,7 +206,7 @@ class AddHostRouteTestV6(T0TestBase):
         self.ipv6_addr = "2001:0db8::1:10"
         self.mac_addr = "00:10:10:10:10:10"
         self.nbr_entry_v6 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif_list[0],
+            rif_id=self.dut.lag_list[0].rif_list[0],
             ip_address=sai_ipaddress(self.ipv6_addr))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -235,7 +235,7 @@ class AddHostRouteTestV6(T0TestBase):
         print("Sending IPv4 packet when host route exists")
         send_packet(self, self.dev_port1, pkt_v6)
         verify_packet_any_port(
-            self, exp_pkt_v6, self.dut.lag1.member_port_indexs)
+            self, exp_pkt_v6, self.dut.lag_list[0].member_port_indexs)
         print("Packet forwarded")
 
     def runTest(self):
@@ -272,7 +272,7 @@ class RemoveAddNeighborTestIPV4(T0TestBase):
         self.mac_addr = "00:10:10:10:10:10"
 
         self.nbr_entry_v4 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif_list[0],
+            rif_id=self.dut.lag_list[0].rif_list[0],
             ip_address=sai_ipaddress(self.ipv4_addr))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -283,7 +283,7 @@ class RemoveAddNeighborTestIPV4(T0TestBase):
         self.net_route = sai_thrift_route_entry_t(
             vr_id=self.dut.default_vrf, destination=sai_ipprefix(self.ipv4_addr+'/32'))
         sai_thrift_create_route_entry(
-            self.client, self.net_route, next_hop_id=self.dut.lag1.rif_list[0])
+            self.client, self.net_route, next_hop_id=self.dut.lag_list[0].rif_list[0])
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
     def RemoveAddNeighborTestV4(self):
@@ -315,7 +315,7 @@ class RemoveAddNeighborTestIPV4(T0TestBase):
                                     ip_ttl=63)
 
         send_packet(self, self.dev_port1, pkt)
-        verify_packet_any_port(self, exp_pkt, self.dut.lag1.member_port_indexs)
+        verify_packet_any_port(self, exp_pkt, self.dut.lag_list[0].member_port_indexs)
 
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v4)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
@@ -335,7 +335,7 @@ class RemoveAddNeighborTestIPV4(T0TestBase):
             dst_mac_address=self.mac_addr)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         send_packet(self, self.dev_port1, pkt)
-        verify_packet_any_port(self, exp_pkt, self.dut.lag1.member_port_indexs)
+        verify_packet_any_port(self, exp_pkt, self.dut.lag_list[0].member_port_indexs)
 
     def runTest(self):
         try:
@@ -371,7 +371,7 @@ class RemoveAddNeighborTestIPV6(T0TestBase):
         self.mac_addr = "00:10:10:10:10:10"
 
         self.nbr_entry_v6 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif_list[0],
+            rif_id=self.dut.lag_list[0].rif_list[0],
             ip_address=sai_ipaddress(self.ipv6_addr))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -382,7 +382,7 @@ class RemoveAddNeighborTestIPV6(T0TestBase):
         self.net_route = sai_thrift_route_entry_t(
             vr_id=self.dut.default_vrf, destination=sai_ipprefix(self.ipv6_addr+'/128'))
         sai_thrift_create_route_entry(
-            self.client, self.net_route, next_hop_id=self.dut.lag1.rif_list[0])
+            self.client, self.net_route, next_hop_id=self.dut.lag_list[0].rif_list[0])
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
     def RemoveAddNeighborTestV6(self):
@@ -413,7 +413,7 @@ class RemoveAddNeighborTestIPV6(T0TestBase):
                                      ipv6_hlim=64)
         send_packet(self, self.dev_port1, pkt_v6)
         verify_packet_any_port(
-            self, exp_pkt_v6, self.dut.lag1.member_port_indexs)
+            self, exp_pkt_v6, self.dut.lag_list[0].member_port_indexs)
 
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v6)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
@@ -434,7 +434,7 @@ class RemoveAddNeighborTestIPV6(T0TestBase):
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         send_packet(self, self.dev_port1, pkt_v6)
         verify_packet_any_port(
-            self, exp_pkt_v6, self.dut.lag1.member_port_indexs)
+            self, exp_pkt_v6, self.dut.lag_list[0].member_port_indexs)
 
     def runTest(self):
         try:
@@ -473,7 +473,7 @@ class NhopDiffPrefixRemoveLonger(T0TestBase):
         Delete new created nhop with ipprefix length 16
         '''
         self.nbr_entry_v4 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif_list[0],
+            rif_id=self.dut.lag_list[0].rif_list[0],
             ip_address=sai_ipaddress(self.ipv4_addr))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -483,11 +483,11 @@ class NhopDiffPrefixRemoveLonger(T0TestBase):
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
         self.subnet_nhop_16 = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
-            self.ipv4_addr + '/16'), router_interface_id=self.dut.lag1.rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
+            self.ipv4_addr + '/16'), router_interface_id=self.dut.lag_list[0].rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         self.subnet_nhop_24 = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
-            self.ipv4_addr + '/24'), router_interface_id=self.dut.lag1.rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
+            self.ipv4_addr + '/24'), router_interface_id=self.dut.lag_list[0].rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         sai_thrift_remove_next_hop(self.client, self.subnet_nhop_24)
@@ -530,7 +530,7 @@ class NhopDiffPrefixRemoveLongerV6(T0TestBase):
         Delete new created nhop with ipprefix length 64
         '''
         self.nbr_entry_128 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif_list[0],
+            rif_id=self.dut.lag_list[0].rif_list[0],
             ip_address=sai_ipprefix(self.ipv6_addr + '/128'))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -539,11 +539,11 @@ class NhopDiffPrefixRemoveLongerV6(T0TestBase):
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
         self.subnet_nhop_64 = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
-            self.ipv6_addr + '/64'), router_interface_id=self.dut.lag1.rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
+            self.ipv6_addr + '/64'), router_interface_id=self.dut.lag_list[0].rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         self.subnet_nhop_128 = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
-            self.ipv6_addr + '/128'), router_interface_id=self.dut.lag1.rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
+            self.ipv6_addr + '/128'), router_interface_id=self.dut.lag_list[0].rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         sai_thrift_remove_next_hop(self.client, self.subnet_nhop_128)
@@ -587,7 +587,7 @@ class NhopDiffPrefixRemoveShorter(T0TestBase):
         '''
 
         self.nbr_entry = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif_list[0],
+            rif_id=self.dut.lag_list[0].rif_list[0],
             ip_address=sai_ipaddress(self.ipv4_addr))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -597,11 +597,11 @@ class NhopDiffPrefixRemoveShorter(T0TestBase):
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
         self.subnet_nhop_24 = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
-            self.ipv4_addr + '/24'), router_interface_id=self.dut.lag1.rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
+            self.ipv4_addr + '/24'), router_interface_id=self.dut.lag_list[0].rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         self.subnet_nhop_16 = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
-            self.ipv4_addr + '/16'), router_interface_id=self.dut.lag1.rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
+            self.ipv4_addr + '/16'), router_interface_id=self.dut.lag_list[0].rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         sai_thrift_remove_next_hop(self.client, self.subnet_nhop_16)
@@ -645,7 +645,7 @@ class NhopDiffPrefixRemoveShorterV6(T0TestBase):
         '''
 
         self.nbr_entry_128 = sai_thrift_neighbor_entry_t(
-            rif_id=self.dut.lag1.rif_list[0],
+            rif_id=self.dut.lag_list[0].rif_list[0],
             ip_address=sai_ipprefix(self.ipv6_addr + '/128'))
         status = sai_thrift_create_neighbor_entry(
             self.client,
@@ -654,11 +654,11 @@ class NhopDiffPrefixRemoveShorterV6(T0TestBase):
             no_host_route=True)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
         self.subnet_nhop_128 = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
-            self.ipv6_addr + '/128'), router_interface_id=self.dut.lag1.rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
+            self.ipv6_addr + '/128'), router_interface_id=self.dut.lag_list[0].rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         self.subnet_nhop_64 = sai_thrift_create_next_hop(self.client, ip=sai_ipprefix(
-            self.ipv6_addr + '/64'), router_interface_id=self.dut.lag1.rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
+            self.ipv6_addr + '/64'), router_interface_id=self.dut.lag_list[0].rif_list[0], type=SAI_NEXT_HOP_TYPE_IP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         sai_thrift_remove_next_hop(self.client, self.subnet_nhop_64)

--- a/test/sai_test/sai_rif_test.py
+++ b/test/sai_test/sai_rif_test.py
@@ -34,6 +34,10 @@ class IngressMacUpdateTest(T0TestBase):
         Test the basic setup process.
         """
         T0TestBase.setUp(self)
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_obj_list[1].oid)
 
     def test_ingress_mac_update(self):
         """
@@ -48,12 +52,6 @@ class IngressMacUpdateTest(T0TestBase):
 
         new_router_mac = "00:77:66:55:44:44"
         ip_dst = self.servers[11][1].ipv4
-
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_list[1])
-
         pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                 eth_src=self.servers[0][1].mac,
                                 ip_dst=ip_dst,
@@ -73,10 +71,10 @@ class IngressMacUpdateTest(T0TestBase):
 
         print("Updating src_mac_address to %s" % (new_router_mac))
         sai_thrift_set_router_interface_attribute(
-            self.client, self.dut.port_rif_list[0], src_mac_address=new_router_mac)
+            self.client, self.dut.port_obj_list[0].rif_list[-1], src_mac_address=new_router_mac)
         time.sleep(3)
         attrs = sai_thrift_get_router_interface_attribute(
-            self.client, self.dut.port_rif_list[0], src_mac_address=True)
+            self.client, self.dut.port_obj_list[0].rif_list[-1], src_mac_address=True)
         self.assertEqual(attrs["src_mac_address"], new_router_mac)
 
         send_packet(self, 1, pkt)
@@ -87,10 +85,10 @@ class IngressMacUpdateTest(T0TestBase):
 
     def tearDown(self):
         sai_thrift_set_router_interface_attribute(
-            self.client, self.dut.port_rif_list[0], src_mac_address=ROUTER_MAC)
+            self.client, self.dut.port_obj_list[0].rif_list[-1], src_mac_address=ROUTER_MAC)
         time.sleep(3)
         attrs = sai_thrift_get_router_interface_attribute(
-            self.client, self.dut.port_rif_list[0], src_mac_address=True)
+            self.client, self.dut.port_obj_list[0].rif_list[-1], src_mac_address=True)
         self.assertEqual(attrs["src_mac_address"], ROUTER_MAC)
         sai_thrift_remove_router_interface(self.client, self.port1_rif)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
@@ -107,6 +105,10 @@ class IngressMacUpdateTestV6(T0TestBase):
         Test the basic setup process.
         """
         T0TestBase.setUp(self)
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_obj_list[1].oid)
 
     def test_ingress_mac_update(self):
         """
@@ -121,12 +123,6 @@ class IngressMacUpdateTestV6(T0TestBase):
 
         new_router_mac = "00:10:10:10:10:10"
         ip_dst = self.servers[11][1].ipv6
-
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_list[1])
-
         pkt = simple_tcpv6_packet(eth_dst=ROUTER_MAC,
                                   eth_src=self.servers[0][1].mac,
                                   ipv6_dst=ip_dst,
@@ -144,10 +140,10 @@ class IngressMacUpdateTestV6(T0TestBase):
 
         print("Updating src_mac_address to %s" % (new_router_mac))
         sai_thrift_set_router_interface_attribute(
-            self.client, self.dut.port_rif_list[0], src_mac_address=new_router_mac)
+            self.client, self.dut.port_obj_list[0].rif_list[-1], src_mac_address=new_router_mac)
         time.sleep(3)
         attrs = sai_thrift_get_router_interface_attribute(
-            self.client, self.dut.port_rif_list[0], src_mac_address=True)
+            self.client, self.dut.port_obj_list[0].rif_list[-1], src_mac_address=True)
         self.assertEqual(attrs["src_mac_address"], new_router_mac)
 
         send_packet(self, 1, pkt)
@@ -158,10 +154,10 @@ class IngressMacUpdateTestV6(T0TestBase):
 
     def tearDown(self):
         sai_thrift_set_router_interface_attribute(
-            self.client, self.dut.port_rif_list[0], src_mac_address=ROUTER_MAC)
+            self.client, self.dut.port_obj_list[0].rif_list[-1], src_mac_address=ROUTER_MAC)
         time.sleep(3)
         attrs = sai_thrift_get_router_interface_attribute(
-            self.client, self.dut.port_rif_list[0], src_mac_address=True)
+            self.client, self.dut.port_obj_list[0].rif_list[-1], src_mac_address=True)
         self.assertEqual(attrs["src_mac_address"], ROUTER_MAC)
         sai_thrift_remove_router_interface(self.client, self.port1_rif)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
@@ -179,7 +175,11 @@ class IngressDisableTestV4(T0TestBase):
         """
 
         T0TestBase.setUp(self)
-        self.port1 = self.dut.port_list[1]
+        self.port1 = self.dut.port_obj_list[1]
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_obj_list[1].oid)
 
     def test_ingress_disable_ipv4(self):
         """
@@ -195,12 +195,6 @@ class IngressDisableTestV4(T0TestBase):
         print("\ntest_ingress_disable_ipv4()")
 
         ip_dst = self.servers[11][1].ipv4
-
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_list[1])
-
         pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                 eth_src=self.servers[0][1].mac,
                                 ip_dst=ip_dst,
@@ -220,14 +214,14 @@ class IngressDisableTestV4(T0TestBase):
 
         print("Disable IPv4 on ingress RIF")
         sai_thrift_set_router_interface_attribute(
-            self.client, self.dut.port_rif_list[0], admin_v4_state=False)
+            self.client, self.dut.port_obj_list[0].rif_list[-1], admin_v4_state=False)
         time.sleep(3)
         send_packet(self, 1, pkt)
         verify_no_other_packets(self, timeout=3)
 
         print("Enable IPv4 on ingress RIF")
         sai_thrift_set_router_interface_attribute(
-            self.client, self.dut.port_rif_list[0], admin_v4_state=True)
+            self.client, self.dut.port_obj_list[0].rif_list[-1], admin_v4_state=True)
         time.sleep(3)
         send_packet(self, 1, pkt)
         verify_packet_any_port(self, exp_pkt, self.dut.lag1.member_port_indexs)
@@ -252,7 +246,11 @@ class IngressDisableTestV6(T0TestBase):
         """
 
         T0TestBase.setUp(self)
-        self.port1 = self.dut.port_list[1]
+        self.port1 = self.dut.port_obj_list[1]
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_obj_list[1].oid)
 
     def test_ingress_disable_ipv6(self):
         """
@@ -268,11 +266,6 @@ class IngressDisableTestV6(T0TestBase):
         print("\ntest_ingress_disable_ipv6()")
 
         ip_dst = self.servers[11][1].ipv6
-
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_list[1])
 
         pkt = simple_tcpv6_packet(eth_dst=ROUTER_MAC,
                                   eth_src=self.servers[0][1].mac,
@@ -291,14 +284,14 @@ class IngressDisableTestV6(T0TestBase):
 
         print("Disable IPv4 on ingress RIF")
         sai_thrift_set_router_interface_attribute(
-            self.client, self.dut.port_rif_list[0], admin_v6_state=False)
+            self.client, self.dut.port_obj_list[0].rif_list[-1], admin_v6_state=False)
         time.sleep(3)
         send_packet(self, 1, pkt)
         verify_no_other_packets(self, timeout=3)
 
         print("Enable IPv4 on ingress RIF")
         sai_thrift_set_router_interface_attribute(
-            self.client, self.dut.port_rif_list[0], admin_v6_state=True)
+            self.client, self.dut.port_obj_list[0].rif_list[-1], admin_v6_state=True)
         time.sleep(3)
         send_packet(self, 1, pkt)
         verify_packet_any_port(self, exp_pkt, self.dut.lag1.member_port_indexs)
@@ -323,6 +316,17 @@ class IngressMtuTestV4(T0TestBase):
         """
 
         T0TestBase.setUp(self)
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_obj_list[1].oid)
+
+        # set MTU to 200 for port1
+        self.mtu_port10_rif = sai_thrift_get_router_interface_attribute(
+            self.client, self.dut.port_obj_list[0].rif_list[-1], mtu=True)
+
+        sai_thrift_set_router_interface_attribute(
+            self.client, self.dut.port_obj_list[0].rif_list[-1], mtu=200)
 
     def test_ingress_mtu(self):
         """
@@ -336,71 +340,56 @@ class IngressMtuTestV4(T0TestBase):
         Verify no packet was received on any LAG1 member
         """
         print("\ntest_ingress_mtu_v4()")
+        print("Max MTU is 200, send pkt size 200, send to port/lag")
+        ip_dst = self.servers[11][1].ipv4
 
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_list[1])
+        pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
+                                eth_src=self.servers[0][1].mac,
+                                ip_dst=ip_dst,
+                                ip_src=self.servers[0][1].ipv4,
+                                ip_id=105,
+                                ip_ttl=64,
+                                pktlen=200 + 14)
 
-        # set MTU to 200 for port1
-        mtu_port10_rif = sai_thrift_get_router_interface_attribute(
-            self.client, self.dut.port_rif_list[0], mtu=True)
-
-        sai_thrift_set_router_interface_attribute(
-            self.client, self.dut.port_rif_list[0], mtu=200)
-
-        try:
-            print("Max MTU is 200, send pkt size 200, send to port/lag")
-            ip_dst = self.servers[11][1].ipv4
-
-            pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                    eth_src=self.servers[0][1].mac,
+        exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+                                    eth_src=ROUTER_MAC,
                                     ip_dst=ip_dst,
                                     ip_src=self.servers[0][1].ipv4,
                                     ip_id=105,
-                                    ip_ttl=64,
+                                    ip_ttl=63,
                                     pktlen=200 + 14)
 
-            exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
-                                        eth_src=ROUTER_MAC,
-                                        ip_dst=ip_dst,
-                                        ip_src=self.servers[0][1].ipv4,
-                                        ip_id=105,
-                                        ip_ttl=63,
-                                        pktlen=200 + 14)
+        send_packet(self, 1, pkt)
+        verify_packet_any_port(
+            self, exp_pkt, self.dut.lag1.member_port_indexs)
 
-            send_packet(self, 1, pkt)
-            verify_packet_any_port(
-                self, exp_pkt, self.dut.lag1.member_port_indexs)
+        print("Max MTU is 200, send pkt size 201, dropped")
+        pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
+                                eth_src=self.servers[0][1].mac,
+                                ip_dst=ip_dst,
+                                ip_src=self.servers[0][1].ipv4,
+                                ip_id=105,
+                                ip_ttl=64,
+                                pktlen=201 + 14)
 
-            print("Max MTU is 200, send pkt size 201, dropped")
-            pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
-                                    eth_src=self.servers[0][1].mac,
+        exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+                                    eth_src=ROUTER_MAC,
                                     ip_dst=ip_dst,
                                     ip_src=self.servers[0][1].ipv4,
                                     ip_id=105,
-                                    ip_ttl=64,
+                                    ip_ttl=63,
                                     pktlen=201 + 14)
 
-            exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
-                                        eth_src=ROUTER_MAC,
-                                        ip_dst=ip_dst,
-                                        ip_src=self.servers[0][1].ipv4,
-                                        ip_id=105,
-                                        ip_ttl=63,
-                                        pktlen=201 + 14)
-
-            send_packet(self, 1, pkt)
-            verify_no_other_packets(self)
-
-        finally:
-            sai_thrift_set_router_interface_attribute(
-                self.client, self.dut.port_rif_list[0], mtu=mtu_port10_rif['mtu'])
+        send_packet(self, 1, pkt)
+        verify_no_other_packets(self)
+            
 
     def runTest(self):
         self.test_ingress_mtu()
 
     def tearDown(self):
+        sai_thrift_set_router_interface_attribute(
+                self.client, self.dut.port_obj_list[0].rif_list[-1], mtu=self.mtu_port10_rif['mtu'])
         sai_thrift_remove_router_interface(self.client, self.port1_rif)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
@@ -415,8 +404,18 @@ class IngressMtuTestV6(T0TestBase):
         """
         Test the basic setup process.
         """
-
         T0TestBase.setUp(self)
+        self.port1_rif = sai_thrift_create_router_interface(self.client,
+                                                            virtual_router_id=self.dut.default_vrf,
+                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
+                                                            port_id=self.dut.port_obj_list[1].oid)
+
+        # set MTU to 200 for port1
+        self.mtu_port10_rif = sai_thrift_get_router_interface_attribute(
+            self.client, self.dut.port_obj_list[0].rif_list[-1], mtu=True)
+
+        sai_thrift_set_router_interface_attribute(
+            self.client, self.dut.port_obj_list[0].rif_list[-1], mtu=200)
 
     def test_ingress_mtu_v6(self):
         """
@@ -430,18 +429,6 @@ class IngressMtuTestV6(T0TestBase):
         Verify no packet was received on any LAG1 member
         """
         print("\ntest_ingress_mtu_v6()")
-
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_list[1])
-
-        # set MTU to 200 for port1
-        mtu_port10_rif = sai_thrift_get_router_interface_attribute(
-            self.client, self.dut.port_rif_list[0], mtu=True)
-
-        sai_thrift_set_router_interface_attribute(
-            self.client, self.dut.port_rif_list[0], mtu=200)
 
         try:
             print("Max MTU is 200, send pkt size 200, send to port/lag")
@@ -484,13 +471,15 @@ class IngressMtuTestV6(T0TestBase):
             verify_no_other_packets(self)
 
         finally:
-            sai_thrift_set_router_interface_attribute(
-                self.client, self.dut.port_rif_list[0], mtu=mtu_port10_rif['mtu'])
+            pass
+            
 
     def runTest(self):
         self.test_ingress_mtu_v6()
 
     def tearDown(self):
+        sai_thrift_set_router_interface_attribute(
+                self.client, self.dut.port_obj_list[0].rif_list[-1], mtu=self.mtu_port10_rif['mtu'])
         sai_thrift_remove_router_interface(self.client, self.port1_rif)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()

--- a/test/sai_test/sai_rif_test.py
+++ b/test/sai_test/sai_rif_test.py
@@ -59,7 +59,7 @@ class IngressMacUpdateTest(T0TestBase):
                                 ip_id=105,
                                 ip_ttl=64)
 
-        exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+        exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                     eth_src=ROUTER_MAC,
                                     ip_dst=ip_dst,
                                     ip_src=self.servers[0][1].ipv4,
@@ -67,7 +67,7 @@ class IngressMacUpdateTest(T0TestBase):
                                     ip_ttl=63)
 
         send_packet(self, 1, pkt)
-        verify_packet_any_port(self, exp_pkt, self.dut.lag1.member_port_indexs)
+        verify_packet_any_port(self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
 
         print("Updating src_mac_address to %s" % (new_router_mac))
         sai_thrift_set_router_interface_attribute(
@@ -129,14 +129,14 @@ class IngressMacUpdateTestV6(T0TestBase):
                                   ipv6_src=self.servers[0][1].ipv6,
                                   ipv6_hlim=64)
 
-        exp_pkt = simple_tcpv6_packet(eth_dst=self.t1_list[1][100].mac,
+        exp_pkt = simple_tcpv6_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                       eth_src=ROUTER_MAC,
                                       ipv6_dst=ip_dst,
                                       ipv6_src=self.servers[0][1].ipv6,
                                       ipv6_hlim=63)
 
         send_packet(self, 1, pkt)
-        verify_packet_any_port(self, exp_pkt, self.dut.lag1.member_port_indexs)
+        verify_packet_any_port(self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
 
         print("Updating src_mac_address to %s" % (new_router_mac))
         sai_thrift_set_router_interface_attribute(
@@ -202,7 +202,7 @@ class IngressDisableTestV4(T0TestBase):
                                 ip_id=105,
                                 ip_ttl=64)
 
-        exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+        exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                     eth_src=ROUTER_MAC,
                                     ip_dst=ip_dst,
                                     ip_src=self.servers[0][1].ipv4,
@@ -210,7 +210,7 @@ class IngressDisableTestV4(T0TestBase):
                                     ip_ttl=63)
 
         send_packet(self, 1, pkt)
-        verify_packet_any_port(self, exp_pkt, self.dut.lag1.member_port_indexs)
+        verify_packet_any_port(self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
 
         print("Disable IPv4 on ingress RIF")
         sai_thrift_set_router_interface_attribute(
@@ -224,7 +224,7 @@ class IngressDisableTestV4(T0TestBase):
             self.client, self.dut.port_obj_list[0].rif_list[-1], admin_v4_state=True)
         time.sleep(3)
         send_packet(self, 1, pkt)
-        verify_packet_any_port(self, exp_pkt, self.dut.lag1.member_port_indexs)
+        verify_packet_any_port(self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
 
     def runTest(self):
         self.test_ingress_disable_ipv4()
@@ -273,14 +273,14 @@ class IngressDisableTestV6(T0TestBase):
                                   ipv6_src=self.servers[0][1].ipv6,
                                   ipv6_hlim=64)
 
-        exp_pkt = simple_tcpv6_packet(eth_dst=self.t1_list[1][100].mac,
+        exp_pkt = simple_tcpv6_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                       eth_src=ROUTER_MAC,
                                       ipv6_dst=ip_dst,
                                       ipv6_src=self.servers[0][1].ipv6,
                                       ipv6_hlim=63)
 
         send_packet(self, 1, pkt)
-        verify_packet_any_port(self, exp_pkt, self.dut.lag1.member_port_indexs)
+        verify_packet_any_port(self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
 
         print("Disable IPv4 on ingress RIF")
         sai_thrift_set_router_interface_attribute(
@@ -294,7 +294,7 @@ class IngressDisableTestV6(T0TestBase):
             self.client, self.dut.port_obj_list[0].rif_list[-1], admin_v6_state=True)
         time.sleep(3)
         send_packet(self, 1, pkt)
-        verify_packet_any_port(self, exp_pkt, self.dut.lag1.member_port_indexs)
+        verify_packet_any_port(self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
 
     def runTest(self):
         self.test_ingress_disable_ipv6()
@@ -351,7 +351,7 @@ class IngressMtuTestV4(T0TestBase):
                                 ip_ttl=64,
                                 pktlen=200 + 14)
 
-        exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+        exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                     eth_src=ROUTER_MAC,
                                     ip_dst=ip_dst,
                                     ip_src=self.servers[0][1].ipv4,
@@ -361,7 +361,7 @@ class IngressMtuTestV4(T0TestBase):
 
         send_packet(self, 1, pkt)
         verify_packet_any_port(
-            self, exp_pkt, self.dut.lag1.member_port_indexs)
+            self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
 
         print("Max MTU is 200, send pkt size 201, dropped")
         pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
@@ -372,7 +372,7 @@ class IngressMtuTestV4(T0TestBase):
                                 ip_ttl=64,
                                 pktlen=201 + 14)
 
-        exp_pkt = simple_tcp_packet(eth_dst=self.t1_list[1][100].mac,
+        exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                     eth_src=ROUTER_MAC,
                                     ip_dst=ip_dst,
                                     ip_src=self.servers[0][1].ipv4,
@@ -441,7 +441,7 @@ class IngressMtuTestV6(T0TestBase):
                                       ipv6_hlim=64,
                                       pktlen=200 + 14)
 
-            exp_pkt = simple_tcpv6_packet(eth_dst=self.t1_list[1][100].mac,
+            exp_pkt = simple_tcpv6_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                           eth_src=ROUTER_MAC,
                                           ipv6_dst=ip_dst,
                                           ipv6_src=self.servers[0][1].ipv6,
@@ -450,7 +450,7 @@ class IngressMtuTestV6(T0TestBase):
 
             send_packet(self, 1, pkt)
             verify_packet_any_port(
-                self, exp_pkt, self.dut.lag1.member_port_indexs)
+                self, exp_pkt, self.servers[11][1].l3_lag_obj.member_port_indexs)
 
             print("Max MTU is 200, send pkt size 201, dropped")
             pkt = simple_tcpv6_packet(eth_dst=ROUTER_MAC,
@@ -460,7 +460,7 @@ class IngressMtuTestV6(T0TestBase):
                                       ipv6_hlim=64,
                                       pktlen=201 + 14)
 
-            exp_pkt = simple_tcpv6_packet(eth_dst=self.t1_list[1][100].mac,
+            exp_pkt = simple_tcpv6_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
                                           eth_src=ROUTER_MAC,
                                           ipv6_dst=ip_dst,
                                           ipv6_src=self.servers[0][1].ipv6,

--- a/test/sai_test/sai_rif_test.py
+++ b/test/sai_test/sai_rif_test.py
@@ -31,13 +31,9 @@ class IngressMacUpdateTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process.
+        Set up test.
         """
         T0TestBase.setUp(self)
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_obj_list[1].oid)
 
     def test_ingress_mac_update(self):
         """
@@ -59,7 +55,7 @@ class IngressMacUpdateTest(T0TestBase):
                                 ip_id=105,
                                 ip_ttl=64)
 
-        exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+        exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                     eth_src=ROUTER_MAC,
                                     ip_dst=ip_dst,
                                     ip_src=self.servers[0][1].ipv4,
@@ -84,14 +80,15 @@ class IngressMacUpdateTest(T0TestBase):
         self.test_ingress_mac_update()
 
     def tearDown(self):
+        """
+        Test the basic tearDown process
+        """
         sai_thrift_set_router_interface_attribute(
             self.client, self.dut.port_obj_list[0].rif_list[-1], src_mac_address=ROUTER_MAC)
         time.sleep(3)
         attrs = sai_thrift_get_router_interface_attribute(
             self.client, self.dut.port_obj_list[0].rif_list[-1], src_mac_address=True)
         self.assertEqual(attrs["src_mac_address"], ROUTER_MAC)
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -102,13 +99,9 @@ class IngressMacUpdateTestV6(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process.
+        Set up test.
         """
         T0TestBase.setUp(self)
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_obj_list[1].oid)
 
     def test_ingress_mac_update(self):
         """
@@ -129,7 +122,7 @@ class IngressMacUpdateTestV6(T0TestBase):
                                   ipv6_src=self.servers[0][1].ipv6,
                                   ipv6_hlim=64)
 
-        exp_pkt = simple_tcpv6_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+        exp_pkt = simple_tcpv6_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                       eth_src=ROUTER_MAC,
                                       ipv6_dst=ip_dst,
                                       ipv6_src=self.servers[0][1].ipv6,
@@ -153,14 +146,15 @@ class IngressMacUpdateTestV6(T0TestBase):
         self.test_ingress_mac_update()
 
     def tearDown(self):
+        """
+        Test the basic tearDown process
+        """
         sai_thrift_set_router_interface_attribute(
             self.client, self.dut.port_obj_list[0].rif_list[-1], src_mac_address=ROUTER_MAC)
         time.sleep(3)
         attrs = sai_thrift_get_router_interface_attribute(
             self.client, self.dut.port_obj_list[0].rif_list[-1], src_mac_address=True)
         self.assertEqual(attrs["src_mac_address"], ROUTER_MAC)
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
 
@@ -171,15 +165,11 @@ class IngressDisableTestV4(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process.
+        Set up test.
         """
 
         T0TestBase.setUp(self)
         self.port1 = self.dut.port_obj_list[1]
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_obj_list[1].oid)
 
     def test_ingress_disable_ipv4(self):
         """
@@ -202,7 +192,7 @@ class IngressDisableTestV4(T0TestBase):
                                 ip_id=105,
                                 ip_ttl=64)
 
-        exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+        exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                     eth_src=ROUTER_MAC,
                                     ip_dst=ip_dst,
                                     ip_src=self.servers[0][1].ipv4,
@@ -230,8 +220,9 @@ class IngressDisableTestV4(T0TestBase):
         self.test_ingress_disable_ipv4()
 
     def tearDown(self):
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        """
+        Test the basic tearDown process
+        """
         super().tearDown()
 
 
@@ -242,15 +233,11 @@ class IngressDisableTestV6(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process.
+        Set up test.
         """
 
         T0TestBase.setUp(self)
         self.port1 = self.dut.port_obj_list[1]
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_obj_list[1].oid)
 
     def test_ingress_disable_ipv6(self):
         """
@@ -273,7 +260,7 @@ class IngressDisableTestV6(T0TestBase):
                                   ipv6_src=self.servers[0][1].ipv6,
                                   ipv6_hlim=64)
 
-        exp_pkt = simple_tcpv6_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+        exp_pkt = simple_tcpv6_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                       eth_src=ROUTER_MAC,
                                       ipv6_dst=ip_dst,
                                       ipv6_src=self.servers[0][1].ipv6,
@@ -300,8 +287,9 @@ class IngressDisableTestV6(T0TestBase):
         self.test_ingress_disable_ipv6()
 
     def tearDown(self):
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        """
+        Test the basic tearDown process
+        """
         super().tearDown()
 
 
@@ -312,21 +300,17 @@ class IngressMtuTestV4(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process.
+        Set up test.
         """
 
         T0TestBase.setUp(self)
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_obj_list[1].oid)
 
-        # set MTU to 200 for port1
-        self.mtu_port10_rif = sai_thrift_get_router_interface_attribute(
-            self.client, self.dut.port_obj_list[0].rif_list[-1], mtu=True)
+        # set MTU to 200 for vlan interface
+        self.mtu_Vlan10_rif = sai_thrift_get_router_interface_attribute(
+            self.client, self.dut.vlans[10].rif_list[0], mtu=True)
 
         sai_thrift_set_router_interface_attribute(
-            self.client, self.dut.port_obj_list[0].rif_list[-1], mtu=200)
+            self.client, self.dut.vlans[10].rif_list[0], mtu=200)
 
     def test_ingress_mtu(self):
         """
@@ -351,7 +335,7 @@ class IngressMtuTestV4(T0TestBase):
                                 ip_ttl=64,
                                 pktlen=200 + 14)
 
-        exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+        exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                     eth_src=ROUTER_MAC,
                                     ip_dst=ip_dst,
                                     ip_src=self.servers[0][1].ipv4,
@@ -372,7 +356,7 @@ class IngressMtuTestV4(T0TestBase):
                                 ip_ttl=64,
                                 pktlen=201 + 14)
 
-        exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+        exp_pkt = simple_tcp_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                     eth_src=ROUTER_MAC,
                                     ip_dst=ip_dst,
                                     ip_src=self.servers[0][1].ipv4,
@@ -388,9 +372,11 @@ class IngressMtuTestV4(T0TestBase):
         self.test_ingress_mtu()
 
     def tearDown(self):
+        """
+        Test the basic tearDown process
+        """
         sai_thrift_set_router_interface_attribute(
-                self.client, self.dut.port_obj_list[0].rif_list[-1], mtu=self.mtu_port10_rif['mtu'])
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
+                self.client, self.dut.vlans[10].rif_list[0], mtu=self.mtu_Vlan10_rif['mtu'])
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()
 
@@ -402,13 +388,9 @@ class IngressMtuTestV6(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process.
+        Set up test.
         """
         T0TestBase.setUp(self)
-        self.port1_rif = sai_thrift_create_router_interface(self.client,
-                                                            virtual_router_id=self.dut.default_vrf,
-                                                            type=SAI_ROUTER_INTERFACE_TYPE_PORT,
-                                                            port_id=self.dut.port_obj_list[1].oid)
 
         # set MTU to 200 for port1
         self.mtu_port10_rif = sai_thrift_get_router_interface_attribute(
@@ -441,7 +423,7 @@ class IngressMtuTestV6(T0TestBase):
                                       ipv6_hlim=64,
                                       pktlen=200 + 14)
 
-            exp_pkt = simple_tcpv6_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+            exp_pkt = simple_tcpv6_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                           eth_src=ROUTER_MAC,
                                           ipv6_dst=ip_dst,
                                           ipv6_src=self.servers[0][1].ipv6,
@@ -460,7 +442,7 @@ class IngressMtuTestV6(T0TestBase):
                                       ipv6_hlim=64,
                                       pktlen=201 + 14)
 
-            exp_pkt = simple_tcpv6_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac_list[0],
+            exp_pkt = simple_tcpv6_packet(eth_dst=self.servers[11][1].l3_lag_obj.neighbor_mac,
                                           eth_src=ROUTER_MAC,
                                           ipv6_dst=ip_dst,
                                           ipv6_src=self.servers[0][1].ipv6,
@@ -478,8 +460,10 @@ class IngressMtuTestV6(T0TestBase):
         self.test_ingress_mtu_v6()
 
     def tearDown(self):
+        """
+        Test the basic tearDown process
+        """
         sai_thrift_set_router_interface_attribute(
                 self.client, self.dut.port_obj_list[0].rif_list[-1], mtu=self.mtu_port10_rif['mtu'])
-        sai_thrift_remove_router_interface(self.client, self.port1_rif)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
         super().tearDown()

--- a/test/sai_test/sai_sanity_test.py
+++ b/test/sai_test/sai_sanity_test.py
@@ -65,6 +65,6 @@ class SaiSanityTest(T0TestBase):
             print("Sanity test, check all the ports be flooded.")
             send_packet(self, 1, pkt)
             verify_each_packet_on_multiple_port_lists(
-                self, [pkt], [self.dut.dev_port_list[2:]])
+                self, [pkt], [[item.dev_port_index for item in self.dut.port_obj_list[2:]]])
         finally:
             pass

--- a/test/sai_test/sai_sanity_test.py
+++ b/test/sai_test/sai_sanity_test.py
@@ -32,7 +32,7 @@ class SaiSanityTest(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup proecss
+        Setup proecss
         """
         T0TestBase.setUp(self,
                          is_reset_default_vlan=False,
@@ -46,7 +46,7 @@ class SaiSanityTest(T0TestBase):
 
     def tearDown(self):
         """
-        Test the basic tearDown process
+        TearDown process
         """
         pass
 

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -477,6 +477,23 @@ class T0TestBase(ThriftInterfaceDataPlane):
         """
         self.route_configer.create_router_interface(lag, reuse)
 
+    def get_dev_port_index(self, port_index):
+        """
+        port_index: port index
+        return dev port index from port index
+        """
+        return self.dut.port_obj_list[port_index].dev_port_index
+
+    def get_dev_port_indexes(self, port_indexes:List):
+        """
+        port_indexes: port index list
+        return dev port indexes from port indexes
+        """
+        dev_port_indexes = []
+        for port_index in port_indexes:
+            dev_port_indexes.append(self.dut.port_obj_list[port_index].dev_port_index)
+        return dev_port_indexes
+
     def tearDown(self):
         '''
         tear down

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -375,11 +375,6 @@ class T0TestBase(ThriftInterfaceDataPlane):
                 test_obj=self,
                 is_create_hostIf=is_create_hostIf,
                 is_recreate_bridge=is_recreate_bridge)
-            # init port rif list
-            self.dut.port_rif_list = [None] * len(self.dut.dev_port_list)
-            # init bridge port rif list
-            self.dut.bridge_port_rif_list = [
-                None] * len(self.dut.bridge_port_list)
             t0_vlan_config_helper(
                 test_obj=self,
                 is_reset_default_vlan=is_reset_default_vlan,

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -464,23 +464,23 @@ class T0TestBase(ThriftInterfaceDataPlane):
             self.t1_list[t1_grp_idx] = [Device(DeviceType.t1, index, t1_grp_idx)
                                         for index in range(0, self.num_device_each_group)]
 
-    def create_vlan_interface(self, vlan: Vlan):
+    def create_vlan_interface(self, vlan: Vlan, reuse=True):
         """
         Create vlan route interface.
 
         Attrs:
             Vlan: vlan for the route interface
         """
-        self.route_configer.create_router_interface_by_vlan(vlan)
+        self.route_configer.create_router_interface(vlan, reuse)
 
-    def create_lag_interface(self, lag: Lag):
+    def create_lag_interface(self, lag: Lag, reuse=True):
         """
         Create lag route interface.
 
         Attrs:
             Lag: lag for the route interface
         """
-        self.route_configer.create_router_interface_by_lag(lag)
+        self.route_configer.create_router_interface(lag, reuse)
 
     def tearDown(self):
         '''

--- a/test/sai_test/sai_vlan_test.py
+++ b/test/sai_test/sai_vlan_test.py
@@ -183,7 +183,7 @@ class TaggedFrameFilteringTest(T0TestBase):
             switch_id=self.dut.switch_id,
             server_list=self.tmp_server_list,
             port_idxs=[1, 1],
-            vlan_oid=self.dut.vlans[10].vlan_oid)
+            vlan_oid=self.dut.vlans[10].oid)
 
     def runTest(self):
         print("\nTaggedFrameFilteringTest")
@@ -219,7 +219,7 @@ class UnTaggedFrameFilteringTest(T0TestBase):
             switch_id=self.dut.switch_id,
             server_list=self.tmp_server_list,
             port_idxs=[1, 1],
-            vlan_oid=self.dut.vlans[10].vlan_oid)
+            vlan_oid=self.dut.vlans[10].oid)
 
     def runTest(self):
         print("\nUnTaggedFrameFilteringTest")
@@ -427,9 +427,9 @@ class VlanMemberListTest(T0TestBase):
         print("VlanMemberListTest")
         mbr_list = []
         mbr_list.extend(self.vlan_configer.get_vlan_member(
-            self.dut.vlans[10].vlan_oid))
+            self.dut.vlans[10].oid))
         mbr_list.extend(self.vlan_configer.get_vlan_member(
-            self.dut.vlans[20].vlan_oid))
+            self.dut.vlans[20].oid))
         self.assertEqual(len(mbr_list), 16)
 
         for i in range(0, 8):
@@ -442,15 +442,15 @@ class VlanMemberListTest(T0TestBase):
         # Adding vlan members and veryfing vlan member list
         new_vlan_member = sai_thrift_create_vlan_member(
             self.client,
-            vlan_id=self.dut.vlans[10].vlan_oid,
+            vlan_id=self.dut.vlans[10].oid,
             bridge_port_id=self.dut.bridge_port_list[17],
             vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
 
         mbr_list = []
         mbr_list.extend(self.vlan_configer.get_vlan_member(
-            self.dut.vlans[10].vlan_oid))
+            self.dut.vlans[10].oid))
         mbr_list.extend(self.vlan_configer.get_vlan_member(
-            self.dut.vlans[20].vlan_oid))
+            self.dut.vlans[20].oid))
         self.assertEqual(len(mbr_list), 17)
 
         # Adding vlan members and veryfing vlan member list
@@ -467,9 +467,9 @@ class VlanMemberListTest(T0TestBase):
 
         mbr_list = []
         mbr_list.extend(self.vlan_configer.get_vlan_member(
-            self.dut.vlans[10].vlan_oid))
+            self.dut.vlans[10].oid))
         mbr_list.extend(self.vlan_configer.get_vlan_member(
-            self.dut.vlans[20].vlan_oid))
+            self.dut.vlans[20].oid))
         self.assertEqual(len(mbr_list), 16)
 
         for i in range(0, 8):
@@ -514,7 +514,7 @@ class DisableMacLearningTaggedTest(T0TestBase):
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         print("DisableMacLearningTaggedTest")
         sai_thrift_set_vlan_attribute(
-            self.client, self.dut.vlans[10].vlan_oid, learn_disable=True)
+            self.client, self.dut.vlans[10].oid, learn_disable=True)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
         print("MAC Learning disabled on VLAN")
 
@@ -547,7 +547,7 @@ class DisableMacLearningUntaggedTest(T0TestBase):
         T0TestBase.setUp(self, is_reset_default_vlan=False)
         print("DisableMacLearningUntaggedTest")
         sai_thrift_set_vlan_attribute(
-            self.client, self.dut.vlans[10].vlan_oid, learn_disable=True)
+            self.client, self.dut.vlans[10].oid, learn_disable=True)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
         print("MAC Learning disabled on VLAN")
 
@@ -641,7 +641,7 @@ class TaggedVlanStatusTest(T0TestBase):
     def runTest(self):
         print("TaggedVlanStatusTest")
         stats = sai_thrift_get_vlan_stats(
-            self.client, self.dut.vlans[10].vlan_oid)
+            self.client, self.dut.vlans[10].oid)
 
         in_bytes_pre = stats["SAI_VLAN_STAT_IN_OCTETS"]
         out_bytes_pre = stats["SAI_VLAN_STAT_OUT_OCTETS"]
@@ -655,7 +655,7 @@ class TaggedVlanStatusTest(T0TestBase):
         verify_packet(self, self.tagged_pkt, self.dut.dev_port_list[2])
 
         stats = sai_thrift_get_vlan_stats(
-            self.client, self.dut.vlans[10].vlan_oid)
+            self.client, self.dut.vlans[10].oid)
         in_bytes = stats["SAI_VLAN_STAT_IN_OCTETS"]
         out_bytes = stats["SAI_VLAN_STAT_OUT_OCTETS"]
         in_packets = stats["SAI_VLAN_STAT_IN_PACKETS"]
@@ -687,11 +687,11 @@ class TaggedVlanStatusTest(T0TestBase):
         verify_packet(self, self.tagged_pkt, self.dut.dev_port_list[2])
 
         # Clear bytes and packets counter
-        sai_thrift_clear_vlan_stats(self.client, self.dut.vlans[10].vlan_oid)
+        sai_thrift_clear_vlan_stats(self.client, self.dut.vlans[10].oid)
 
         # Check counters
         stats = sai_thrift_get_vlan_stats(
-            self.client, self.dut.vlans[10].vlan_oid)
+            self.client, self.dut.vlans[10].oid)
         in_bytes = stats["SAI_VLAN_STAT_IN_OCTETS"]
         out_bytes = stats["SAI_VLAN_STAT_OUT_OCTETS"]
         in_packets = stats["SAI_VLAN_STAT_IN_PACKETS"]
@@ -743,7 +743,7 @@ class UntaggedVlanStatusTest(T0TestBase):
 
         time.sleep(1)
         stats = sai_thrift_get_vlan_stats(
-            self.client, self.dut.vlans[10].vlan_oid)
+            self.client, self.dut.vlans[10].oid)
         in_bytes = stats["SAI_VLAN_STAT_IN_OCTETS"]
         out_bytes = stats["SAI_VLAN_STAT_OUT_OCTETS"]
         in_packets = stats["SAI_VLAN_STAT_IN_PACKETS"]
@@ -775,11 +775,11 @@ class UntaggedVlanStatusTest(T0TestBase):
         verify_packet(self, self.untagged_pkt, self.dut.dev_port_list[2])
 
         # Clear bytes and packets counter
-        sai_thrift_clear_vlan_stats(self.client, self.dut.vlans[10].vlan_oid)
+        sai_thrift_clear_vlan_stats(self.client, self.dut.vlans[10].oid)
         # Check counters
 
         stats = sai_thrift_get_vlan_stats(
-            self.client, self.dut.vlans[10].vlan_oid)
+            self.client, self.dut.vlans[10].oid)
         in_bytes = stats["SAI_VLAN_STAT_IN_OCTETS"]
         out_bytes = stats["SAI_VLAN_STAT_OUT_OCTETS"]
         in_packets = stats["SAI_VLAN_STAT_IN_PACKETS"]

--- a/test/sai_test/sai_vlan_test.py
+++ b/test/sai_test/sai_vlan_test.py
@@ -50,30 +50,30 @@ class Vlan_Domain_Forwarding_Test(T0TestBase):
             for index in range(2, 9):
                 print("Forwarding in VLAN {} from {} to port: {}".format(
                     10,
-                    self.dut.dev_port_list[1],
-                    self.dut.dev_port_list[index]))
+                    self.dut.port_obj_list[1].dev_port_index,
+                    self.dut.port_obj_list[index].dev_port_index))
                 pkt = simple_udp_packet(eth_dst=self.servers[1][index].mac,
                                         eth_src=self.servers[1][1].mac,
                                         vlan_vid=10,
                                         ip_id=101,
                                         ip_ttl=64)
 
-                send_packet(self, self.dut.dev_port_list[1], pkt)
-                verify_packet(self, pkt, self.dut.dev_port_list[index])
+                send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
+                verify_packet(self, pkt, self.dut.port_obj_list[index].dev_port_index)
                 verify_no_other_packets(self, timeout=1)
 
             for index in range(10, 17):
                 print("Forwarding in VLAN {} from {} to port: {}".format(
                     20,
-                    self.dut.dev_port_list[9],
-                    self.dut.dev_port_list[index]))
+                    self.dut.port_obj_list[9].dev_port_index,
+                    self.dut.port_obj_list[index].dev_port_index))
                 pkt = simple_udp_packet(eth_dst=self.servers[1][index].mac,
                                         eth_src=self.servers[1][9].mac,
                                         vlan_vid=20,
                                         ip_id=101,
                                         ip_ttl=64)
-                send_packet(self, self.dut.dev_port_list[9], pkt)
-                verify_packet(self, pkt, self.dut.dev_port_list[index])
+                send_packet(self, self.dut.port_obj_list[9].dev_port_index, pkt)
+                verify_packet(self, pkt, self.dut.port_obj_list[index].dev_port_index)
                 verify_no_other_packets(self, timeout=1)
         finally:
             pass
@@ -98,25 +98,25 @@ class UntagAccessToAccessTest(T0TestBase):
         try:
             for index in range(2, 9):
                 print("Sending untagged packet from vlan10 tagged port {} to vlan10 tagged port: {}".format(
-                    self.dut.dev_port_list[1],
-                    self.dut.dev_port_list[index]))
+                    self.dut.port_obj_list[1].dev_port_index,
+                    self.dut.port_obj_list[index].dev_port_index))
                 pkt = simple_udp_packet(eth_dst=self.servers[1][index].mac,
                                         eth_src=self.servers[1][1].mac,
                                         ip_id=101,
                                         ip_ttl=64)
-                send_packet(self, self.dut.dev_port_list[1], pkt)
-                verify_packet(self, pkt, self.dut.dev_port_list[index])
+                send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
+                verify_packet(self, pkt, self.dut.port_obj_list[index].dev_port_index)
                 verify_no_other_packets(self, timeout=2)
             for index in range(10, 17):
                 print("Sending untagged packet from vlan20 tagged port {} to vlan20 tagged port: {}".format(
-                    self.dut.dev_port_list[9],
-                    self.dut.dev_port_list[index]))
+                    self.dut.port_obj_list[9].dev_port_index,
+                    self.dut.port_obj_list[index].dev_port_index))
                 pkt = simple_udp_packet(eth_dst=self.servers[1][index].mac,
                                         eth_src=self.servers[1][9].mac,
                                         ip_id=101,
                                         ip_ttl=64)
-                send_packet(self, self.dut.dev_port_list[9], pkt)
-                verify_packet(self, pkt, self.dut.dev_port_list[index])
+                send_packet(self, self.dut.port_obj_list[9].dev_port_index, pkt)
+                verify_packet(self, pkt, self.dut.port_obj_list[index].dev_port_index)
                 verify_no_other_packets(self, timeout=2)
         finally:
             pass
@@ -141,25 +141,25 @@ class MismatchDropTest(T0TestBase):
         try:
             for index in range(1, 9):
                 print("Sending vlan20 tagged packet from vlan20 tagged port {} to vlan10 tagged port: {}".format(
-                    self.dut.dev_port_list[9],
-                    self.dut.dev_port_list[index]))
+                    self.dut.port_obj_list[9].dev_port_index,
+                    self.dut.port_obj_list[index].dev_port_index))
                 pkt = simple_udp_packet(eth_dst=self.servers[1][index].mac,
                                         eth_src=self.servers[1][9].mac,
                                         vlan_vid=20,
                                         ip_id=101,
                                         ip_ttl=64)
-                send_packet(self, self.dut.dev_port_list[9], pkt)
+                send_packet(self, self.dut.port_obj_list[9].dev_port_index, pkt)
                 verify_no_other_packets(self, timeout=2)
             for index in range(9, 17):
                 print("Sending vlan10 tagged packet from {} to vlan20 tagged port: {}".format(
-                    self.dut.dev_port_list[1],
-                    self.dut.dev_port_list[index]))
+                    self.dut.port_obj_list[1].dev_port_index,
+                    self.dut.port_obj_list[index].dev_port_index))
                 pkt = simple_udp_packet(eth_dst=self.servers[1][index].mac,
                                         eth_src=self.servers[1][1].mac,
                                         vlan_vid=10,
                                         ip_id=101,
                                         ip_ttl=64)
-                send_packet(self, self.dut.dev_port_list[1], pkt)
+                send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 verify_no_other_packets(self, timeout=2)
         finally:
             pass
@@ -194,7 +194,7 @@ class TaggedFrameFilteringTest(T0TestBase):
                                         vlan_vid=10,
                                         ip_id=101,
                                         ip_ttl=64)
-                send_packet(self, self.dut.dev_port_list[1], pkt)
+                send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 verify_no_other_packets(self, timeout=1)
         finally:
             pass
@@ -229,7 +229,7 @@ class UnTaggedFrameFilteringTest(T0TestBase):
                                         eth_src=self.servers[1][1].mac,
                                         ip_id=101,
                                         ip_ttl=64)
-                send_packet(self, self.dut.dev_port_list[1], pkt)
+                send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 verify_no_other_packets(self, timeout=1)
         finally:
             pass
@@ -257,8 +257,8 @@ class TaggedVlanFloodingTest(T0TestBase):
                                     vlan_vid=10,
                                     ip_id=101,
                                     ip_ttl=64)
-            send_packet(self, self.dut.dev_port_list[1], pkt)
-            other_ports = self.dut.dev_port_list[1:8]
+            send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
+            other_ports = [item.dev_port_index for item in self.dut.port_obj_list[1:8]]
             verify_packet_any_port(self, pkt, other_ports)
         finally:
             pass
@@ -286,8 +286,8 @@ class UnTaggedVlanFloodingTest(T0TestBase):
                                     eth_src=self.servers[1][1].mac,
                                     ip_id=101,
                                     ip_ttl=64)
-            send_packet(self, self.dut.dev_port_list[1], pkt)
-            other_ports = self.dut.dev_port_list[1:8]
+            send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
+            other_ports = [item.dev_port_index for item in self.dut.port_obj_list[1:8]]
             verify_packet_any_port(self, pkt, other_ports)
         finally:
             pass
@@ -314,8 +314,8 @@ class BroadcastTest(T0TestBase):
                                              eth_src=self.servers[1][1].mac,
                                              ip_id=101,
                                              ip_ttl=64)
-            send_packet(self, self.dut.dev_port_list[1], untagged_pkt)
-            other_ports = self.dut.dev_port_list[1:8]
+            send_packet(self, self.dut.port_obj_list[1].dev_port_index, untagged_pkt)
+            other_ports = [item.dev_port_index for item in self.dut.port_obj_list[1:8]]
             verify_packet_any_port(self, untagged_pkt, other_ports)
             # tag
             tagged_pkt = simple_udp_packet(eth_dst=macX,
@@ -323,8 +323,8 @@ class BroadcastTest(T0TestBase):
                                            vlan_vid=10,
                                            ip_id=101,
                                            ip_ttl=64)
-            send_packet(self, self.dut.dev_port_list[1], tagged_pkt)
-            other_ports = self.dut.dev_port_list[1:8]
+            send_packet(self, self.dut.port_obj_list[1].dev_port_index, tagged_pkt)
+            other_ports = [item.dev_port_index for item in self.dut.port_obj_list[1:8]]
             verify_packet_any_port(self, tagged_pkt, other_ports)
         finally:
             pass
@@ -355,8 +355,8 @@ class UntaggedMacLearningTest(T0TestBase):
                                              eth_src=macX,
                                              ip_id=101,
                                              ip_ttl=64)
-            send_packet(self, self.dut.dev_port_list[1], untagged_pkt)
-            verify_packet(self, untagged_pkt, self.dut.dev_port_list[2])
+            send_packet(self, self.dut.port_obj_list[1].dev_port_index, untagged_pkt)
+            verify_packet(self, untagged_pkt, self.dut.port_obj_list[2].dev_port_index)
             verify_no_other_packets(self, timeout=2)
             sleep(2)  # wait for add mac entry
             available_fdb_entry_cnt_now = sai_thrift_get_switch_attribute(
@@ -396,8 +396,8 @@ class TaggedMacLearningTest(T0TestBase):
                                            vlan_vid=10,
                                            ip_id=101,
                                            ip_ttl=64)
-            send_packet(self, self.dut.dev_port_list[1], tagged_pkt)
-            verify_packet(self, tagged_pkt, self.dut.dev_port_list[2])
+            send_packet(self, self.dut.port_obj_list[1].dev_port_index, tagged_pkt)
+            verify_packet(self, tagged_pkt, self.dut.port_obj_list[2].dev_port_index)
             verify_no_other_packets(self, timeout=2)
             sleep(2)  # wait for add mac entry
             available_fdb_entry_cnt_now = sai_thrift_get_switch_attribute(
@@ -443,7 +443,7 @@ class VlanMemberListTest(T0TestBase):
         new_vlan_member = sai_thrift_create_vlan_member(
             self.client,
             vlan_id=self.dut.vlans[10].oid,
-            bridge_port_id=self.dut.bridge_port_list[17],
+            bridge_port_id=self.dut.port_obj_list[17].bridge_port_oid,
             vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
 
         mbr_list = []
@@ -497,7 +497,7 @@ class VlanMemberInvalidTest(T0TestBase):
         incorrect_member = sai_thrift_create_vlan_member(
             self.client,
             vlan_id=11,
-            bridge_port_id=self.dut.bridge_port_list[17],
+            bridge_port_id=self.dut.port_obj_list[17].bridge_port_oid,
             vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
         self.assertEqual(incorrect_member, 0)
 
@@ -530,7 +530,7 @@ class DisableMacLearningTaggedTest(T0TestBase):
                                 ip_ttl=64)
         send_packet(self, 1, pkt)
         verify_each_packet_on_multiple_port_lists(
-            self, [pkt], [self.dut.dev_port_list[2:9]])
+            self, [pkt], [[item.dev_port_index for item in self.dut.port_obj_list[2:9]]])
 
         self.assertEqual(attr["available_fdb_entry"] - current_fdb_entry, 0)
 
@@ -560,9 +560,9 @@ class DisableMacLearningUntaggedTest(T0TestBase):
                                 eth_src=self.servers[1][1].mac,
                                 ip_id=101,
                                 ip_ttl=64)
-        send_packet(self, self.dut.dev_port_list[1], pkt)
+        send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
         verify_each_packet_on_multiple_port_lists(
-            self, [pkt], [self.dut.dev_port_list[2:9]])
+            self, [pkt], [[item.dev_port_index for item in self.dut.port_obj_list[2:9]]])
 
         self.assertEqual(attr["available_fdb_entry"] - current_fdb_entry, 0)
 
@@ -586,9 +586,9 @@ class ArpRequestFloodingTest(T0TestBase):
 
     def runTest(self):
         print("ArpRequestFloodingTest")
-        send_packet(self, self.dut.dev_port_list[1], self.arp_request)
+        send_packet(self, self.dut.port_obj_list[1].dev_port_index, self.arp_request)
         verify_each_packet_on_multiple_port_lists(
-            self, [self.arp_request], [self.dut.dev_port_list[2:9]])
+            self, [self.arp_request], [[item.dev_port_index for item in self.dut.port_obj_list[2:9]]])
 
     def tearDown(self):
         super().tearDown()
@@ -615,8 +615,8 @@ class ArpRequestLearningTest(T0TestBase):
 
     def runTest(self):
         print("ArpRequestLearningTest")
-        send_packet(self, self.dut.dev_port_list[2], self.arp_response)
-        verify_packet(self, self.arp_response, self.dut.dev_port_list[1])
+        send_packet(self, self.dut.port_obj_list[2].dev_port_index, self.arp_response)
+        verify_packet(self, self.arp_response, self.dut.port_obj_list[1].dev_port_index)
         verify_no_other_packets(self)
 
     def tearDown(self):
@@ -651,8 +651,8 @@ class TaggedVlanStatusTest(T0TestBase):
         out_ucast_packets_pre = stats["SAI_VLAN_STAT_OUT_UCAST_PKTS"]
 
         print("Sending L2 packet port 1 -> port 2")
-        send_packet(self, self.dut.dev_port_list[1], self.tagged_pkt)
-        verify_packet(self, self.tagged_pkt, self.dut.dev_port_list[2])
+        send_packet(self, self.dut.port_obj_list[1].dev_port_index, self.tagged_pkt)
+        verify_packet(self, self.tagged_pkt, self.dut.port_obj_list[2].dev_port_index)
 
         stats = sai_thrift_get_vlan_stats(
             self.client, self.dut.vlans[10].oid)
@@ -683,8 +683,8 @@ class TaggedVlanStatusTest(T0TestBase):
         #                 'vlan OUT bytes counter is 0')
 
         print("Sending L2 packet port 1 -> port 2")
-        send_packet(self, self.dut.dev_port_list[1], self.tagged_pkt)
-        verify_packet(self, self.tagged_pkt, self.dut.dev_port_list[2])
+        send_packet(self, self.dut.port_obj_list[1].dev_port_index, self.tagged_pkt)
+        verify_packet(self, self.tagged_pkt, self.dut.port_obj_list[2].dev_port_index)
 
         # Clear bytes and packets counter
         sai_thrift_clear_vlan_stats(self.client, self.dut.vlans[10].oid)
@@ -728,7 +728,7 @@ class UntaggedVlanStatusTest(T0TestBase):
 
     def runTest(self):
         print("UntaggedVlanStatusTest")
-        stats = sai_thrift_get_vlan_stats(self.client, self.dut.port_list[1])
+        stats = sai_thrift_get_vlan_stats(self.client, self.dut.vlans[10].oid)
 
         in_bytes_pre = stats["SAI_VLAN_STAT_IN_OCTETS"]
         out_bytes_pre = stats["SAI_VLAN_STAT_OUT_OCTETS"]
@@ -738,8 +738,8 @@ class UntaggedVlanStatusTest(T0TestBase):
         out_ucast_packets_pre = stats["SAI_VLAN_STAT_OUT_UCAST_PKTS"]
 
         print("Sending L2 packet port 1 -> port 2 [access vlan=10])")
-        send_packet(self, self.dut.dev_port_list[1], self.untagged_pkt)
-        verify_packet(self, self.untagged_pkt, self.dut.dev_port_list[2])
+        send_packet(self, self.dut.port_obj_list[1].dev_port_index, self.untagged_pkt)
+        verify_packet(self, self.untagged_pkt, self.dut.port_obj_list[2].dev_port_index)
 
         time.sleep(1)
         stats = sai_thrift_get_vlan_stats(
@@ -771,8 +771,8 @@ class UntaggedVlanStatusTest(T0TestBase):
         #                 'vlan OUT bytes counter is 0')
 
         print("Sending L2 packet port 1 -> port 2 [access vlan=10])")
-        send_packet(self, self.dut.dev_port_list[1], self.untagged_pkt)
-        verify_packet(self, self.untagged_pkt, self.dut.dev_port_list[2])
+        send_packet(self, self.dut.port_obj_list[1].dev_port_index, self.untagged_pkt)
+        verify_packet(self, self.untagged_pkt, self.dut.port_obj_list[2].dev_port_index)
 
         # Clear bytes and packets counter
         sai_thrift_clear_vlan_stats(self.client, self.dut.vlans[10].oid)

--- a/test/sai_test/sai_vlan_test.py
+++ b/test/sai_test/sai_vlan_test.py
@@ -37,7 +37,7 @@ class Vlan_Domain_Forwarding_Test(T0TestBase):
 
     def setUp(self):
         """
-        Test the basic setup process
+        Set up test
         """
         T0TestBase.setUp(self, is_reset_default_vlan=False)
 
@@ -79,6 +79,9 @@ class Vlan_Domain_Forwarding_Test(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         super().tearDown()
 
 
@@ -122,6 +125,9 @@ class UntagAccessToAccessTest(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         super().tearDown()
 
 
@@ -165,6 +171,9 @@ class MismatchDropTest(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         super().tearDown()
 
 
@@ -200,6 +209,9 @@ class TaggedFrameFilteringTest(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         super().tearDown()
 
 
@@ -235,6 +247,9 @@ class UnTaggedFrameFilteringTest(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         super().tearDown()
 
 
@@ -264,6 +279,9 @@ class TaggedVlanFloodingTest(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         super().tearDown()
 
 
@@ -293,6 +311,9 @@ class UnTaggedVlanFloodingTest(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         super().tearDown()
 
 
@@ -330,6 +351,9 @@ class BroadcastTest(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         super().tearDown()
 
 
@@ -368,6 +392,9 @@ class UntaggedMacLearningTest(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC)
         sleep(2)
@@ -409,6 +436,9 @@ class TaggedMacLearningTest(T0TestBase):
             pass
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC)
         sleep(2)
@@ -480,6 +510,9 @@ class VlanMemberListTest(T0TestBase):
                 self.dut.vlans[20].vlan_mport_oids[i - 8], mbr_list[i])
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         super().tearDown()
 
 
@@ -502,6 +535,9 @@ class VlanMemberInvalidTest(T0TestBase):
         self.assertEqual(incorrect_member, 0)
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         super().tearDown()
 
 
@@ -535,6 +571,9 @@ class DisableMacLearningTaggedTest(T0TestBase):
         self.assertEqual(attr["available_fdb_entry"] - current_fdb_entry, 0)
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         super().tearDown()
 
 
@@ -567,6 +606,9 @@ class DisableMacLearningUntaggedTest(T0TestBase):
         self.assertEqual(attr["available_fdb_entry"] - current_fdb_entry, 0)
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         super().tearDown()
 
 
@@ -591,6 +633,9 @@ class ArpRequestFloodingTest(T0TestBase):
             self, [self.arp_request], [[item.dev_port_index for item in self.dut.port_obj_list[2:9]]])
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         super().tearDown()
 
 
@@ -620,6 +665,9 @@ class ArpRequestLearningTest(T0TestBase):
         verify_no_other_packets(self)
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC)
         sleep(2)
@@ -710,6 +758,9 @@ class TaggedVlanStatusTest(T0TestBase):
         # self.assertEqual(out_bytes, 0, 'vlan OUT bytes counter is not 0')
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         super().tearDown()
 
 
@@ -798,4 +849,7 @@ class UntaggedVlanStatusTest(T0TestBase):
         # self.assertEqual(out_bytes, 0, 'vlan OUT bytes counter is not 0')
 
     def tearDown(self):
+        """
+        TearDown process
+        """
         super().tearDown()


### PR DESCRIPTION
## Description of PR
1. add a port data object
2. add a new super class for routable item
3. add more basic config and correct the cases
4. refactor code add more comment
5. use the new data module and make the test base on the config data

## Test
Run all sanity, fdb, vlan, neighbor, lag and rif cases and passed.

