### PR TITLE
[SAI-PTF] Proposal for enhancement in VLAN cases

### DIFF
--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -276,7 +276,7 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
                 index=True,
                 parent_scheduler_node=True)
             self.assertEqual(queue, q_attr['index'])
-            self.assertEqual(self.cpu_port_hdl, q_attr['port'])
+            self.assertEqual(self.cpu_port_hdl, q_attr['port']-1)
 
 
     def start_switch(self):

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -276,7 +276,10 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
                 index=True,
                 parent_scheduler_node=True)
             self.assertEqual(queue, q_attr['index'])
-            self.assertEqual(self.cpu_port_hdl, q_attr['port']-1)
+            if platform == 'brcm':
+                self.assertEqual(self.cpu_port_hdl, q_attr['port']-1)
+            else:
+                self.assertEqual(self.cpu_port_hdl, q_attr['port'])
 
 
     def start_switch(self):

--- a/ptf/saivlan.py
+++ b/ptf/saivlan.py
@@ -560,8 +560,7 @@ class L2VlanTest(PlatformSaiHelper):
                 fdb_entry,
                 type=SAI_FDB_ENTRY_TYPE_STATIC,
                 bridge_port_id=self.lag2_bp,
-                packet_action=mac_action,
-                allow_mac_move=True)
+                packet_action=mac_action)
 
             sai_thrift_set_lag_attribute(
                 self.client, self.lag2, port_vlan_id=20)
@@ -2413,6 +2412,8 @@ class L2VlanTest(PlatformSaiHelper):
             sai_thrift_remove_vlan(self.client, vlan200)
             sai_thrift_remove_vlan(self.client, vlan100)
 
+
+# proposal for issue #1604: https://github.com/opencomputeproject/SAI/issues/1604
 class NativeVlanTest(PlatformSaiHelper):
     """
     This test case verifies the packet with or without tag sending
@@ -2460,6 +2461,7 @@ class NativeVlanTest(PlatformSaiHelper):
 
         self.fdb_entry0 = sai_thrift_fdb_entry_t(
             switch_id=self.switch_id, mac_address=self.mac0, bv_id=self.vlan10)
+        # explicitly set allow_mac_move for issue #1605: https://github.com/opencomputeproject/SAI/issues/1605
         sai_thrift_create_fdb_entry(
             self.client,
             self.fdb_entry0,


### PR DESCRIPTION
# Description of PR
For vlan test cases, there are some issues need to be addressed.
**1. Initialize and setup the ports but not recreate ports** #1603 
- Issue
Between different platforms, some of them doesn't support recreate ports but need to initialize and setup the ports at once after starting the switch.
- Solution
We use **PlatformSaiHelper** class to help setting basic common config based on [platform] class attribute instead of base class **SaiHelper**. When setting Platform = brcm, PlatformSaihelper actually is BrcmSaihelper. 

**2. Each class should have a clear test target** #1604 
- Issue
There are often multiple test cases in a class, which may affect each other and cause the test to fail.
- Solution
One class only contain one test case and only config the configuration that test case required.
For example, there is a nativeVlanTest in V2VlanTest test class. We separate this test case from L2VlanTest and divide this test case into two: **NativeVlanTest** class and **UpdateNativeVlanTest** class according to the test objective.
NativeVlanTest case only test the tagged/untagged packet tx/rx on trunk/access ports.
Test result:
![image](https://user-images.githubusercontent.com/19384917/190986673-144b9496-b42f-45b7-9316-78fb35a51491.png)
![image](https://user-images.githubusercontent.com/19384917/191025127-d19d218f-f04b-40ef-8f1a-89e7a2cd39a8.png)
*Separate cases from a big one, continue to split if you need.*

**3. Different default config through different platforms** #1605 
- Issue
For static FDB entry, default **allow_mac_move** should be false according to spec. When we run Intel's test cases on both Broadcom's and Intel's platform, we found that Intel's default configuration for this property is true so we can't run ptf cases on Broadcom's platform directly.
- Original result on Broadcom
![image](https://user-images.githubusercontent.com/19384917/190985979-d9c38c64-5ef0-409a-b97e-d56160c90022.png)
Without explicitly setting allow_mac_move to true, static FDB entry of mac: 00:33:33:33:33:33 cannot move from port24 to port1, causing test case to failed.
- Solution
Explicitly set allow_mac_move to be true when calling sai_thrift_create_fdb_entry() if you need.
- Current result
Run our sample case
![image](https://user-images.githubusercontent.com/19384917/190986673-144b9496-b42f-45b7-9316-78fb35a51491.png)

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>