### PR TITLE
[Saithrift][cherry-pick]fix a compile issue when build docker-syncd-brcm-dnx-rpc.gz

### DIFF
--- a/test/saithrift/Makefile
+++ b/test/saithrift/Makefile
@@ -3,7 +3,7 @@ CXX = $(CROSS_COMPILE)g++
 SAI_PREFIX = /usr
 SAI_HEADER_DIR ?= $(SAI_PREFIX)/include/sai
 SAI_HEADERS = $(SAI_HEADER_DIR)/sai*.h
-CFLAGS = -I$(SAI_HEADER_DIR) -I. -std=c++11
+CFLAGS = -I$(SAI_HEADER_DIR) -I. -I../../experimental -std=c++11
 ifeq ($(DEBUG),1)
 CFLAGS += -O0 -ggdb
 endif


### PR DESCRIPTION
fix a compile issue when building docker-syncd-brcm-dnx-rpc.gz

Add dependence for ``experimental``
```
/usr/include/sai/saiobject.h:40:10: fatal error: saiexperimentalbmtor.h: No such file or directory
   40 | #include <saiexperimentalbmtor.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~
```

Test done
https://github.com/sonic-net/sonic-buildimage/pull/12662