### PR TITLE
improve enum values integration check

### DIFF
--- a/meta/checkenumlock.sh
+++ b/meta/checkenumlock.sh
@@ -30,6 +30,7 @@ rm -rf temp
 mkdir temp
 
 git --work-tree=temp/ checkout origin/master inc
+git --work-tree=temp/ checkout origin/master experimental
 
 echo "Checking for possible enum values shift (current branch vs origin/master) ..."
 

--- a/meta/checkheaders.pl
+++ b/meta/checkheaders.pl
@@ -149,7 +149,7 @@ sub GetValues
 
     my ($fhb, $bin) = tempfile( SUFFIX => '.bin', UNLINK => 1  );
 
-    system("gcc $src -I. -I ../experimental -I '$dir' -o $bin") == 0 or die "gcc failed! $!";
+    system("gcc $src -I. -I '$dir'/../experimental -I '$dir' -o $bin") == 0 or die "gcc failed! $!";
 
     close $fhs;
     close $fhb;


### PR DESCRIPTION
**What I did?**
I added dedicated 'expiremantal' dir which belongs to origin/master during enum values integration check
**Why I did it ?**
It fixes issue when content of current repo's  'expiremantal' dir differs from origin/master, in simplest case current repo doesn't point to latest master (what is a common case)

If new files were added to 'experental' dir and current repo don't have them checkenumlock.sh would fail
```

root@e9031bc4ca37:/home/sw/xlink/third-party/SAI/meta# ./checkenumlock.sh 
Checking for possible enum values shift (current branch vs origin/master) ...
In file included from ./temp/inc//sai.h:48,
                 from /tmp/lqfy58VJK8.c:2:
./temp/inc//saiobject.h:40:10: fatal error: saiexperimentaldashvip.h: No such file or directory
 #include <saiexperimentaldashvip.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
Uncaught exception from user code:
        gcc failed! Inappropriate ioctl for device at ./checkheaders.pl line 152.
        main::GetValues("temp/inc/") called at ./checkheaders.pl line 172
```

I faced this issue when DASH API were merged.