### PR TITLE
[SAI-PTF] API Logger - reformat dict in return value

### DIFF
--- a/meta/templates/sai_adapter_utils.tt
+++ b/meta/templates/sai_adapter_utils.tt
@@ -237,7 +237,14 @@ def invocation_logger(func):
         args_values = args_dict.values()
 
         retval = func(*args, **kwargs)
-        logging.info("sai_adapter_return func:[{}] retval:[{}]".format(func.__name__, repr(retval)))
+        # Base on some vendor's requirement, 
+        # need to convert all the values in the dict to a string
+        retDict = eval(repr(retval))
+        if type(retDict) is dict:
+            retDict = { key:str(value) for (key,value) in retDict.items()}
+            logging.info("sai_adapter_return func:[{}] retval:[{}]".format(func.__name__, retDict))
+        else:
+            logging.info("sai_adapter_return func:[{}] retval:[{}]".format(func.__name__, repr(retval)))
         return retval
  
     return inner_logger


### PR DESCRIPTION
Why
Base on some requirement, when logging the return value is a dict, need return the value for each key as a string.

For example,  returning this.
```
 "[{
'client': <sai_thrift.sai_rpc.Client object at 0x7fd9b46861d0>,
'port_oid': 4294967303,
'hw_lane_list': sai_thrift_object_list_t(count=100, idlist=[1,2,34])
}]"
```
 it returned as (see the ' around the value too below)
 ```
"[{
'client': '<sai_thrift.sai_rpc.Client object at 0x7fd9b46861d0>', 'port_oid': '4294967303',
'hw_lane_list': 'sai_thrift_object_list_t(count=100, idlist=[1,2,34])' }]"
```

How
Convert the dict value to string

Test:
Unit test and DUT test

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>