### PR TITLE
[SAI-PTF]Remove Draft tag from cases on enabled cases

### DIFF
--- a/ptf/saineighbor.py
+++ b/ptf/saineighbor.py
@@ -22,7 +22,6 @@ from ptf.thriftutils import *
 from sai_base_test import *
 
 
-@group("draft")
 class NeighborAttrIpv6TestHelper(PlatformSaiHelper):
     """
     Neighbor entry attributes IPv6 tests class
@@ -62,7 +61,6 @@ class NeighborAttrIpv6TestHelper(PlatformSaiHelper):
         super(NeighborAttrIpv6TestHelper, self).tearDown()
 
 
-@group("draft")
 class noHostRouteIpv6NeighborTest(NeighborAttrIpv6TestHelper):
     '''
     Verifies if IPv6 host route is not created according to
@@ -97,7 +95,6 @@ class noHostRouteIpv6NeighborTest(NeighborAttrIpv6TestHelper):
         super(noHostRouteIpv6NeighborTest, self).tearDown()
 
 
-@group("draft")
 class noHostRouteIpv6LinkLocalNeighborTest(NeighborAttrIpv6TestHelper):
     '''
     Verifies if host route is not created for link local IPv6 address
@@ -152,7 +149,6 @@ class noHostRouteIpv6LinkLocalNeighborTest(NeighborAttrIpv6TestHelper):
         super(noHostRouteIpv6LinkLocalNeighborTest, self).tearDown()
 
 
-@group("draft")
 class addHostRouteIpv6NeighborTest(NeighborAttrIpv6TestHelper):
     '''
     Verifies if IPv6 host route is created according to
@@ -187,7 +183,6 @@ class addHostRouteIpv6NeighborTest(NeighborAttrIpv6TestHelper):
         super(addHostRouteIpv6NeighborTest, self).tearDown()
 
 
-@group("draft")
 class NeighborAttrIpv4TestHelper(PlatformSaiHelper):
     """
     Neighbor entry attributes IPv4 tests class
@@ -226,7 +221,6 @@ class NeighborAttrIpv4TestHelper(PlatformSaiHelper):
         super(NeighborAttrIpv4TestHelper, self).tearDown()
 
 
-@group("draft")
 class noHostRouteIpv4NeighborTest(NeighborAttrIpv4TestHelper):
     '''
     Verifies if IPv4 host route is not created according to
@@ -262,7 +256,6 @@ class noHostRouteIpv4NeighborTest(NeighborAttrIpv4TestHelper):
         super(noHostRouteIpv4NeighborTest, self).tearDown()
 
 
-@group("draft")
 class addHostRouteIpv4NeighborTest(NeighborAttrIpv4TestHelper):
     '''
     Verifies if IPv4 host route is created according to
@@ -298,7 +291,6 @@ class addHostRouteIpv4NeighborTest(NeighborAttrIpv4TestHelper):
         super(addHostRouteIpv4NeighborTest, self).tearDown()
 
 
-@group("draft")
 class updateNeighborEntryAttributeDstMacAddr(NeighborAttrIpv4TestHelper):
     '''
     Verifies if SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS is updated
@@ -348,7 +340,6 @@ class updateNeighborEntryAttributeDstMacAddr(NeighborAttrIpv4TestHelper):
         super(updateNeighborEntryAttributeDstMacAddr, self).tearDown()
 
 
-@group("draft")
 class addNeighborEntryAttrIPv4addrFamily(NeighborAttrIpv4TestHelper):
     '''
     check NeighborEntryAttrIPaddrFamily is SAI_IP_ADDR_FAMILY_IPV4
@@ -406,7 +397,6 @@ class addNeighborEntryAttrIPv4addrFamily(NeighborAttrIpv4TestHelper):
         super(addNeighborEntryAttrIPv4addrFamily, self).tearDown()
 
 
