### PR TITLE
[master][SAI-PTF]Add return value in the SAI-PTF log

### DIFF
--- a/meta/templates/sai_adapter_utils.tt
+++ b/meta/templates/sai_adapter_utils.tt
@@ -235,7 +235,10 @@ def invocation_logger(func):
         logging.info("sai_adapter_invoke func:[{}] args: [{}]".format(func.__name__, args_dict))
 
         args_values = args_dict.values()
-        return func(*args, **kwargs)
+
+        retval = func(*args, **kwargs)
+        logging.info("sai_adapter_return func:[{}] retval:[{}]".format(func.__name__, repr(retval)))
+        return retval
  
     return inner_logger
 [%- END -%]

--- a/ptf/utest/MockClient.py
+++ b/ptf/utest/MockClient.py
@@ -1,6 +1,17 @@
+import logging
+try:
+    from meta.sai_adapter import *
+except ImportError:
+    from sai_thrift.sai_adapter import *
+
 class MockSuccessClient():
     
     def sai_thrift_remove_acl_table(self, var):
+        logging.info("sai_thrift_remove_acl_table invoked")
+        # e = sai_thrift_exception()
+        # e.status = -2
+        # raise e
+
         return 0
     
     def sai_thrift_create_switch(client,
@@ -88,4 +99,21 @@ class MockSuccessClient():
                              qos_tc_and_color_to_mpls_exp_map=None,
                              failover_config_mode=None,
                              tunnel_objects_list=None):
+        logging.info("sai_thrift_create_switch invoked")
         return 0
+
+
+    def sai_thrift_get_acl_table_attribute(client, 
+                                            oid,
+                                            attr_list):
+        logging.info("sai_thrift_get_acl_table_attribute invoked")
+        attr_list = []
+        attribute1 = sai_thrift_attribute_t(id=SAI_ACL_TABLE_ATTR_ACL_STAGE)
+        attribute1.value = sai_thrift_attribute_value_t()
+        attribute = sai_thrift_attribute_t(id=SAI_ACL_TABLE_ATTR_ACL_STAGE, value=attribute1.value)
+        attr_list.append(attribute)
+
+
+        attr_lists = sai_thrift_attribute_list_t(attr_list=attr_list)
+        attr_lists.attr_list = attr_list
+        return attr_lists

--- a/ptf/utest/TemplateTest.py
+++ b/ptf/utest/TemplateTest.py
@@ -42,6 +42,8 @@ class TestAdapterLogger(BasicMockedTest):
                                  init_switch=True, 
                                  hardware_access_bus="11:11:11:11:11:11")
         self.check_file_contains(LOG_FILE_PATH, 'hardware_access_bus')
+        sai_thrift_get_acl_table_attribute(self.client, acl_table_oid=1, acl_stage=1)
+        self.check_file_contains(LOG_FILE_PATH, 'SAI_ACL_TABLE_ATTR_ACL_STAGE')
         
     
     def check_file_contains(self, file, content):


### PR DESCRIPTION
Why
In order to track the SAI-API result and add the return value for each SAI_thrift api.

How
In sai_adapter, use the invocation_logger, log the return value when sai_thrift API returned

Test:
Unit test and DUT test

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>