### PR TITLE
[SAI-PTF] API Logger - reformat arg values

### DIFF
--- a/meta/templates/sai_adapter_utils.tt
+++ b/meta/templates/sai_adapter_utils.tt
@@ -232,6 +232,7 @@ def invocation_logger(func):
 
         args_dict = dict(zip(args_name, args))
         args_dict.update(kwargs)
+        args_dict = { key:str(value) for (key,value) in args_dict.items()}
         logging.info("sai_adapter_invoke func:[{}] args: [{}]".format(func.__name__, args_dict))
 
         args_values = args_dict.values()


### PR DESCRIPTION
Why
Base on some requirement, when logging the arg values, need return the value for each key as a string.

For example,  returning this.
```
sai_adapter_invoke func:[sai_thrift_create_route_entry] args: [{'client': <sai_thrift.sai_rpc.Client object at 0x7f9e07154438>, 'route_entry': sai_thrift_route_entry_t(switch_id=None, vr_id=12884901888, destination=sai_thrift_ip_prefix_t(addr_family=1, addr=sai_thrift_ip_addr_t(ip4=None, ip6='0000:0000:0000:0000:0000:0000:0000:0000'), mask=sai_thrift_ip_addr_t(ip4=None, ip6='0000:0000:0000:0000:0000:0000:0000:0000'))), 'packet_action': 0}]
```
 Turn into
 ```
sai_adapter_invoke func:[sai_thrift_create_route_entry] args: [{'client': '<sai_thrift.sai_rpc.Client object at 0x7f9e07154438>', 'route_entry': 'sai_thrift_route_entry_t(switch_id=None, vr_id=12884901888, destination=sai_thrift_ip_prefix_t(addr_family=1, addr=sai_thrift_ip_addr_t(ip4=None, ip6='0000:0000:0000:0000:0000:0000:0000:0000'), mask=sai_thrift_ip_addr_t(ip4=None, ip6='0000:0000:0000:0000:0000:0000:0000:0000')))', 'packet_action': '0'}]
```

How
Convert the dict value to string

Test:
Unit test and DUT test

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>