### PR TITLE
[sai-ptf]Init port base on available interface and optimize init process 

### DIFF
--- a/ptf/config/config_db_loader.py
+++ b/ptf/config/config_db_loader.py
@@ -43,6 +43,7 @@ class ConfigDBLoader():
 
         self.file_path = self.__validate_file_path__(file_path)
         self.config_json = None
+        self.port_config = None
         with open(self.file_path, mode='r') as f:
             self.config_json = json.load(f)
     
@@ -64,8 +65,9 @@ class ConfigDBLoader():
         file_exists = exists(config_path)
         if not file_exists:
             raise FileNotFoundError("File not found:{}. Please refer to {} for how to set it.".format(
-                "https://github.com/opencomputeproject/SAI/blob/master/ptf/docs/SAI-PTFv2Overview.md#run-test",
-                 config_path))
+                config_path,
+                "https://github.com/opencomputeproject/SAI/blob/master/ptf/docs/SAI-PTFv2Overview.md#run-test"
+                 ))
         return config_path
 
 
@@ -77,5 +79,5 @@ class ConfigDBLoader():
         '''
         
         port_conf = self.config_json.get('PORT')
-        key_0 = list(port_conf.keys())[0]
-        return self.config_json.get('PORT').get(key_0)
+        self.port_config = port_conf
+        return port_conf

--- a/ptf/config/port_config_ini_loader.py
+++ b/ptf/config/port_config_ini_loader.py
@@ -23,6 +23,7 @@ from os.path import exists
 
 from typing import TYPE_CHECKING
 from typing import List, Dict
+from data_module.data_obj import auto_str
 
 DEFAULT_CONFIG_DB = "../resources/port_config.ini"
 
@@ -69,8 +70,8 @@ class PortConfigInILoader():
         file_exists = exists(config_path)
         if not file_exists:
             raise FileNotFoundError("File not found:{}. Please refer to {} for how to set it.".format(
-                "https://github.com/opencomputeproject/SAI/blob/master/ptf/docs/SAI-PTFv2Overview.md#run-test",
-                 config_path))
+                config_path,
+                "https://github.com/opencomputeproject/SAI/blob/master/ptf/docs/SAI-PTFv2Overview.md#run-test"))
         return config_path
 
 
@@ -138,7 +139,7 @@ class PortConfigInILoader():
         except Exception as e:
             raise e
 
-
+@auto_str
 class PortConfig(object):
     """
     Represent the PortConfig Object

--- a/ptf/config/port_configer.py
+++ b/ptf/config/port_configer.py
@@ -104,9 +104,9 @@ class PortConfiger(object):
             self.client, port_list=port_list)
         port_list = p_list['port_list'].idlist
         active_1q_bridge_ports = []
-        for bp in default_1q_bridge_port_list:
-            attr = self.get_bridge_port_all_attribute(bp)
-            for index in range(0, len(port_list)):
+        for index in range(0, len(port_list)):
+            for bp in default_1q_bridge_port_list:
+                attr = self.get_bridge_port_all_attribute(bp)            
                 port_id = port_list[index]
                 if port_id == attr['port_id']:
                     setattr(self.test_obj, 'port%s_bp' % index, bp)

--- a/ptf/data_module/port.py
+++ b/ptf/data_module/port.py
@@ -73,9 +73,10 @@ class Port(data_item):
         bridge port object id
         """
         self.port_config:Dict = {}
-        self.host_itf_idx = None
+        self.config_db:Dict = {}
+        self.host_itf_id = None
         """
-        Port binded host interface index, the object saved in dut.hostif_list
+        Port binded host interface id, the object saved in dut.hostif_list
         """
         self.default_lane_list = []
         """

--- a/ptf/platform_helper/brcm_sai_helper.py
+++ b/ptf/platform_helper/brcm_sai_helper.py
@@ -198,23 +198,29 @@ class BrcmSaiHelper(CommonSaiHelper):
 
         self.port_list = self.port_configer.get_lane_sorted_port_list()
         self.port_configer.generate_port_obj_list_by_interface_config()
-        self.port_configer.assign_port_config(self.port_conifg_ini_loader.portConfigs)
-        #compatiable with portx variables
-        self.port_configer.set_port_attr(self.port_list)
+        self.port_configer.assign_port_config(self.port_config_ini_loader.portConfigs)
+        self.port_configer.assign_config_db(
+            self.config_db_loader.port_config,
+            self.port_config_ini_loader.portConfigs)
+        
+        
 
         attr = sai_thrift_get_switch_attribute(
             self.client, default_trap_group=True)
         default_trap_group = attr['default_trap_group']
-        self.port_configer.turn_on_port_admin_state_by_port_list(self.port_obj_list)
-        self.port_configer.turn_up_and_check_ports_by_port_list(self.port_obj_list)
-
+        self.port_configer.set_port_attribute(self.active_port_obj_list)
+        self.port_obj_list = self.port_configer.turn_up_and_get_checked_ports(
+            self.active_port_obj_list)
+        #compatiable with portx variables
+        self.get_port_id_list = self.port_configer.get_port_id_list(self.port_obj_list)
+        self.port_configer.set_test_port_attr(self.port_list)
 
         if 'port_config_ini' in self.test_params:
             host_intf_table_id, hostif_list = self.port_configer.create_port_hostif_by_port_config_ini(
-                port_list=self.port_obj_list, trap_group=default_trap_group)
+                port_list=self.active_port_obj_list, trap_group=default_trap_group)
         else:
             host_intf_table_id, hostif_list = self.port_configer.create_host_intf(
-                port_list=self.port_obj_list, trap_group=default_trap_group)
+                port_list=self.active_port_obj_list, trap_group=default_trap_group)
         self.host_intf_table_id = host_intf_table_id
         self.hostif_list = hostif_list
 
@@ -233,4 +239,4 @@ class BrcmSaiHelper(CommonSaiHelper):
         #Port needs to be init and setup at same time.
         #Make the process happened in turn_up_and_check_ports
         print("BrcmSaiHelperBase::recreate_ports does not support. Just Parse Port Config")
-        self.ports_config = self.port_conifg_ini_loader.ports_config
+        self.ports_config = self.port_config_ini_loader.ports_config

--- a/test/sai_test/config/config_db_loader.py
+++ b/test/sai_test/config/config_db_loader.py
@@ -65,8 +65,8 @@ class ConfigDBLoader():
         file_exists = exists(config_path)
         if not file_exists:
             raise FileNotFoundError("File not found:{}. Please refer to {} for how to set it.".format(
-                "https://github.com/opencomputeproject/SAI/blob/master/ptf/docs/SAI-PTFv2Overview.md#run-test",
-                 config_path))
+                config_path,
+                "https://github.com/opencomputeproject/SAI/blob/master/ptf/docs/SAI-PTFv2Overview.md#run-test"))
         return config_path
 
 

--- a/test/sai_test/config/config_db_loader.py
+++ b/test/sai_test/config/config_db_loader.py
@@ -43,6 +43,7 @@ class ConfigDBLoader():
 
         self.file_path = self.__validate_file_path__(file_path)
         self.config_json = None
+        self.port_config = None
         with open(self.file_path, mode='r') as f:
             self.config_json = json.load(f)
     
@@ -77,5 +78,5 @@ class ConfigDBLoader():
         '''
         
         port_conf = self.config_json.get('PORT')
