### PR TITLE
[SAI-PTF]Fix issue when transfer make parameter GEN_SAIRPC_OPTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test:
 	make -C test
 
 saithrift-build:
-	SAIRPC_EXTRA_LIBS="$(SAIRPC_EXTRA_LIBS)" GEN_SAIRPC_OPTS=$(GEN_SAIRPC_OPTS) make -C $(SAITHRIFT_PATH)
+	SAIRPC_EXTRA_LIBS="$(SAIRPC_EXTRA_LIBS)" GEN_SAIRPC_OPTS="$(GEN_SAIRPC_OPTS)" make -C $(SAITHRIFT_PATH)
 
 saithrift-install: saithrift-build
 	make -C $(SAITHRIFT_PATH) install


### PR DESCRIPTION
Fix issue when transfer make param GEN_SAIRPC_OPTS with space in it

when transfer GEN_SAIRPC_OPTS with multi parameters in it and use the space to split it, there is a issue for translate from build system to actual make system.
```
--adapter_logger --skip_error=-2
```

add quota when transfer the parameter

Test Done:
Verified in local container
Verified in build system

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>