### PR TITLE
[cherry-pick][[SAI-PTF] Add uninit API support in SAI-PTF and enhance the platformhelper (#1636)

### DIFF
--- a/meta/sai_rpc_frontend.cpp
+++ b/meta/sai_rpc_frontend.cpp
@@ -837,6 +837,14 @@ class sai_rpcHandlerFrontend : virtual public sai_rpcHandler {
     return sai_switch_id_query(object_id);
   }
 
+    /**
+   * @brief Thrift wrapper for sai_api_uninitialize() SAI function
+   */
+  sai_thrift_status_t sai_thrift_api_uninitialize(void) {
+
+    return sai_api_uninitialize();
+  }
+
   /**
    * @brief Thrift wrapper for sai_query_attribute_enum_values_capability()
    *        function

--- a/meta/templates/sai_rpc_server_functions.tt
+++ b/meta/templates/sai_rpc_server_functions.tt
@@ -5,7 +5,7 @@
 [%- create_switch_function = 'create_switch' %]
 [%- remove_switch_function = 'remove_switch' %]
 
-[%- sai_utils_functions = '(query_attribute_enum_values_capability|sai_object_type_get_availability|sai_object_type_query|sai_switch_id_query)' -%]
+[%- sai_utils_functions = '(query_attribute_enum_values_capability|sai_object_type_get_availability|sai_object_type_query|sai_switch_id_query|sai_api_uninitialize)' -%]
 
 [%- ######################################################################## -%]
 
@@ -88,7 +88,7 @@ if ([% api %]_api->[% name = function.name; GET methods.$name %] == (void *)0) {
 
     // This function should be manually implemented elsewhere
     [%- indentation = 2 || 2; tab = 2; indent = ' '; indent = indent.repeat(tab*indentation) %]
-    [%- IF ret_type == 'int64_t' %]
+    [%- IF ret_type == 'int64_t' OR ret_type == 'sai_thrift_status_t' %]
 [% indent %]return 0ULL;
     [%- ELSIF ret_type == 'sai_thrift_object_id_t' OR ret_type == 'sai_thrift_object_type_t' %]
 [% indent %]return SAI_NULL_OBJECT_ID;

--- a/meta/templates/sai_thrift_utils.tt
+++ b/meta/templates/sai_thrift_utils.tt
@@ -6,6 +6,7 @@
     i64 sai_thrift_object_type_get_availability(1 : sai_thrift_object_type_t object_type, 2: sai_thrift_attr_id_t attr_id, 3: i32 attr_type);
     sai_thrift_object_id_t sai_thrift_switch_id_query(1 : sai_thrift_object_id_t object_id);
     sai_thrift_object_type_t sai_thrift_object_type_query(1 : sai_thrift_object_id_t object_id);
+    sai_thrift_status_t sai_thrift_api_uninitialize();
 
 [%- END -%]
 

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -1008,7 +1008,11 @@ class PlatformSaiHelper(SaiHelper):
         else:
             target_base_class = sai_helper_subclass_map[pl]
 
-        cls.__bases__ = (target_base_class,)
+        cur_cls = cls
+        while cur_cls.__base__ != PlatformSaiHelper:
+            cur_cls = cur_cls.__base__
+
+        cur_cls.__bases__ = (target_base_class,)
 
         instance = target_base_class.__new__(cls, *args, **kwargs)
         return instance

--- a/ptf/sai_utils.py
+++ b/ptf/sai_utils.py
@@ -112,6 +112,20 @@ def sai_thrift_switch_id_query(client,
     return switch_obj_id
 
 
+def sai_thrift_api_uninitialize(client):
+    """
+    sai_thrift_api_uninitialize() RPC client function
+    implementation
+    Args:
+        client (Client): SAI RPC client
+    Returns:
+        uint: object type
+    """
+    obj_type = client.sai_thrift_api_uninitialize()
+
+    return obj_type
+
+
 def sai_thrift_get_debug_counter_port_stats(client, port_oid, counter_ids):
     """
     Get port statistics for given debug counters


### PR DESCRIPTION


Add uninit API support in SAI-PTF and enhance the platform helper
- add interface for SAI-PTF to uninitalize the sai interface
- use the uninitalize interface to triger the ASIC data dump
> this change picked parts of the change in #1440, but without the warm reboot part.

Test Done:
Local Docker build for building the saiserver
Local testing environment

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>