-        key_0 = list(port_conf.keys())[0]
-        return self.config_json.get('PORT').get(key_0)
+        self.port_config = port_conf
+        return port_conf

--- a/test/sai_test/config/port_config_ini_loader.py
+++ b/test/sai_test/config/port_config_ini_loader.py
@@ -71,8 +71,8 @@ class PortConfigInILoader():
         file_exists = exists(config_path)
         if not file_exists:
             raise FileNotFoundError("File not found:{}. Please refer to {} for how to set it.".format(
-                "https://github.com/opencomputeproject/SAI/blob/master/ptf/docs/SAI-PTFv2Overview.md#run-test",
-                 config_path))
+                config_path,
+                "https://github.com/opencomputeproject/SAI/blob/master/ptf/docs/SAI-PTFv2Overview.md#run-test"))
         return config_path
 
 

--- a/test/sai_test/config/port_config_ini_loader.py
+++ b/test/sai_test/config/port_config_ini_loader.py
@@ -133,7 +133,6 @@ class PortConfigInILoader():
                     portConfig.name = name
                     portConfigs[index] = portConfig
                     index = index + 1
-                    index = index + 1
             self.ports_config = ports
             self.portConfigs = portConfigs
             return ports, portConfigs

--- a/test/sai_test/config/port_config_ini_loader.py
+++ b/test/sai_test/config/port_config_ini_loader.py
@@ -24,6 +24,8 @@ from os.path import exists
 from typing import TYPE_CHECKING
 from typing import List, Dict
 
