### PR TITLE
[sai-port] Fixed port autoneg status attr description

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -1755,7 +1755,8 @@ typedef enum _sai_port_attr_t
     /**
      * @brief Attribute data for #SAI_PORT_ATTR_AUTO_NEG_STATUS
      *
-     * Auto negotiation (AN) done state: 0 for AN in progress, 0 for AN done
+     * Auto negotiation (AN) done state: 0 for AN in progress, 1 for AN done
+     * If auto negotiation is off, the returned value should be 0.
      *
      * @type bool
      * @flags READ_ONLY


### PR DESCRIPTION
Updating the comment for port attribute SAI_PORT_ATTR_AUTO_NEG_STATUS to explicitly define its usage.

* Auto negotiation (AN) done state: 0 for AN in progress, 1 for AN done
* If auto negotiation is off, the returned value should be 0.

Signed-off-by: Vitalii Bylinka <vitaliix.bylinka@intel.com>