### PR TITLE
[sai-ptf][cherry-pick]Add thr missing API into saithriftv2 missing for syncd (#1484)

### DIFF
--- a/meta/sai_rpc_frontend.cpp
+++ b/meta/sai_rpc_frontend.cpp
@@ -939,6 +939,16 @@ int start_p4_sai_thrift_rpc_server(char *port) {
 }
 
 /**
+ * @brief Start Thrift RPC server Wrapper
+ */
+int start_sai_thrift_rpc_server(int port)
+{
+    static char port_str[10];
+    snprintf(port_str, sizeof(port_str), "%d", port);
+    return start_p4_sai_thrift_rpc_server(port_str);
+}
+
+/**
  * @brief Stop Thrift RPC server
  */
 int stop_p4_sai_thrift_rpc_server(void) {

--- a/test/saithriftv2/src/saiserver.cpp
+++ b/test/saithriftv2/src/saiserver.cpp
@@ -266,13 +266,6 @@ void handleInitScript(const std::string& initScript)
     system(initScript.c_str());
 }
 
-int start_sai_thrift_rpc_server(int port)
-{
-    static char port_str[10];
-    snprintf(port_str, sizeof(port_str), "%d", port);
-    return start_p4_sai_thrift_rpc_server(port_str);
-}
-
 int
 main(int argc, char* argv[])
 {

--- a/test/saithriftv2/src/switch_sai_rpc_server.h
+++ b/test/saithriftv2/src/switch_sai_rpc_server.h
@@ -1,3 +1,4 @@
 extern "C" {
 int start_p4_sai_thrift_rpc_server(char *port);
+int start_sai_thrift_rpc_server(int port);
 }


### PR DESCRIPTION
saithriftv1 offers start_sai_thrift_rpc_server API to start the saithrift server and syncd is currently using that API https://github.com/Azure/sonic-sairedis/blob/master/syncd/syncd_main.cpp#L60

But this API is missing from the for saithriftv2.

Made the relevant changes to provide a similar API for saithriftv2 library

The start_sai_thrift_rpc_server API currently resides in saiserver.cpp which is not included in librpcserver.a and is not available for the users of the static library. Thus moved the function definition into sai_rpc_frontend.cpp for including it in the static library.

Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>