### PR TITLE
[cherry-pick][SAI-PTF] Enhance the function for getting counters in sai_adapter.py (#1626)

### DIFF
--- a/meta/templates/sai_adapter.py.tt
+++ b/meta/templates/sai_adapter.py.tt
@@ -93,6 +93,15 @@ def [% function.thrift_name %](client
     [%- FOREACH attr IN apis.$api.objects.${function.object}.attrs.${function.operation} -%]
 ,[% br %][% attr.simple_name %]=None
     [%- END -%]
+    [%- IF function.operation == 'stats' OR function.operation == 'clear' -%]
+        [%- FOREACH arg IN function.adapter_preprocessed_args -%]
+            [%- IF arg.is_list and arg.name == 'counter_ids' -%]
+,[% br %][% arg.name %]=[% function.name %]_[% arg.name %]
+            [%- ELSIF arg.is_attr %]
+        [% arg.name %] = None
+            [%- END -%]
+        [%- END -%]
+    [%- END -%] 
 ):
 [% END -%]
 
@@ -103,11 +112,30 @@ def [% function.thrift_name %](client
     [%- # but are required by thritft functions -%]
     [%- FOREACH arg IN function.adapter_preprocessed_args -%]
 
-        [%- IF arg.is_list %]
+        [%- IF arg.is_list AND arg.name!= 'counter_ids' %]
     [% arg.name %] = []
         [%- ELSIF arg.is_attr %]
     [% arg.name %] = None
         [%- END -%]
+    [%- END -%]
+[%- END -%]
+
+[%- BLOCK declare_stats_variables -%]
+    [%- IF function.operation == 'stats' OR function.operation == 'clear' %]
+        [%- FOREACH arg IN function.adapter_preprocessed_args -%]
+
+            [%- IF arg.is_list %]
+[% function.name %]_[% arg.name %] = []
+[% function.name %]_[% arg.name %]_dict = dict()
+            [%- ELSIF arg.is_attr %]
+        [% arg.name %] = None
+            [%- END -%]
+        [%- END -%]
+        [%- FOREACH stat IN apis.$api.objects.${function.object}.stats.all %]
+[% function.name %]_[% arg.name %].append([% stat.name %])
+[% function.name %]_[% arg.name %]_dict[[% stat.name %]] = "[% stat.name %]"
+        [%- END -%]
+
     [%- END -%]
 [%- END -%]
 
@@ -240,6 +268,7 @@ client.[% function.thrift_name %](
 [%- BLOCK preprocess_attributes %]
     [%- # For 'set attr' function we just do call the funtion for first argument -%]
     [%- IF function.operation == 'set' -%]
+    
     global status
     status = SAI_STATUS_SUCCESS
 
@@ -279,8 +308,10 @@ client.[% function.thrift_name %](
 
 [%- BLOCK preprocess_stats -%]
 
-    [%- FOREACH stat IN apis.$api.objects.${function.object}.stats.all %]
-    [% arg.name %].append([% stat.name %])
+    [%- IF arg.name != "counter_ids" -%]
+        [%- FOREACH stat IN apis.$api.objects.${function.object}.stats.all %]
+    [% function.name %]_[% arg.name %].append([% stat.name %])
+        [%- END -%]
     [%- END -%]
 
 [%- END -%]
@@ -292,11 +323,9 @@ client.[% function.thrift_name %](
 [%- BLOCK postprocess_stats %]
     stats = dict()
 
-    [%- i = 0 %]
-    [%- FOREACH stat IN apis.$api.objects.${function.object}.stats.all %]
-    stats["[% stat.name %]"] = [% function.rpc_return.name %][[% i %]]
-        [%- i = i + 1 -%]
-    [%- END %]
+    for index, item in enumerate(counter_ids):
+        stats[[% function.name %]_[% arg.name %]_dict[item]] = counters[index]
+
 
 [%- END -%]
 
@@ -308,13 +337,11 @@ client.[% function.thrift_name %](
     [%- # Basically we do it for each list variable, we assume we have one -%]
     [%- FOREACH arg IN function.adapter_preprocessed_args -%]
         [%- IF function.operation == 'stats' OR function.operation == 'clear' %]
-            [%- # For 'get stats' function create stats list -%]
+            [%- # For 'get stats' function NOT create stats list in function body -%]
             [%- PROCESS preprocess_stats %]
-
         [%- ELSIF function.operation != 'remove' %]
             [%- # For 'create' and 'get' functions create list of arguments -%]
             [%- PROCESS preprocess_attributes %]
-
         [%- END -%]
     [%- END -%]
 
@@ -400,6 +427,9 @@ client.[% function.thrift_name %](
 [%- ######################################################################## -%]
 
 [%- BLOCK function_body -%]
+    [%- PROCESS declare_stats_variables -%]
+
+
     [%- PROCESS decorate_method IF dev_utils -%]
     [%- PROCESS decorate_skip_test_on_error IF skip_error -%]
     [%- PROCESS function_header %]
@@ -407,11 +437,11 @@ client.[% function.thrift_name %](
 
     [%- IF has_body -%]
         [%- PROCESS declare_variables %]
-
         [%- PROCESS preprocess_args -%]
 
         [%- # Now, call the thrift function -%]
         [%- IF function.operation != 'set' -%]
+
     global status
     status = SAI_STATUS_SUCCESS
 


### PR DESCRIPTION


* [SAI-PTF] Enhance the function for getting counters in sai_adapter.py

    Resolve issue #1614

    For the auto-generated adapter, need to add a parameter for which counter_id/counter_ids we want, in order to compatiable with current code and reduce the modification, we can define a constant parameter as the list of counter_ids, and use this constant as the default.

    Before

    ```
    def sai_thrift_get_bfd_session_stats(client,
                                         bfd_session_oid):

        counter_ids = []
        counter_ids.append(SAI_BFD_SESSION_STAT_IN_PACKETS)
        counter_ids.append(SAI_BFD_SESSION_STAT_OUT_PACKETS)
        counter_ids.append(SAI_BFD_SESSION_STAT_DROP_PACKETS)

        counters = [0] * 3
        global status
        status = SAI_STATUS_SUCCESS
    ```

    After the refactor
    ```
    sai_get_bfd_session_stats_counter_ids = []
    sai_get_bfd_session_stats_counter_ids.append(SAI_BFD_SESSION_STAT_IN_PACKETS)
    sai_get_bfd_session_stats_counter_ids.append(SAI_BFD_SESSION_STAT_OUT_PACKETS)
    sai_get_bfd_session_stats_counter_ids.append(SAI_BFD_SESSION_STAT_DROP_PACKETS)

    def sai_thrift_get_bfd_session_stats(client,
                                         bfd_session_oid,
                                         counter_ids=sai_get_bfd_session_stats_counter_ids):

        counters = [0] * 3
        global status
        status = SAI_STATUS_SUCCESS
    ```

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>

* make some enhancement on the code, add dict which can get the enum name by id

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>
Co-authored-by: richardyu <richardyu@contoso.com>