### PR TITLE
[Cherry-pick][SAI-PTF] Enable saiserverv2 with syncd-rpc and fix saithriftv2 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,12 @@ else
 SAITHRIFT_PATH=test/saithrift
 endif
 
+# Passed to genrpc.pl via "make saithrift-build":
+GEN_SAIRPC_OPTS?=
+
+# Passed to meta/Makefile via "make saithrift-build, can specify add'l libraries along with libsai
+SAIRPC_EXTRA_LIBS?=
+
 .PHONY: test doc clean
 
 doc:
@@ -37,7 +43,7 @@ test:
 	make -C test
 
 saithrift-build:
-	make -C $(SAITHRIFT_PATH)
+	SAIRPC_EXTRA_LIBS="$(SAIRPC_EXTRA_LIBS)" GEN_SAIRPC_OPTS=$(GEN_SAIRPC_OPTS) make -C $(SAITHRIFT_PATH)
 
 saithrift-install: saithrift-build
 	make -C $(SAITHRIFT_PATH) install

--- a/meta/Makefile
+++ b/meta/Makefile
@@ -22,6 +22,9 @@
 # @brief   This module defines SAI Metadata Makefile
 #
 
+# Passed to genrpc.pl:
+GEN_SAIRPC_OPTS?=
+
 WARNINGS = \
 	-ansi \
 	-Wall \