-@group("draft")
 class addNeighborEntryAttrIPv6addrFamily(NeighborAttrIpv6TestHelper):
     '''
     check NeighborEntryAttrIPaddrFamily is SAI_IP_ADDR_FAMILY_IPV6

--- a/ptf/sainexthop.py
+++ b/ptf/sainexthop.py
@@ -25,7 +25,6 @@ from ptf.thriftutils import *
 from sai_base_test import *
 
 
-@group("draft")
 class L3NexthopTestHelper(PlatformSaiHelper):
     """
     Basic L3 nexthop tests.
@@ -47,7 +46,6 @@ class L3NexthopTestHelper(PlatformSaiHelper):
         super(L3NexthopTestHelper, self).tearDown()
 
 
-@group("draft")
 class removeNexthopTest(L3NexthopTestHelper):
     """
         Test verifies correct nexthop removal.
@@ -119,7 +117,6 @@ class removeNexthopTest(L3NexthopTestHelper):
         super(removeNexthopTest, self).tearDown()
 
 
-@group("draft")
 class cpuNexthopTest(L3NexthopTestHelper):
     '''
         Test verifies nexthop to CPU.
@@ -233,7 +230,6 @@ class cpuNexthopTest(L3NexthopTestHelper):
         super(cpuNexthopTest, self).tearDown()
 
 
-@group("draft")
 class NhopTunnelEncapDecapTestHelper(PlatformSaiHelper):
     '''
         Nexthop tunnel encapsulation and decapsulation tests.
@@ -340,7 +336,6 @@ class NhopTunnelEncapDecapTestHelper(PlatformSaiHelper):
         super(NhopTunnelEncapDecapTestHelper, self).tearDown()
 
 
-@group("draft")
 class l3InterfaceTunnelTest(NhopTunnelEncapDecapTestHelper):
     '''
         Test verifies l3 interface tunnel nexthop.
@@ -429,7 +424,6 @@ class l3InterfaceTunnelTest(NhopTunnelEncapDecapTestHelper):
         super(l3InterfaceTunnelTest, self).tearDown()
 
 
-@group("draft")
 class subPortTunnelTest(NhopTunnelEncapDecapTestHelper):
     '''
         Test verifies subport tunnel nexthop.
@@ -527,7 +521,6 @@ class subPortTunnelTest(NhopTunnelEncapDecapTestHelper):
         super(subPortTunnelTest, self).tearDown()
 
 
-@group("draft")
 class sviTunnelTest(NhopTunnelEncapDecapTestHelper):
     '''
         Test verifies SVI tunnel nexthop.
@@ -656,7 +649,6 @@ class sviTunnelTest(NhopTunnelEncapDecapTestHelper):
         super(sviTunnelTest, self).tearDown()
 
 
-@group("draft")
 class NhopTunnelVNITestHelper(PlatformSaiHelper):
     '''
         Nexthop tunnel VNI tests.
@@ -750,7 +742,6 @@ class NhopTunnelVNITestHelper(PlatformSaiHelper):
         super(NhopTunnelVNITestHelper, self).tearDown()
 
 
-@group("draft")
 class tunnelVniTest(NhopTunnelVNITestHelper):
     '''
         Test verifies correct tunnel VNI behavior.
@@ -999,7 +990,6 @@ class tunnelVniTest(NhopTunnelVNITestHelper):
         super(tunnelVniTest, self).tearDown()
 
 