+from data_module.data_obj import auto_str
+
 DEFAULT_CONFIG_DB = "../resources/port_config.ini"
 
 class PortConfigInILoader():
@@ -138,7 +140,7 @@ class PortConfigInILoader():
         except Exception as e:
             raise e
 
-
+@auto_str
 class PortConfig(object):
     """
     Represent the PortConfig Object

--- a/test/sai_test/config/port_configer.py
+++ b/test/sai_test/config/port_configer.py
@@ -198,9 +198,9 @@ class PortConfiger(object):
                     self.client, hostif_oid=hostif, oper_status=False)
                 hostif_list[index] = hostif
                 port.host_itf_id = hostif
-                print("Create hostitf: name:{} port hardIdx: {} port lane: {}".format(
-                    port.port_config.name, port.port_index, port.conifg_db['lanes'])
-                )
+                # print("Create hostitf: name:{} port hardIdx: {} port lane: {}".format(
+                #     port.port_config.name, port.port_index, port.conifg_db['lanes'])
+                # )
             except BaseException as e:
                 print("Cannot create hostif, error : {}".format(e))
         return host_intf_table_id, hostif_list
@@ -459,7 +459,7 @@ class PortConfiger(object):
         """
         print("Set port...")
         for index, port in enumerate(port_list):
