### PR TITLE
[SAI-PTF]Support dynamic port init

### DIFF
--- a/ptf/config/port_config_ini_loader.py
+++ b/ptf/config/port_config_ini_loader.py
@@ -22,6 +22,7 @@ import os
 from os.path import exists
 
 from typing import TYPE_CHECKING
+from typing import List, Dict
 
 DEFAULT_CONFIG_DB = "../resources/port_config.ini"
 
@@ -41,13 +42,13 @@ class PortConfigInILoader():
 
 
         self.file_path = self.__validate_file_path__(file_path)
-        self.ports_config = None
+        self.ports_config: Dict = None
         """
         ports_config dict, use to compatiable with old data module
         """
-        self.portConfigs = None
+        self.portConfigs: List[PortConfig] = None
         """
-        PortConfig object
+        PortConfig object list
         """
 
 

--- a/ptf/platform_helper/brcm_sai_helper.py
+++ b/ptf/platform_helper/brcm_sai_helper.py
@@ -63,7 +63,7 @@ class BrcmSaiHelper(CommonSaiHelper):
             test_obj: the test object
         """
         super().__init__(*args, **kwargs)
-        self.port_configer = None
+        self.port_configer: PortConfiger = None
 
         # port
         self.default_trap_group = None
@@ -196,8 +196,8 @@ class BrcmSaiHelper(CommonSaiHelper):
 
     def config_port(self):
 
-        self.port_list = self.port_configer.get_port_list()
-        self.port_configer.get_local_mapped_ports()
+        self.port_list = self.port_configer.get_lane_sorted_port_list()
+        self.port_configer.generate_port_obj_list_by_interface_config()
         self.port_configer.assign_port_config(self.port_conifg_ini_loader.portConfigs)
         #compatiable with portx variables
         self.port_configer.set_port_attr(self.port_list)

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -42,7 +42,7 @@ import sai_thrift.sai_adapter as adapter
 
 from config.port_configer import PortConfiger
 from config.config_db_loader import ConfigDBLoader
-from config.port_config_ini_loader import PortConfigInILoader
+from config.port_config_ini_loader import PortConfig, PortConfigInILoader
 
 ROUTER_MAC = '00:77:66:55:44:00'
 THRIFT_PORT = 9092
@@ -331,9 +331,18 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         self.cpu_port_hdl = None
         self.active_ports_no: List = []
         self.port_list: List = []
-        self.port_configer = None
+        self.port_configer: PortConfiger = None
         self.config_db_loader: ConfigDBLoader = None
         self.port_conifg_ini_loader: PortConfigInILoader = None
+        # TODO: Below two attributes should be move to port_configer
+        self.ports_config: Dict = None
+        """
+        ports_config dict, use to compatiable with old data module
+        """
+        self.portConfigs: List[PortConfig] = None
+        """
+        PortConfig object List
+        """
 
 
     def set_logger_name(self):

--- a/ptf/saisanity.py
+++ b/ptf/saisanity.py
@@ -296,13 +296,24 @@ class L2SanityTest(PlatformSaiHelper):
 
     def test_forwad_to_each_port(self):
         try:
-            for index in range(1, len(self.port_list)):
+            for index in range(2, len(self.port_list), 2):
                 self.dataplane.flush()
                 print("Check port{} forwarding...".format(index))
+                # example for debug with pdb and open a sai shell
+                # import pdb
+                # pdb.set_trace()
+                # note, this method to open the shell 
+                # is not support on diff platform, diff asic
+                # in some cases, the shell might need to be
+                # opened from cmd line.
+                # Then, just set the break point by pdb.set_trace()
+                # and open shell in CLI, then start debugging with sai shell.
+                # self.shell()
                 target_pkt = getattr(self, 'pkt%s' % index)
                 exp_pkt = getattr(self, 'exp_pkt%s' % index)
                 send_packet(self, self.dev_port0, target_pkt)
                 verify_packet(self, exp_pkt, index)
+                #verify_packet_any_port(self, exp_pkt, range(1,len(self.port_list)))
         finally:
             pass
 
@@ -324,7 +335,7 @@ class L2SanityTest(PlatformSaiHelper):
             send_packet(
                 self, 1, pkt)
             received_index = verify_each_packet_on_multiple_port_lists(
-                self, [pkt], [range(2,31)])
+                self, [pkt], [range(2, len(self.port_list))])
         finally:
             pass
 

--- a/test/sai_test/config/port_config_ini_loader.py
+++ b/test/sai_test/config/port_config_ini_loader.py
@@ -22,6 +22,7 @@ import os
 from os.path import exists
 
 from typing import TYPE_CHECKING
+from typing import List, Dict
 
 DEFAULT_CONFIG_DB = "../resources/port_config.ini"
 
@@ -41,13 +42,13 @@ class PortConfigInILoader():
 
 
         self.file_path = self.__validate_file_path__(file_path)
-        self.ports_config = None
+        self.ports_config: Dict = None
         """
         ports_config dict, use to compatiable with old data module
         """
-        self.portConfigs = None
+        self.portConfigs: List[PortConfig] = None
         """
