### PR TITLE
[SAi-PTF]Fix Failed cases by add dataplane flush with time consuming verify

### DIFF
--- a/test/sai_test/sai_ecmp_test.py
+++ b/test/sai_test/sai_ecmp_test.py
@@ -73,7 +73,7 @@ class EcmpHashFieldSportTestV4(T0TestBase):
                                          tcp_sport= src_port,
                                          ip_id=105,
                                          ip_ttl=63)
-
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             rcv_idx = verify_any_packet_any_port(
                 self, [exp_pkt1, exp_pkt2, exp_pkt3, exp_pkt4], recv_dev_port_idxs)
@@ -156,7 +156,7 @@ class EcmpHashFieldSportTestV6(T0TestBase):
                                            ipv6_src=ip_src,
                                            tcp_sport= src_port,
                                            ipv6_hlim=63)
-
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             rcv_idx = verify_any_packet_any_port(
                 self, [exp_pkt1, exp_pkt2, exp_pkt3, exp_pkt4], recv_dev_port_idxs)
@@ -244,7 +244,7 @@ class EcmpHashFieldDportTestV4(T0TestBase):
                                          tcp_dport= dst_port,
                                          ip_id=105,
                                          ip_ttl=63) 
-
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             rcv_idx = verify_any_packet_any_port(
                 self, [exp_pkt1, exp_pkt2, exp_pkt3, exp_pkt4], recv_dev_port_idxs)
@@ -327,7 +327,7 @@ class EcmpHashFieldDportTestV6(T0TestBase):
                                            ipv6_src=ip_src,
                                            tcp_dport= dst_port,
                                            ipv6_hlim=63) 
-
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             rcv_idx = verify_any_packet_any_port(
                 self, [exp_pkt1, exp_pkt2, exp_pkt3, exp_pkt4], recv_dev_port_idxs)
@@ -409,7 +409,7 @@ class EcmpHashFieldSIPTestV4(T0TestBase):
                                          ip_src=ip_src,
                                          ip_id=105,
                                          ip_ttl=63) 
-
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             rcv_idx = verify_any_packet_any_port(
                 self, [exp_pkt1, exp_pkt2, exp_pkt3, exp_pkt4], recv_dev_port_idxs)
@@ -486,7 +486,7 @@ class EcmpHashFieldSIPTestV6(T0TestBase):
                                            ipv6_dst=ip_dst,
                                            ipv6_src=ip_src,
                                            ipv6_hlim=63) 
-
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             rcv_idx = verify_any_packet_any_port(
                 self, [exp_pkt1, exp_pkt2, exp_pkt3, exp_pkt4], recv_dev_port_idxs)
@@ -607,7 +607,7 @@ class EcmpHashFieldProtoTestV4(T0TestBase):
                                              ip_src=ip_src,
                                              ip_id=105,
                                              ip_ttl=63) 
-
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             rcv_idx = verify_any_packet_any_port(
                 self, [exp_pkt1, exp_pkt2, exp_pkt3, exp_pkt4], recv_dev_port_idxs)
@@ -718,7 +718,7 @@ class EcmpHashFieldProtoTestV6(T0TestBase):
                                                ipv6_dst=ip_dst,
                                                ipv6_src=ip_src,
                                                ipv6_hlim=63)
-
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             rcv_idx = verify_any_packet_any_port(
                 self, [exp_pkt1, exp_pkt2, exp_pkt3, exp_pkt4], recv_dev_port_idxs)
@@ -797,6 +797,7 @@ class IngressNoDiffTestV4(T0TestBase):
         
         for i in range(5, 9):
             # step 4
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[i].dev_port_index, pkt1)
             if exp_port_idx1 == -1:
                 exp_port_idx1, _ = verify_packet_any_port(self, exp_pkt1, recv_dev_port_idxs)
@@ -804,6 +805,7 @@ class IngressNoDiffTestV4(T0TestBase):
                 verify_packet(self, exp_pkt1, recv_dev_port_idxs[exp_port_idx1])
 
             # step 6
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[i].dev_port_index, pkt2)
             if exp_port_idx2 == -1:
                 exp_port_idx2, _ = verify_packet_any_port(self, exp_pkt2, recv_dev_port_idxs)
@@ -877,7 +879,7 @@ class RemoveLagEcmpTestV4(T0TestBase):
                                          ip_src=ip_src,
                                          ip_id=105,
                                          ip_ttl=63)