-@group("draft")
 class tunnelVrfTest(NhopTunnelVNITestHelper):
     '''
         Test verifies correct tunnel behavior with multiple nexthops

--- a/ptf/sainexthopgroup.py
+++ b/ptf/sainexthopgroup.py
@@ -167,7 +167,6 @@ def save_number_of_available_nhg_resources(self, debug=False):
         print_number_of_available_nhg_resources(self)
 
 
-@group("draft")
 class L3IPv4EcmpHostHelper(PlatformSaiHelper):
     """
     Base ECMP tests for IPv4 and ECMP members as regular L3 port RIFs
@@ -249,7 +248,6 @@ class L3IPv4EcmpHostHelper(PlatformSaiHelper):
             super(L3IPv4EcmpHostHelper, self).tearDown()
 
 
-@group("draft")
 class l3SaiNhgSetGetTest(L3IPv4EcmpHostHelper):
     """
     Checks SAI switch ECMP attributes and validates
@@ -404,7 +402,6 @@ class l3SaiNhgSetGetTest(L3IPv4EcmpHostHelper):
         super(l3SaiNhgSetGetTest, self).tearDown()
 
 
-@group("draft")
 class l3IPv4EcmpHostTest(L3IPv4EcmpHostHelper):
     """
     IPv4 ECMP tests with all members which are port RIFs
@@ -470,7 +467,6 @@ class l3IPv4EcmpHostTest(L3IPv4EcmpHostHelper):
     def tearDown(self):
         super(l3IPv4EcmpHostTest, self).tearDown()
 
-@group("draft")
 class L3ipv6EcmpHostHelper(PlatformSaiHelper):
     """
     Basic ECMP tests for IPv6 and regular L3 port RIFs
@@ -551,7 +547,6 @@ class L3ipv6EcmpHostHelper(PlatformSaiHelper):
         super(L3ipv6EcmpHostHelper, self).tearDown()
 
 
-@group("draft")
 class saiL3ipv6EcmpHostTest(L3ipv6EcmpHostHelper):
     """
     IPv6 ECMP tests with all members as regular L3 port RIFs
@@ -609,7 +604,6 @@ class saiL3ipv6EcmpHostTest(L3ipv6EcmpHostHelper):
         super(saiL3ipv6EcmpHostTest, self).tearDown()
 
 
-@group("draft")
 class L3IPv4EcmpLpmTestHelper(PlatformSaiHelper):
     """
     Base ECMP tests with LPM routes for IPv4
@@ -757,7 +751,6 @@ class L3IPv4EcmpLpmTestHelper(PlatformSaiHelper):
         super(L3IPv4EcmpLpmTestHelper, self).tearDown()
 
 
-@group("draft")
 class l3IPv4EcmpLpmTest(L3IPv4EcmpLpmTestHelper):
     """
     Verifies ECMP load balancing with LPM routes configured
@@ -813,7 +806,6 @@ class l3IPv4EcmpLpmTest(L3IPv4EcmpLpmTestHelper):
         super(l3IPv4EcmpLpmTest, self).tearDown()
 
 
-@group("draft")
 class l3Ipv4EcmpLpmAddRemoveNhopTest(L3IPv4EcmpLpmTestHelper):  # to be removed from here
     """
     IPv4 ECMP rebalance test with removal of a nexthop member
@@ -1129,7 +1121,6 @@ class l3Ipv4EcmpLpmAddRemoveNhopTest(L3IPv4EcmpLpmTestHelper):  # to be removed 
                 ecmp_default_hash_seed=ecmp_default_hash_seed)
 
 
-@group("draft")
 class L3IPv6EcmpLagTestHelper(PlatformSaiHelper):
     """
     Base ECMP tests with ECMP members as LAG RIFs
@@ -1382,7 +1373,6 @@ class L3IPv6EcmpLagTestHelper(PlatformSaiHelper):
             self.assertEqual(status, SAI_STATUS_SUCCESS)
 
 
-@group("draft")
 class l3Ipv6EcmpLpmTest(L3IPv6EcmpLagTestHelper):
     """
     Base ECMP tests with LPM routes for IPv6
@@ -1466,7 +1456,6 @@ class l3Ipv6EcmpLpmTest(L3IPv6EcmpLagTestHelper):
         super(l3Ipv6EcmpLpmTest, self).tearDown()
 
 
-@group("draft")
 class l3IPv6EcmpHostTwoLagsTest(L3IPv6EcmpLagTestHelper):
     """
     IPv6 ECMP tests with all members with RIF as LAG
@@ -1527,7 +1516,6 @@ class l3IPv6EcmpHostTwoLagsTest(L3IPv6EcmpLagTestHelper):
         super(l3IPv6EcmpHostTwoLagsTest, self).tearDown()
 
 
-@group("draft")
 class l3IPv6EcmpHostPortLagTest(L3IPv6EcmpLagTestHelper):
     """
     IPv6 ECMP tests with members combination of port and LAG RIFs
@@ -1610,7 +1598,6 @@ class l3IPv6EcmpHostPortLagTest(L3IPv6EcmpLagTestHelper):
         super(l3IPv6EcmpHostPortLagTest, self).tearDown()
 
 
-@group("draft")
 class l3IPv6EcmpHashPortLagTest(L3IPv6EcmpLagTestHelper):
     """
     IPv6 ECMP loads balance tests to check fair share on all members
@@ -1842,7 +1829,6 @@ class l3IPv6EcmpHashPortLagTest(L3IPv6EcmpLagTestHelper):
         super(l3IPv6EcmpHashPortLagTest, self).tearDown()
 
 
-@group("draft")
 class l3IPv6EcmpHostTwoLagsDisabledLagMembersTest(L3IPv6EcmpLagTestHelper):
     """
     IPv6 ECMP tests with LAG RIF and some LAG member in disable state
@@ -1938,7 +1924,6 @@ class l3IPv6EcmpHostTwoLagsDisabledLagMembersTest(L3IPv6EcmpLagTestHelper):
         super(l3IPv6EcmpHostTwoLagsDisabledLagMembersTest, self).tearDown()
 
 
-@group("draft")
 class l3Ipv6EcmpAddRemoveNhopTest(L3IPv6EcmpLagTestHelper):
     """
     IPv6 ECMP rebalance test with removal of a nexthop member
@@ -2109,7 +2094,6 @@ class l3Ipv6EcmpAddRemoveNhopTest(L3IPv6EcmpLagTestHelper):
         super(l3Ipv6EcmpAddRemoveNhopTest, self).tearDown()
 
 
-@group("draft")
 class l3IPv6EcmpHostPortLagSharedMembersTest(L3IPv6EcmpLagTestHelper):
     """
     IPv6 Multiple ECMP with shared nexthop members
@@ -2242,7 +2226,6 @@ class l3IPv6EcmpHostPortLagSharedMembersTest(L3IPv6EcmpLagTestHelper):
         super(l3IPv6EcmpHostPortLagSharedMembersTest, self).tearDown()
 
 
-@group("draft")
 class L3IPv4SVIEcmpTestHelper(PlatformSaiHelper):
     """
     Base ECMP tests for IPv4 and ECMP members as SVI RIFs
@@ -2536,7 +2519,6 @@ class L3IPv4SVIEcmpTestHelper(PlatformSaiHelper):
         super(L3IPv4SVIEcmpTestHelper, self).tearDown()
 
 
-@group("draft")
 class l3IPv4EcmpSVIHostTest(L3IPv4SVIEcmpTestHelper):
     """
     IPv4 ECMP tests with SVI RIF as member
@@ -2634,7 +2616,6 @@ class l3IPv4EcmpSVIHostTest(L3IPv4SVIEcmpTestHelper):
         super(l3IPv4EcmpSVIHostTest, self).tearDown()
 
 
-@group("draft")
 class l3IPv4EcmpSVILagHostTest(L3IPv4SVIEcmpTestHelper):
     """
     IPv4 ECMP tests with Port, LAG and SVI RIFs as nexthop members
@@ -2743,7 +2724,6 @@ class l3IPv4EcmpSVILagHostTest(L3IPv4SVIEcmpTestHelper):
         super(l3IPv4EcmpSVILagHostTest, self).tearDown()
 
 
-@group("draft")
 class L3IPv6SVIEcmpTestHelper(PlatformSaiHelper):
     """
     Base ECMP tests for IPv6 and ECMP members as SVI RIFs
@@ -3077,7 +3057,6 @@ class L3IPv6SVIEcmpTestHelper(PlatformSaiHelper):
         super(L3IPv6SVIEcmpTestHelper, self).tearDown()
 
 
-@group("draft")
 class l3IPv6EcmpSVIHostTest(L3IPv6SVIEcmpTestHelper):
     """
     IPv6 ECMP tests with SVI RIF members
@@ -3176,7 +3155,6 @@ class l3IPv6EcmpSVIHostTest(L3IPv6SVIEcmpTestHelper):
         super(l3IPv6EcmpSVIHostTest, self).tearDown()
 
 
-@group("draft")
 class l3IPv6EcmpSVIPortLagHostTest(L3IPv6SVIEcmpTestHelper):
     """
     IPv6 ECMP tests with Port, LAG and SVI RIFs as ECMP members
@@ -3273,7 +3251,6 @@ class l3IPv6EcmpSVIPortLagHostTest(L3IPv6SVIEcmpTestHelper):
         super(l3IPv6EcmpSVIPortLagHostTest, self).tearDown()
 
 
-@group("draft")
 class L3IPv4EcmpLagTestHelper(PlatformSaiHelper):
     """
     Base ECMP tests common setup and teardown with lag for IPv4
@@ -3458,7 +3435,6 @@ class L3IPv4EcmpLagTestHelper(PlatformSaiHelper):
         super(L3IPv4EcmpLagTestHelper, self).tearDown()
 
 
-@group("draft")
 class L3IPv4EcmpHostTwoLagsTest(L3IPv4EcmpLagTestHelper):
     """
     IPv4 ECMP tests with all LAG RIFs members
@@ -3530,7 +3506,6 @@ class L3IPv4EcmpHostTwoLagsTest(L3IPv4EcmpLagTestHelper):
         super(L3IPv4EcmpHostTwoLagsTest, self).tearDown()
 
 
-@group("draft")
 class L3IPv4EcmpHostPortLagSharedMembersTest(L3IPv4EcmpLagTestHelper):
     """
     IPv4 multiples ECMP with shared nexthop members
@@ -3623,7 +3598,6 @@ class L3IPv4EcmpHostPortLagSharedMembersTest(L3IPv4EcmpLagTestHelper):
         super(L3IPv4EcmpHostPortLagSharedMembersTest, self).tearDown()
 
 
-@group("draft")
 class L3IPv4EcmpHostTwoLagsDisabledLagMembersTest(L3IPv4EcmpLagTestHelper):
     """
     IPv4 ECMP tests with LAG RIF and some LAG member in disable state
@@ -3721,7 +3695,6 @@ class L3IPv4EcmpHostTwoLagsDisabledLagMembersTest(L3IPv4EcmpLagTestHelper):
         super(L3IPv4EcmpHostTwoLagsDisabledLagMembersTest, self).tearDown()
 
 
-@group("draft")
 class L3IPv4EcmpHostPortLagTest(L3IPv4EcmpLagTestHelper):
     """
     IPv4 ECMP load balance tests to check fair share on all members
@@ -3821,7 +3794,6 @@ class L3IPv4EcmpHostPortLagTest(L3IPv4EcmpLagTestHelper):
         super(L3IPv4EcmpHostPortLagTest, self).tearDown()
 
 
-@group("draft")
 class L3IPv4EcmpHashPortLagTest(L3IPv4EcmpLagTestHelper):
     """
     Creates hash object and sends multiple packets
@@ -4052,7 +4024,6 @@ class L3IPv4EcmpHashPortLagTest(L3IPv4EcmpLagTestHelper):
             self.assertEqual(status, SAI_STATUS_SUCCESS)
 
 
-@group("draft")
 class EcmpFGTestHelper(PlatformSaiHelper):
     '''
     ECMP Fine Grain Test cases
