### PR TITLE
[SAI-PTF] Proposal for enhancement in FDB cases

### DIFF
--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -276,7 +276,7 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
                 index=True,
                 parent_scheduler_node=True)
             self.assertEqual(queue, q_attr['index'])
-            self.assertEqual(self.cpu_port_hdl, q_attr['port'])
+            self.assertEqual(self.cpu_port_hdl, q_attr['port']-1)
 
 
     def start_switch(self):

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -276,7 +276,10 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
                 index=True,
                 parent_scheduler_node=True)
             self.assertEqual(queue, q_attr['index'])
-            self.assertEqual(self.cpu_port_hdl, q_attr['port']-1)
+            if platform == 'brcm':
+                self.assertEqual(self.cpu_port_hdl, q_attr['port']-1)
+            else:
+                self.assertEqual(self.cpu_port_hdl, q_attr['port'])
 
 
     def start_switch(self):

--- a/ptf/sai_utils.py
+++ b/ptf/sai_utils.py
@@ -317,7 +317,7 @@ def delay_wrapper(func, delay=2):
             status: original function return value
         """
         test_params = test_params_get()
-        if test_params['target'] != "hw":
+        if 'target' in test_params.keys() and test_params['target'] != "hw":
             time.sleep(delay)
 
         status = func(*args, **kwargs)

--- a/ptf/saifdb.py
+++ b/ptf/saifdb.py
@@ -956,7 +956,7 @@ class FdbLearnTest(SaiHelper):
                 self.client, vlan_id=self.vlan10, bridge_port_id=self.port1_bp,
                 vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
 
-
+# proposal for issue #1604: https://github.com/opencomputeproject/SAI/issues/1604
 class FdbDynamicMacLearnTest(PlatformSaiHelper):
     '''
     Verify dynamic mac learning for FDB: vlan, new vlan member and new lag member


### PR DESCRIPTION
# Description of PR
For fdb test cases, there are some issues need to be addressed.
**1. Initialize and setup the ports but not recreate ports** #1603 
- Issue
Between different platforms, some of them doesn't support recreate ports but need to initialize and setup the ports at once after starting the switch.
- Solution
We use **PlatformSaiHelper** class to help setting basic common config based on [platform] class attribute instead of base class **SaiHelper**. When setting Platform = brcm, PlatformSaihelper actually is BrcmSaihelper.

**2. Each class should have a clear test target** #1604 
- Issue
There are often multiple test cases in a class, which may affect each other and cause the test to fail.
For example, if we run saifdb.FdbLearnTest on brcm platform, we will get following result.
![image](https://user-images.githubusercontent.com/19384917/191022682-d4c79378-1e0d-41bc-aca5-384be9c504a5.png)

- Solution
One class should only contain one test case and only config the configuration that test case required.
We have a sample case for fdb:FdbDynamicMacLearnTest from FdbLearnTest class that only verify dynamic mac learning for FDB.
Test case result:
![image](https://user-images.githubusercontent.com/19384917/191023493-5bef32a1-9f04-434c-9007-b222ee668701.png)
*Continue to split cases when it has serval test target.*

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>