-            
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             verify_any_packet_any_port(self, [exp_pkt1, exp_pkt2, exp_pkt3], recv_dev_port_idxs)
 
@@ -951,7 +953,7 @@ class RemoveLagEcmpTestV6(T0TestBase):
                                            ipv6_src=ip_src,
                                            tcp_dport= dst_port,
                                            ipv6_hlim=63) 
-
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             rcv_idx = verify_any_packet_any_port(
                 self, [exp_pkt1, exp_pkt2, exp_pkt3], recv_dev_port_idxs)
@@ -1035,7 +1037,7 @@ class RemoveAllNextHopMemeberTestV4(T0TestBase):
                                          tcp_sport= src_port,
                                          ip_id=105,
                                          ip_ttl=63)
-
+        self.dataplane.flush()
         send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
         verify_no_other_packets(self)
 
@@ -1118,7 +1120,7 @@ class RemoveNexthopGroupTestV4(T0TestBase):
                                          tcp_sport= src_port,
                                          ip_id=105,
                                          ip_ttl=63)
-
+        self.dataplane.flush()
         send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
         verify_no_other_packets(self)
 
@@ -1189,7 +1191,7 @@ class ReaAddLagEcmpTestV4(T0TestBase):
                                          ip_src=ip_src,
                                          ip_id=105,
                                          ip_ttl=63)
-
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             verify_any_packet_any_port(self, [exp_pkt1, exp_pkt2, exp_pkt3], recv_dev_port_idxs)
 
@@ -1231,7 +1233,7 @@ class ReaAddLagEcmpTestV4(T0TestBase):
                                          ip_src=ip_src,
                                          ip_id=105,
                                          ip_ttl=63)
-
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             verify_any_packet_any_port(self, [exp_pkt1, exp_pkt2, exp_pkt3, exp_pkt4], recv_dev_port_idxs)
     def runTest(self):
@@ -1296,7 +1298,7 @@ class ReaAddLagEcmpTestV6(T0TestBase):
                                            ipv6_src=ip_src,
                                            tcp_dport= dst_port,
                                            ipv6_hlim=63) 
-
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             rcv_idx = verify_any_packet_any_port(
                 self, [exp_pkt1, exp_pkt2, exp_pkt3], recv_dev_port_idxs)
@@ -1349,7 +1351,7 @@ class ReaAddLagEcmpTestV6(T0TestBase):
                                            ipv6_src=ip_src,
                                            tcp_dport= dst_port,
                                            ipv6_hlim=63) 
-
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             rcv_idx = verify_any_packet_any_port(
                 self, [exp_pkt1, exp_pkt2, exp_pkt3, exp_pkt4], recv_dev_port_idxs)
@@ -1420,7 +1422,7 @@ class EcmpLagDisableTestV4(T0TestBase):
                                          ip_id=105,
                                          ip_ttl=63)
 
-
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             verify_no_packet_any(self, exp_pkt1, self.dut.lag_list[0].member_port_indexs)
 
@@ -1491,7 +1493,7 @@ class EcmpLagDisableTestV6(T0TestBase):
                                            ipv6_src=ip_src,
                                            tcp_dport= dst_port,
                                            ipv6_hlim=63)
-      
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             verify_no_packet_any(self, exp_pkt1, self.dut.lag_list[0].member_port_indexs)
 
@@ -1563,7 +1565,7 @@ class EcmpIngressDisableTestV4(T0TestBase):
                                          ip_id=105,
                                          ip_ttl=63)
 
-
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             verify_no_packet_any(self, exp_pkt1, self.dut.lag_list[0].member_port_indexs)
 
@@ -1630,7 +1632,7 @@ class EcmpIngressDisableTestV6(T0TestBase):
                                            ipv6_src=ip_src,
                                            tcp_dport= dst_port,
                                            ipv6_hlim=63)
-      
+            self.dataplane.flush()
             send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
             verify_no_packet_any(self, exp_pkt1, self.dut.lag_list[0].member_port_indexs)
 

--- a/test/sai_test/sai_fdb_test.py
+++ b/test/sai_test/sai_fdb_test.py
@@ -59,7 +59,7 @@ class L2PortForwardingTest(T0TestBase):
                                         vlan_vid=10,
                                         ip_id=101,
                                         ip_ttl=64)