@@ -4237,7 +4208,6 @@ class EcmpFGTestHelper(PlatformSaiHelper):
         finally:
             pass
 
-@group("draft")
 class ecmpFGBasicTest(EcmpFGTestHelper):
     '''
     Ecmp FG Basic TCs
@@ -4281,7 +4251,6 @@ class ecmpFGBasicTest(EcmpFGTestHelper):
         super(ecmpFGBasicTest, self).tearDown()
 
 
-@group("draft")
 class ecmpFGAddDelMemTest(EcmpFGTestHelper):
     '''
     Ecmp FG Add & Del member TCs
@@ -4323,7 +4292,6 @@ class ecmpFGAddDelMemTest(EcmpFGTestHelper):
         super(ecmpFGAddDelMemTest, self).tearDown()
 
 
-@group("draft")
 class ecmpFGGrpMemAttrTest(EcmpFGTestHelper):
     '''
     Ecmp FG Member Attribure TCs

--- a/ptf/sairoute.py
+++ b/ptf/sairoute.py
@@ -23,7 +23,6 @@ from ptf.thriftutils import *
 
 from sai_base_test import *
 
-@group("draft")
 class multipleRoutesTest(PlatformSaiHelper):
     '''
     Verify forwarding with multiple route to the same nhop.
@@ -101,7 +100,6 @@ class multipleRoutesTest(PlatformSaiHelper):
         super(multipleRoutesTest, self).tearDown()
 
 