-        PortConfig object
+        PortConfig object list
         """
 
 


### PR DESCRIPTION
## Why
In some situations, some of the ports might not available, but those ports can be listed from devices, and in the test, those tests intented not to be tested. We need some mechanism to skip the un-available port during port init process. 

Current solution is we will init the port base on the port map configurations (from parameters or port map file). Cause there are some data structure index@ptf-ndev data structure, and those port map to remove dut ndev in sequence. Then we will just init the available ones.

After this change we can use port_config.ini to define actual available port like
for example just need four ports
> Note, there is just a command sample, in real cases, it always need at least 32 ports.
```
# name           lanes                alias      speed       index
Ethernet0        65,66,67,68          etp1       100000      1
Ethernet4        69,70,71,72          etp2       100000      2
Ethernet8        73,74,75,76          etp3       100000      3
Ethernet12       77,78,79,80          etp4       100000      4
```
Then, command to run cases
```
ptf --test-dir ptf saisanity.L2SanityTest  --interface '0-0@eth0' --interface '0-1@eth1' --interface '0-2@eth2' --interface '0-3@eth3'  --relax --xunit --xunit-dir /tmp/sai_qualify/test_results_tmp "--test-params=thrift_server='$DUTIP';port_config_ini='/tmp/sai_qualify/resources/port_config.ini';config_db_json='/tmp/sai_qualify/resources/config_db.json'"
```
> note, cause currenrt cases already used ports on some data structure. With the data structure, it expects the index num in local dev port (index@ptf-ndev) are continuously, in 1,2,3,4..., not 1,3,5.... Then even after this code enhancement, we cannot support the jumped index number.

> Todo, design some mechanism to support arbitariry ports init and usage.

## How
Load the actual port list from port_config.ini
Base on the num of port in this config file, init the port
Other port config like bridge port also depends on the actual port number

## Verify
```
    ptf --test-dir ptf saisanity.L2SanityTest  --interface '0-0@eth0' --interface '0-1@eth1' --interface '0-2@eth2' --interface '0-3@eth3' --interface '0-4@eth4' --interface '0-5@eth5' --interface '0-6@eth6' --interface '0-7@eth7' --interface '0-8@eth8' --interface '0-9@eth9' --interface '0-10@eth10' --interface '0-11@eth11' --interface '0-12@eth12' --interface '0-13@eth13' --interface '0-14@eth14' --interface '0-15@eth15' --interface '0-16@eth16' --interface '0-17@eth17' --interface '0-18@eth18' --interface '0-19@eth19' --interface '0-20@eth20' --interface '0-21@eth21' --interface '0-22@eth22' --interface '0-23@eth23' --interface '0-24@eth24' --interface '0-25@eth25' --interface '0-26@eth26' --interface '0-27@eth27' --interface '0-28@eth28' --interface '0-29@eth29' --interface '0-30@eth30' --interface '0-31@eth31' --relax --xunit --xunit-dir /tmp/sai_qualify/test_results_tmp "--test-params=thrift_server='$DUTIP';port_config_ini='/tmp/sai_qualify/resources/port_config.ini';config_db_json='/tmp/sai_qualify/resources/config_db.json'"
    
    ptf --test-dir test/sai_test sai_fdb_test.L2PortForwardingTest --relax --xunit --xunit-dir "/tmp/sai_qualify/test_results_tmp" --interface '0-0@eth0' --interface '0-1@eth1' --interface '0-2@eth2' --interface '0-3@eth3' --interface '0-4@eth4' --interface '0-5@eth5' --interface '0-6@eth6' --interface '0-7@eth7' --interface '0-8@eth8' --interface '0-9@eth9' --interface '0-10@eth10' --interface '0-11@eth11' --interface '0-12@eth12' --interface '0-13@eth13' --interface '0-14@eth14' --interface '0-15@eth15' --interface '0-16@eth16' --interface '0-17@eth17' --interface '0-18@eth18' --interface '0-19@eth19' --interface '0-20@eth20' --interface '0-21@eth21' --interface '0-22@eth22' --interface '0-23@eth23' --interface '0-24@eth24' --interface '0-25@eth25' --interface '0-26@eth26' --interface '0-27@eth27' --interface '0-28@eth28' --interface '0-29@eth29' --interface '0-30@eth30' --relax "--test-params=thrift_server='$DUTIP';port_config_ini='/tmp/sai_qualify/resources/port_config.ini';config_db_json='/tmp/sai_qualify/resources/config_db.json'"
```

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>