-
+                self.dataplane.flush()
                 send_packet(
                     self, send_port.dev_port_index, pkt)
                 verify_packet(

--- a/test/sai_test/sai_lag_test.py
+++ b/test/sai_test/sai_lag_test.py
@@ -117,6 +117,7 @@ class LoadbalanceOnSrcPortTest(T0TestBase):
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 rcv_idx, _ = verify_packet_any_port(
                     self, exp_pkt, self.recv_dev_port_idxs)
@@ -173,6 +174,7 @@ class LoadbalanceOnDesPortTest(T0TestBase):
                                             tcp_dport=des_port,
                                             ip_id=105,
                                             ip_ttl=63)
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 rcv_idx, _ = verify_packet_any_port(
                     self, exp_pkt, self.recv_dev_port_idxs)
@@ -226,6 +228,7 @@ class LoadbalanceOnSrcIPTest(T0TestBase):
                                             ip_src=self.servers[1][i].ipv4,
                                             ip_id=105,
                                             ip_ttl=63)
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 rcv_idx, _ = verify_packet_any_port(
                     self, exp_pkt, self.recv_dev_port_idxs)
@@ -280,6 +283,7 @@ class LoadbalanceOnDesIPTest(T0TestBase):
                                             ip_src=self.servers[1][1].ipv4,
                                             ip_id=105,
                                             ip_ttl=63)
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 rcv_idx, _ = verify_packet_any_port(
                     self, exp_pkt, self.recv_dev_port_idxs)
@@ -354,6 +358,7 @@ class LoadbalanceOnProtocolTest(T0TestBase):
                                                  ip_src=self.servers[1][1].ipv4,
                                                  ip_id=105,
                                                  ip_ttl=63)
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 rcv_idx, _ = verify_packet_any_port(
                     self, exp_pkt, self.recv_dev_port_idxs)
@@ -416,6 +421,7 @@ class DisableEgressTest(T0TestBase):
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 rcv_idx, _ = verify_packet_any_port(
                     self, exp_pkt, self.recv_dev_port_idxs)
@@ -445,6 +451,7 @@ class DisableEgressTest(T0TestBase):
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 if src_port in exp_drop:
                     verify_no_packet(self, exp_pkt, self.get_dev_port_index(18))
@@ -508,6 +515,7 @@ class DisableIngressTest(T0TestBase):
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[18].dev_port_index, pkt)
                 verify_packet(self, exp_pkt, self.dut.port_obj_list[1].dev_port_index)
             # git disable ingress of lag member: port18
@@ -532,6 +540,7 @@ class DisableIngressTest(T0TestBase):
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[18].dev_port_index, pkt)
                 verify_no_packet(self, exp_pkt, self.dut.port_obj_list[1].dev_port_index)
         finally:
@@ -584,6 +593,7 @@ class RemoveLagMemberTest(T0TestBase):
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 verify_packet_any_port(
                     self, exp_pkt, self.recv_dev_port_idxs)
@@ -607,6 +617,7 @@ class RemoveLagMemberTest(T0TestBase):
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 verify_no_packet(self, exp_pkt, self.get_dev_port_index(18))
             self.lag_configer.create_lag_member(lag_obj=self.servers[11][1].l3_lag_obj,
@@ -662,6 +673,7 @@ class AddLagMemberTest(T0TestBase):
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 verify_packet_any_port(
                     self, exp_pkt, self.recv_dev_port_idxs)
@@ -685,6 +697,7 @@ class AddLagMemberTest(T0TestBase):
                                             tcp_sport=src_port,
                                             ip_id=105,
                                             ip_ttl=63)
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 rcv_idx, _ = verify_packet_any_port(
                     self, exp_pkt, self.recv_dev_port_idxs)
@@ -729,6 +742,7 @@ class IndifferenceIngressPortTest(T0TestBase):
             exp_port_idx = -1
             exp_port_list = self.get_dev_port_indexes(self.servers[11][1].l3_lag_obj.member_port_indexs)
             for i in range(1, 9):
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[i].dev_port_index, pkt)
                 if exp_port_idx == -1:
                     exp_port_idx, _ = verify_packet_any_port(

--- a/test/sai_test/sai_route_test.py
+++ b/test/sai_test/sai_route_test.py
@@ -55,6 +55,7 @@ class RouteRifTest(T0TestBase):
                                             ip_dst=self.servers[12][i].ipv4,
                                             ip_id=105,
                                             ip_ttl=63)
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[5].dev_port_index, pkt)
                 verify_packet_any_port(self, exp_pkt, self.recv_dev_port_idxs)
                 print("received packet with dst_ip:{} on one of lag2 member".format(self.servers[12][i].ipv4))