-@group("draft")
 class dropRouteTest(PlatformSaiHelper):
     '''
     Verify drop route.
@@ -156,7 +154,6 @@ class dropRouteTest(PlatformSaiHelper):
         super(dropRouteTest, self).tearDown()
 
 
-@group("draft")
 class routeUpdateTest(PlatformSaiHelper):
     '''
     Verify correct forwarding after route update.
@@ -277,7 +274,6 @@ class routeUpdateTest(PlatformSaiHelper):
         super(routeUpdateTest, self).tearDown()
 
 
-@group("draft")
 class routeIngressRifTest(PlatformSaiHelper):
     '''
     Verify forwarding to ingress rif.
@@ -331,7 +327,6 @@ class routeIngressRifTest(PlatformSaiHelper):
         super(routeIngressRifTest, self).tearDown()
 
 
-@group("draft")
 class emptyECMPGroupTest(PlatformSaiHelper):
     '''
     Verify drop on empty ECMP group.
@@ -370,7 +365,6 @@ class emptyECMPGroupTest(PlatformSaiHelper):
         super(emptyECMPGroupTest, self).tearDown()
 
 
-@group("draft")
 class sviNeighborTest(PlatformSaiHelper):
     '''
     Function verifying correct SVI neighbor forwarding.
@@ -534,7 +528,6 @@ class sviNeighborTest(PlatformSaiHelper):
         super(sviNeighborTest, self).tearDown()
 
 
-@group("draft")
 class cpuForwardTest(PlatformSaiHelper):
     '''
     Function verifying forwading to CPU.