-            self.log_port_state(port, index)
+            #self.log_port_state(port, index)
             sai_thrift_set_port_attribute(
                 self.client, port_oid=port.oid, mtu=self.get_mtu(port),
                 fec_mode=self.get_fec_mode(port),
@@ -484,7 +484,7 @@ class PortConfiger(object):
 
         print("Turn up ports...")
         for index, port in enumerate(port_list):
-            if not port.dev_port_index:
+            if not port.dev_port_index and index != 0:
                 print("Skip turn up port {} , local index {} id {} name{}.".format(
                         index, port.port_index, port.oid, port.port_config.name))
                 continue

--- a/test/sai_test/config/port_configer.py
+++ b/test/sai_test/config/port_configer.py
@@ -46,10 +46,10 @@ def t0_port_config_helper(test_obj: 'T0TestBase', is_recreate_bridge=True, is_cr
     configer = PortConfiger(test_obj)
     test_obj.dut.port_id_list = configer.get_lane_sorted_port_list()
     configer.generate_port_obj_list_by_interface_config()
-    configer.assign_port_config(test_obj.port_conifg_ini_loader.portConfigs)
+    configer.assign_port_config(test_obj.port_config_ini_loader.portConfigs)
     configer.assign_config_db(
         test_obj.config_db_loader.port_config,
-        test_obj.port_conifg_ini_loader.portConfigs)
+        test_obj.port_config_ini_loader.portConfigs)
 
     attr = sai_thrift_get_switch_attribute(
         configer.client, default_trap_group=True)
@@ -199,7 +199,7 @@ class PortConfiger(object):
                 hostif_list[index] = hostif
                 port.host_itf_id = hostif
                 # print("Create hostitf: name:{} port hardIdx: {} port lane: {}".format(
-                #     port.port_config.name, port.port_index, port.conifg_db['lanes'])
+                #     port.port_config.name, port.port_index, port.config_db['lanes'])
                 # )
             except BaseException as e:
                 print("Cannot create hostif, error : {}".format(e))
@@ -415,7 +415,7 @@ class PortConfiger(object):
         """
         for index, key in enumerate(portConfigs):
         # index: sequence number, key: port config order, should be equals to index
-            self.test_obj.dut.active_port_obj_list[index].conifg_db \
+            self.test_obj.dut.active_port_obj_list[index].config_db \
                 = port_config_db[portConfigs[key].name]
 
     def remove_bridge_with_port(self):
@@ -528,8 +528,8 @@ class PortConfiger(object):
         RETURN:
              int: SAI_PORT_FEC_MODE_X
         '''
-        if 'fec' in port.conifg_db:
-            fec_mode = port.conifg_db['fec']
+        if 'fec' in port.config_db:
+            fec_mode = port.config_db['fec']
         else:
             fec_mode = None
         fec_change = {
@@ -546,7 +546,7 @@ class PortConfiger(object):
         RETURN:
             int: mtu number
         '''
-        return int(port.conifg_db['mtu'])
+        return int(port.config_db['mtu'])
 
     def get_speed(self, port: Port):
         '''
@@ -555,7 +555,7 @@ class PortConfiger(object):
         RETURN:
             int: speed
         '''
-        return int(port.conifg_db['speed'])
+        return int(port.config_db['speed'])
 
     def get_cpu_port_queue(self):
 
@@ -588,7 +588,7 @@ class PortConfiger(object):
             port.dev_port_index,
             port.port_config.name,
             port.port_config.lanes,
-            port.conifg_db['lanes'],
+            port.config_db['lanes'],
             self.get_mtu(port),
             self.get_fec_mode(port),
             self.get_speed(port)))

--- a/test/sai_test/config/vlan_configer.py
+++ b/test/sai_test/config/vlan_configer.py
@@ -171,7 +171,8 @@ class VlanConfiger(object):
         Returns:
             list: vlan member oid list
         """
-        vlan_member_list = sai_thrift_object_list_t(count=100)
+        vlan_member_list = sai_thrift_object_list_t(
+            count=self.test_obj.dut.active_ports_no)
         mbr_list = sai_thrift_get_vlan_attribute(
             self.client, vlan_id, member_list=vlan_member_list)
         return mbr_list['SAI_VLAN_ATTR_MEMBER_LIST'].idlist

--- a/test/sai_test/data_module/dut.py
+++ b/test/sai_test/data_module/dut.py
@@ -138,9 +138,9 @@ class Dut(object):
         """
         Host interface list
         """
-        self.default_bridge_port_list = []
+        self.bridge_port_list = []
         """
-        Default bridge port list
+        Bridge port list
         """
         self.host_if_port_idx_map = []
         """
@@ -167,4 +167,9 @@ class Dut(object):
         self.nhp_grpv6_list: List[NexthopGroup] = []
         """
         Nexthop group list, contains nexthop ipv6 objects
+        """
+
+        self.active_ports_no = 0
+        """
+        Device active ports.
         """

--- a/test/sai_test/data_module/dut.py
+++ b/test/sai_test/data_module/dut.py
@@ -128,7 +128,9 @@ class Dut(object):
         self.host_intf_table_id = None
         self.port_obj_list: List['Port'] = []
         """
-        Port object list
+        Port object list.
+        Actual Port list for testing.
+        Depends on the local device(PTF) interfaces number.
         """
         self.port_id_list = []
         """
@@ -141,14 +143,6 @@ class Dut(object):
         self.bridge_port_list = []
         """
         Bridge port list
-        """
-        self.host_if_port_idx_map = []
-        """
-        list in order of the host interface create sequence, and with the value for port index
-        """
-        self.host_if_name_list = []
-        """
-        List of the interface name
         """
 
         self.rif_list: List = []
@@ -172,4 +166,11 @@ class Dut(object):
         self.active_ports_no = 0
         """
         Device active ports.
+        """
+
+        self.active_port_obj_list: List['Port'] = []
+        """
+        Device active port obj list.
+        Those ports might more than actual port in testing.
+        For ports in testing, please use port_obj_list.
         """

--- a/test/sai_test/data_module/dut.py
+++ b/test/sai_test/data_module/dut.py
@@ -140,7 +140,7 @@ class Dut(object):
         """
         Host interface list
         """
-        self.bridge_port_list = []
+        self.def_bridge_port_list = []
         """
         Bridge port list
         """

--- a/test/sai_test/data_module/port.py
+++ b/test/sai_test/data_module/port.py
@@ -83,9 +83,9 @@ class Port(route_item):
         """
         self.port_config:Dict = {}
         self.conifg_db:Dict = {}
-        self.host_itf_idx = None
+        self.host_itf_id = None
         """
-        Port binded host interface index, the object saved in dut.hostif_list
+        Port binded host interface id, the object saved in dut.hostif_list
         """
         self.default_lane_list = []
         """

--- a/test/sai_test/data_module/port.py
+++ b/test/sai_test/data_module/port.py
@@ -82,7 +82,7 @@ class Port(route_item):
         bridge port object id
         """
         self.port_config:Dict = {}
-        self.conifg_db:Dict = {}
+        self.config_db:Dict = {}
         self.host_itf_id = None
         """
         Port binded host interface id, the object saved in dut.hostif_list

--- a/test/sai_test/data_module/port.py
+++ b/test/sai_test/data_module/port.py
@@ -82,6 +82,7 @@ class Port(route_item):
         bridge port object id
         """
         self.port_config:Dict = {}
+        self.conifg_db:Dict = {}
         self.host_itf_idx = None
         """
         Port binded host interface index, the object saved in dut.hostif_list

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -351,7 +351,7 @@ class T0TestBase(ThriftInterfaceDataPlane):
         self.persist_helper = PersistHelper()
         self.ports_config = None
         self.config_db_loader: ConfigDBLoader = None
-        self.port_conifg_ini_loader: PortConfigInILoader = None
+        self.port_config_ini_loader: PortConfigInILoader = None
 
     def set_logger_name(self):
         """
@@ -383,11 +383,11 @@ class T0TestBase(ThriftInterfaceDataPlane):
         self.set_logger_name()
         # parse the port_config.ini, will create port, bridge port and host interface base on that file
         if 'port_config_ini' in self.test_params:
-            self.port_conifg_ini_loader = PortConfigInILoader(self.test_params['port_config_ini'])
+            self.port_config_ini_loader = PortConfigInILoader(self.test_params['port_config_ini'])
         else:
-            self.port_conifg_ini_loader = PortConfigInILoader()        
-        self.port_conifg_ini_loader.parse_port_config()
-        self.ports_config = self.port_conifg_ini_loader.ports_config
+            self.port_config_ini_loader = PortConfigInILoader()        
+        self.port_config_ini_loader.parse_port_config()
+        self.ports_config = self.port_config_ini_loader.ports_config
 
         if 'config_db_json' in self.test_params:
             self.config_db_loader = ConfigDBLoader(self.test_params['config_db_json'])


### PR DESCRIPTION
## why
Enhancement on #1725
In some situations, some of the ports might not available, but those ports can be listed from devices, and in the test, those tests intented not to be tested. We need some mechanism to skip the un-available port during port init process.
in #1725, we introduced two configuration files, and the number of the port that for testing depends on CLI parameters and the port_config.ini

There are some drawback of this method. Port onfigure process mix with port turn up process. 
We cannot configure the port from all the configurations. We need to split the port config and init(turn up) process.

In this change, the actual port for testing only depends on the CLI parameters, interface. For this parameter, it illustrate how many port are availale from PTF running environment, and also define how many PTF interfaces map to DUT devices. If not map the interface, then those port from DUT should be non-available for test.

Base on this, we turn up the port base on the interfaces and init all the interfaces' setting. 

## How
1. make the port init process only depends on the configuration file
2. make the port turn up process depends on interface parameter
3. Optimize the process when creating bridge port

## Verify
Test in DUT
Verified in Pipeline
T0 test set on s6000 and dx010
PTF test set on 7260 and dx010