@@ -94,6 +95,7 @@ class RouteRifv6Test(T0TestBase):
                                                  eth_dst=self.servers[12][i].l3_lag_obj.neighbor_mac,
                                                  ipv6_dst=self.servers[12][i].ipv6,
                                                  ipv6_hlim=63)
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[5].dev_port_index, pkt_v6)
                 verify_packet_any_port(self, exp_pkt_v6, self.recv_dev_port_idxs)
                 print("received packet with dst_ip:{} on one of lag2 member".format(self.servers[12][i].ipv6))
@@ -1012,6 +1014,7 @@ class RemoveRouteTest(T0TestBase):
                                             ip_dst=self.servers[12][i].ipv4,
                                             ip_id=105,
                                             ip_ttl=63)
+                self.dataplane.flush()
                 send_packet(self, self.dut.port_obj_list[5].dev_port_index, pkt)
                 verify_no_other_packets(self)
         finally:

--- a/test/sai_test/sai_vlan_test.py
+++ b/test/sai_test/sai_vlan_test.py
@@ -57,7 +57,7 @@ class Vlan_Domain_Forwarding_Test(T0TestBase):
                                         vlan_vid=10,
                                         ip_id=101,
                                         ip_ttl=64)
-
+                self.dataplane.flush()
                 send_packet(
                     self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 verify_packet(
@@ -74,6 +74,7 @@ class Vlan_Domain_Forwarding_Test(T0TestBase):
                                         vlan_vid=20,
                                         ip_id=101,
                                         ip_ttl=64)
+                self.dataplane.flush()
                 send_packet(
                     self, self.dut.port_obj_list[9].dev_port_index, pkt)
                 verify_packet(
@@ -111,6 +112,7 @@ class UntagAccessToAccessTest(T0TestBase):
                                         eth_src=self.servers[1][1].mac,
                                         ip_id=101,
                                         ip_ttl=64)
+                self.dataplane.flush()
                 send_packet(
                     self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 verify_packet(
@@ -124,6 +126,7 @@ class UntagAccessToAccessTest(T0TestBase):
                                         eth_src=self.servers[1][9].mac,
                                         ip_id=101,
                                         ip_ttl=64)
+                self.dataplane.flush()
                 send_packet(
                     self, self.dut.port_obj_list[9].dev_port_index, pkt)
                 verify_packet(
@@ -162,6 +165,7 @@ class MismatchDropTest(T0TestBase):
                                         vlan_vid=20,
                                         ip_id=101,
                                         ip_ttl=64)
+                self.dataplane.flush()
                 send_packet(
                     self, self.dut.port_obj_list[9].dev_port_index, pkt)
                 verify_no_other_packets(self, timeout=2)
@@ -174,6 +178,7 @@ class MismatchDropTest(T0TestBase):
                                         vlan_vid=10,
                                         ip_id=101,
                                         ip_ttl=64)
+                self.dataplane.flush()
                 send_packet(
                     self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 verify_no_other_packets(self, timeout=2)
@@ -211,6 +216,7 @@ class TaggedFrameFilteringTest(T0TestBase):
                                         vlan_vid=10,
                                         ip_id=101,
                                         ip_ttl=64)
+                self.dataplane.flush()
                 send_packet(
                     self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 verify_no_other_packets(self, timeout=1)
@@ -249,6 +255,7 @@ class UnTaggedFrameFilteringTest(T0TestBase):
                                         eth_src=self.servers[1][1].mac,
                                         ip_id=101,
                                         ip_ttl=64)
+                self.dataplane.flush()
                 send_packet(
                     self, self.dut.port_obj_list[1].dev_port_index, pkt)
                 verify_no_other_packets(self, timeout=1)


### PR DESCRIPTION
Fix Failed cases by add dataplane flush with time comsuming verify.

For some long time running cases(within a loop) there might be some noise from network, and the noise packet might impact the test result, in order to reduce the impact, add a dataplance flush before send the packet to elimit the noice.

Test Done
DUT test

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>