### PR TITLE
Add ACL table attribute to specify Dst IPv6 valid bits

### DIFF
--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -1429,6 +1429,44 @@ typedef enum _sai_acl_table_attr_t
     SAI_ACL_TABLE_ATTR_AVAILABLE_ACL_COUNTER,
 
     /**
+     * @brief Start of Table Match valid bits
+     *
+     * The valid bits specify the bits of match field that should be
+     * included in the lookup key. If a match field does not have
+     * valid bits specified, all bits in the field are valid.
+     *
+     * For tables implemented using Exact Match, there is no further
+     * key masking supported in table entries. The mask for such
+     * entries needs to be set to all 1s.
+     */
+    SAI_ACL_TABLE_ATTR_FIELD_VALID_BITS_START = 0x00003000,
+
+    /**
+     * @brief Src IPv6 Valid bits
+     *
+     * @type sai_acl_field_data_mask_t sai_ip6_t
+     * @flags CREATE_ONLY
+     * @default ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+     * @validonly SAI_ACL_TABLE_ATTR_FIELD_SRC_IPV6 == true
+     */
+    SAI_ACL_TABLE_ATTR_FIELD_VALID_BITS_SRC_IPV6 = SAI_ACL_TABLE_ATTR_FIELD_VALID_BITS_START,
+
+    /**
+     * @brief Dst IPv6 Valid bits
+     *
+     * @type sai_acl_field_data_mask_t sai_ip6_t
+     * @flags CREATE_ONLY
+     * @default ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+     * @validonly SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6 == true
+     */
+    SAI_ACL_TABLE_ATTR_FIELD_VALID_BITS_DST_IPV6 = SAI_ACL_TABLE_ATTR_FIELD_VALID_BITS_START + 1,
+
+    /**
+     * @brief End of Table Match Field Mask
+     */
+    SAI_ACL_TABLE_ATTR_FIELD_VALID_BITS_END = SAI_ACL_TABLE_ATTR_FIELD_VALID_BITS_DST_IPV6,
+
+    /**
      * @brief End of ACL Table attributes
      */
     SAI_ACL_TABLE_ATTR_END,

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1320,6 +1320,12 @@ typedef union _sai_attribute_value_t
      */
     sai_acl_action_data_t aclaction;
 
+    /**
+     * @passparam meta
+     * @validonly meta->isaclmask == true
+     */
+    sai_acl_field_data_mask_t aclmask;
+
     /** @validonly meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_ACL_CAPABILITY */
     sai_acl_capability_t aclcapability;
 

--- a/meta/saimetadatatypes.h
+++ b/meta/saimetadatatypes.h
@@ -1144,6 +1144,13 @@ typedef struct _sai_attr_metadata_t
     bool                                        isaclaction;
 
     /**
+     * @brief Determines whether attribute is ACL mask
+     *
+     * Can only be set for ACL table mask
+     */
+    bool                                        isaclmask;
+
+    /**
      * @brief Determines whether attribute is mandatory on create
      */
     bool                                        ismandatoryoncreate;

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -1909,6 +1909,14 @@ void check_attr_acl_fields(
 
             }
 
+            if (md->objecttype == SAI_OBJECT_TYPE_ACL_TABLE &&
+                    md->attrid >= SAI_ACL_TABLE_ATTR_FIELD_VALID_BITS_START &&
+                    md->attrid  <= SAI_ACL_TABLE_ATTR_FIELD_VALID_BITS_END)
+            {
+                break;
+
+            }
+
             if (md->objecttype == SAI_OBJECT_TYPE_UDF_MATCH)
             {
                 /*
@@ -2081,22 +2089,19 @@ void check_attr_acl_conditions(
 
     /*
      * Purpose of this check is to find out if there is any condition in
-     * attributes that depends on acl entry object field or actions since such
+     * attributes that depends on acl entry object actions since such
      * dependency has no sense.
      */
 
     if (md->objecttype == SAI_OBJECT_TYPE_ACL_TABLE)
     {
-        check_condition_in_range(md, md->validonlylength, md->validonly,
-                SAI_ACL_TABLE_ATTR_FIELD_START, SAI_ACL_TABLE_ATTR_FIELD_END);
-
         check_condition_in_range(md, md->conditionslength, md->conditions,
                 SAI_ACL_TABLE_ATTR_FIELD_START, SAI_ACL_TABLE_ATTR_FIELD_END);
 
         if (md->attrid >= SAI_ACL_TABLE_ATTR_FIELD_START &&
                 md->attrid >= SAI_ACL_TABLE_ATTR_FIELD_END)
         {
-            if (md->conditionslength != 0 || md->validonlylength != 0)
+            if (md->conditionslength != 0)
             {
                 META_MD_ASSERT_FAIL(md, "acl table field has conditions, not allowed");
             }


### PR DESCRIPTION
This diff adds an ACL table parameter to specify the valid bits of Src/Dst IPv6 to use in ACL table creation. There are two main uses cases.

1. For TCAM ACLs, this attribute allows creation of table with shorter keys as users can specify a lower number of bits instead of whole 128 bits
2. For exact match lookup (ref PR 1717), masks cannot be specified at ACL entry level since all entries in a table need to have the same mask. The new attribute allows users to specify the mask for exact match tables.    

Signed-off-by: Midhun Somasundaran <msomasundaran@meta.com>, Shrikrishna Khare <skhare@meta.com>