@@ -100,7 +103,7 @@ saimetadatatest.c saimetadata.c saimetadata.h: xml $(XMLDEPS) parse.pl $(CONSTHE
 	perl -I. parse.pl
 
 rpc sai.thrift sai_rpc_server.cpp sai_adapter.py: xml $(XMLDEPS) gensairpc.pl
-	perl -Irpc gensairpc.pl
+	perl -Irpc gensairpc.pl $(GEN_SAIRPC_OPTS)
 
 HEADERS = saimetadata.h $(CONSTHEADERS)
 

--- a/meta/README.md
+++ b/meta/README.md
@@ -13,5 +13,9 @@ Parser also forces headers to be well formated when adding new code.
 To test your changes just type:
 
 ```sh
-make
+[GEN_SAIRPC_OPTS=<option flags>] make
+```
+e.g. 
+```
+GEN_SAIRPC_OPTS="-ve" make
 ```

--- a/meta/gensairpc.README
+++ b/meta/gensairpc.README
@@ -25,10 +25,14 @@ USAGE
 
 DEPENDENCIES
     Ubuntu packages:
-
-      libtemplate-perl
-      libconst-fast-perl
-      libmoosex-aliases-perl
-      libnamespace-autoclean-perl
-      libgetopt-long-descriptive-perl
-
+  ```
+    [sudo] apt-get install -y \
+      libtemplate-perl \
+      libconst-fast-perl \
+      libmoosex-aliases-perl \
+      libnamespace-autoclean-perl \
+      libgetopt-long-descriptive-perl \
+      doxygen \
+      graphviz \
+      aspell-en
+```

--- a/meta/gensairpc.pl
+++ b/meta/gensairpc.pl
@@ -281,7 +281,7 @@ sub generate_server_template_from_skeleton {
 
                 # Define global variable before "class"
                 print {$server_template}
-"\nextern sai_object_id_t switch_id;\nsai_object_id_t switch_id;\n\n\n";
+"\nextern sai_object_id_t switch_id;\nsai_object_id_t switch_id;\nextern sai_object_id_t gSwitchId;\n\n\n";
 
                 # Define helper functions
                 print {$server_template} "[% PROCESS helper_functions %]\n\n\n";

--- a/meta/templates/sai_rpc_server_functions.tt
+++ b/meta/templates/sai_rpc_server_functions.tt
@@ -28,6 +28,16 @@
 [% END -%]
 [%- END -%]
 
+[%- BLOCK check_sai_function -%]
+[% name = function.name; UNLESS methods.$name %]
+[% END -%]
+if ([% api %]_api->[% name = function.name; GET methods.$name %] == (void *)0) {
+        std::cerr << "NULL ptr: [% api %]_api->[% name = function.name; GET methods.$name %]" << std::endl;
+        [%- PROCESS throw_null_api_exception %]
+    }
+
+[%- END -%]
+
 [%- ######################################################################## -%]
 
 [%- ######################################################################## -%]
@@ -53,6 +63,12 @@
     // need to check if the switch exist
     if (switch_id != NULL) {
         return switch_id;
+    }
+
+    //check if the switch created in syncd
+    if (gSwitchId != NULL) {
+      switch_id = gSwitchId;
+      return switch_id;
     }
    
 [%- END -%]
@@ -110,7 +126,7 @@
 [%- ######################################################################## -%]
 
 [%- BLOCK sai_api_query -%]
-    status = sai_api_query(SAI_API_[% api.upper %], (void **)&[% api %]_api);
+    status = sai_api_query(static_cast<sai_api_t>(SAI_API_[% api.upper %]), (void **)&[% api %]_api);
     if (status != SAI_STATUS_SUCCESS) {
       [%- PROCESS return_error indentation = 3 status_variable = 'status' %]
     }
@@ -124,6 +140,14 @@
     [%- indentation = indentation || 2; tab = 2; indent = ' '; indent = indent.repeat(tab*indentation) %]
 [% indent %]sai_thrift_exception e;
 [% indent %]e.status = [% status_variable %];
+[% indent %]throw e;
+[%- END -%]
+
+[%- BLOCK throw_null_api_exception -%]
+    [%- indentation = indentation || 2; tab = 2; indent = ' '; indent = indent.repeat(tab*indentation) %]
+    
+[% indent %]sai_thrift_exception e;
+[% indent %]e.status = SAI_STATUS_NOT_IMPLEMENTED;
 [% indent %]throw e;
 [%- END -%]
 
@@ -344,6 +368,9 @@
         [%- PROCESS sai_api_query -%]
 
         [%- PROCESS preprocess_arguments %]
+
+        [%- # Ensure function ptr not NULL -%]
+    [% name = function.name; UNLESS methods.$name %]//[% END %][% PROCESS check_sai_function -%]
 
         [%- # Now just call the function -%]
     [% name = function.name; UNLESS methods.$name %]//[% END %]status = [% PROCESS call_sai_function -%]

--- a/meta/templates/sai_rpc_server_helper_functions.tt
+++ b/meta/templates/sai_rpc_server_helper_functions.tt
@@ -64,7 +64,7 @@ void sai_thrift_parse_[% object %]_attributes(const std::vector<sai_thrift_attri
   for (uint32_t i = 0; i < thrift_attr_list.size(); i++, it++) {
     attribute = (sai_thrift_attribute_t)*it;
     attr_list[i].id = attribute.id;
-    convert_attr_thrift_to_sai(SAI_OBJECT_TYPE_[% object.upper %], attribute, &attr_list[i]);
+    convert_attr_thrift_to_sai(static_cast<sai_object_type_t>(SAI_OBJECT_TYPE_[% object.upper %]), attribute, &attr_list[i]);
   }
 [% END -%]
 
@@ -85,7 +85,7 @@ void sai_thrift_deparse_[% object %]_attributes(sai_attribute_t *attr_list,
 
   for (uint32_t i = 0; i < attr_count; i++, it++) {
     sai_thrift_attribute_t attribute;
-    convert_attr_sai_to_thrift(SAI_OBJECT_TYPE_[% object.upper %], attr_list[i], attribute);
+    convert_attr_sai_to_thrift(static_cast<sai_object_type_t>(SAI_OBJECT_TYPE_[% object.upper %]), attr_list[i], attribute);
     thrift_attr_list.push_back(attribute);
   }
 [% END -%]

--- a/test/saithriftv2/Makefile
+++ b/test/saithriftv2/Makefile
@@ -18,6 +18,9 @@ CPPFLAGS = -I$(SAI_HEADER_DIR) -I. -std=c++11
 CPPFLAGS += -O0 -ggdb
 
 
+# specify add'l libraries along with libsai
+SAIRPC_EXTRA_LIBS?=
+
 ifeq ($(platform),MLNX)
 CDEFS = -DMLNXSAI
 else
@@ -90,7 +93,7 @@ $(ODIR)/sai_rpc_server.o: ../../meta/sai_rpc_frontend.cpp
 	$(CXX) $(CPPFLAGS) -c $^ -o $@ $(CPPFLAGS) -I./gen-cpp -I../../meta -I../../inc -I../../experimental
 
 $(ODIR)/saiserver.o: src/saiserver.cpp $(CPP_SOURCES) directories
-	$(CXX) $(CPPFLAGS) -c src/saiserver.cpp  -o $@ $(CPPFLAGS) $(CDEFS) -I./gen-cpp -I../../inc
+	$(CXX) $(CPPFLAGS) -c src/saiserver.cpp  -o $@ $(CPPFLAGS) $(CDEFS) -I./gen-cpp -I../../inc -I../../experimental
 
 $(ODIR)/librpcserver.a: $(ODIR)/sai_rpc.o $(ODIR)/sai_types.o $(ODIR)/sai_constants.o $(ODIR)/sai_rpc_server.o
 	ar rcs $(ODIR)/librpcserver.a $^
@@ -100,7 +103,7 @@ clientlib: $(PY_SOURCES) $(SAI_PY_HEADERS)
 
 saiserver: $(ODIR)/saiserver.o $(ODIR)/librpcserver.a
 	$(CXX) $(LDFLAGS) $(ODIR)/sai_rpc_server.o $(ODIR)/saiserver.o -o $@ \
-		   $(ODIR)/librpcserver.a $(LIBS)
+		   $(ODIR)/librpcserver.a $(LIBS) $(SAIRPC_EXTRA_LIBS)
 
 install-lib: $(ODIR)/librpcserver.a
 	$(INSTALL) -D $(ODIR)/librpcserver.a $(DESTDIR)/usr/lib/librpcserver.a


### PR DESCRIPTION
## Summary
cherry-pick changes from 1.10
which include the changes:

## Details

[SAI-PTF]Support init swtich from syncd-rpc container #1552
Saithriftv2 fixes for extensions #1533
Add GEN_SAIRPC_OPTS to pass flags to gensairpc.pl from top-level Make… #1514
Added missing dependencies required to run gensairpc.pl #1492
Check for NULL APIs returned by sai_api_query() and handle gracefully instead of crashing. #1558

## Test done:
Local build with command 
NOSTRETCH=y NOJESSIE=y NOBUSTER=y SAITHRIFT_V2=y INSTALL_DEBUG_TOOLS=y SONIC_BUILD_JOBS=4 ENABLE_DHCP_GRAPH_SERVICE=y SHUTDOWN_BGP_ON_START=y ENABLE_PFCWD_ON_START=y make target/docker-saiserverv2-brcm.gz