@@ -595,7 +588,6 @@ class cpuForwardTest(PlatformSaiHelper):
         super(cpuForwardTest, self).tearDown()
 
 
-@group("draft")
 class routeNbrColisionTest(PlatformSaiHelper):
     '''
     Verfies if packet is gleaned to CPU when nexthop id is RIF
@@ -756,7 +748,6 @@ class routeNbrColisionTest(PlatformSaiHelper):
         super(routeNbrColisionTest, self).tearDown()
 
 
-@group("draft")
 class L3DirBcastRouteTestHelper(PlatformSaiHelper):
     '''
     Verifies direct broadcast routing
@@ -995,7 +986,6 @@ class L3DirBcastRouteTestHelper(PlatformSaiHelper):
         finally:
             pass
 
-@group("draft")
 class DirBcastGleanAndForwardTest(L3DirBcastRouteTestHelper):
     """
     Verifies if frame is frowarded to cpu when there is only route without
@@ -1095,7 +1085,6 @@ class DirBcastGleanAndForwardTest(L3DirBcastRouteTestHelper):
         super(DirBcastGleanAndForwardTest, self).tearDown()
 
 
-@group("draft")
 class DirBcastForwardTest(L3DirBcastRouteTestHelper):
     """
     Verifies if frame is forwarded properly when configuration is correct


### PR DESCRIPTION
Why
For cases already running on the pipeline, remove Draft tag from cases on enabled cases for code scanning

How
Remove Draft tag from cases on enabled cases

Verify
Pipeline test and code scanning

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>