### PR TITLE
[SAI-PTF] Read configuration from a json config file

### DIFF
--- a/test/sai_test/config/config_db_loader.py
+++ b/test/sai_test/config/config_db_loader.py
@@ -23,6 +23,9 @@ from os.path import exists
 import json
 
 from typing import TYPE_CHECKING
+from typing import Dict, List
+
+from data_module.port_config import PortConfig
 
 DEFAULT_CONFIG_DB = "../resources/config_db.json"
 
@@ -70,13 +73,30 @@ class ConfigDBLoader():
         return config_path
 
 
-    def get_port_config(self):
+    def get_port_configs(self) -> List['PortConfig']:
         '''
         Method for get the configuration for port config.
         RETURN:
-            dict: port config
+            dict: port config, key is the interface name
         '''
         
         port_conf = self.config_json.get('PORT')
-        self.port_config = port_conf
-        return port_conf
+        port_Configs = []
+        for index, key in enumerate(port_conf):
+            portConfig = PortConfig()
+            portConfig.name = key
+            portConfig.alias = port_conf[key]['alias']
+            portConfig.index = int(port_conf[key]['index'])
+            portConfig.lanes = [int(i) for i in port_conf[key]['lanes'].split(',')]
+            portConfig.mtu = 0 if not 'mtu' in  port_conf[key] else int(port_conf[key]['mtu'])
+            portConfig.pfc_asym = None \
+                if not 'pfc_asym' in  port_conf[key] else port_conf[key]['pfc_asym']
+            portConfig.speed = 0 \
+                if not 'speed' in  port_conf[key] else int(port_conf[key]['speed'])
+            portConfig.fec = None \
+                if not 'fec' in  port_conf[key] else port_conf[key]['fec']
+            portConfig.tpid = None if not 'tpid' in  port_conf[key] else port_conf[key]['tpid']
+            port_Configs.append(portConfig)
+
+        self.port_config = port_Configs
+        return port_Configs

--- a/test/sai_test/config/port_config_ini_loader.py
+++ b/test/sai_test/config/port_config_ini_loader.py
@@ -25,9 +25,11 @@ from typing import TYPE_CHECKING
 from typing import List, Dict
 
 from data_module.data_obj import auto_str
+from data_module.port_config import PortConfig
 
 DEFAULT_CONFIG_DB = "../resources/port_config.ini"
 
+@DeprecationWarning
 class PortConfigInILoader():
     '''
     Read config from port_config.ini.
@@ -138,19 +140,3 @@ class PortConfigInILoader():
             return ports, portConfigs
         except Exception as e:
             raise e
-
-@auto_str
-class PortConfig(object):
-    """
-    Represent the PortConfig Object
-
-    Attrs:
-        name: interface name
-        lanes: lanes
-        speed: port speed
-    """
-
-    def __init__(self, name=None, lanes=None, speed=None):
-        self.name = name
-        self.lanes = lanes
-        self.speed = speed

--- a/test/sai_test/config/port_configer.py
+++ b/test/sai_test/config/port_configer.py
@@ -26,6 +26,8 @@ from typing import TYPE_CHECKING
 from data_module.port import Port
 
 from typing import Dict, List
+
+from data_module.port_config import PortConfig
 if TYPE_CHECKING:
     from sai_test_base import T0TestBase
 
@@ -44,12 +46,9 @@ def t0_port_config_helper(test_obj: 'T0TestBase', is_recreate_bridge=True, is_cr
 
     """
     configer = PortConfiger(test_obj)
-    test_obj.dut.port_id_list = configer.get_lane_sorted_port_list()
+    port_obj_list_with_lane = configer.get_port_default_lane()
+    test_obj.dut.port_id_list = configer.get_lane_sorted_port_list(port_obj_list_with_lane)
     configer.generate_port_obj_list_by_interface_config()
-    configer.assign_port_config(test_obj.port_config_ini_loader.portConfigs)
-    configer.assign_config_db(
-        test_obj.config_db_loader.port_config,
-        test_obj.port_config_ini_loader.portConfigs)
 
     attr = sai_thrift_get_switch_attribute(
         configer.client, default_trap_group=True)
@@ -103,8 +102,7 @@ class PortConfiger(object):
             test_obj: the test object
         """
         self.test_obj = test_obj
-        self.client = test_obj.client        
-        self.config_db_port = test_obj.config_db_loader.get_port_config()
+        self.client = test_obj.client
 
     def create_bridge_ports(self, bridge_id, port_list: List['Port']):
         """
@@ -163,7 +161,7 @@ class PortConfiger(object):
                     self.client,
                     type=SAI_HOSTIF_TYPE_NETDEV,
                     obj_id=item.oid,
-                    name=item.port_config.name)
+                    name=item.config.name)
                 sai_thrift_set_hostif_attribute(
                     self.client, hostif_oid=hostif, oper_status=False)
                 hostif_list[index] = hostif
@@ -187,13 +185,13 @@ class PortConfiger(object):
                     self.client,
                     type=SAI_HOSTIF_TYPE_NETDEV,
                     obj_id=port.oid,
-                    name=port.port_config.name)
+                    name=port.config.name)
                 sai_thrift_set_hostif_attribute(
                     self.client, hostif_oid=hostif, oper_status=False)
                 hostif_list[index] = hostif
                 port.host_itf_id = hostif
                 # print("Create hostitf: name:{} port hardIdx: {} port lane: {}".format(
-                #     port.port_config.name, port.port_index, port.config_db['lanes'])
+                #     port.config.name, port.port_index, port.config.lanes)
                 # )
             except BaseException as e:
                 print("Cannot create hostif, error : {}".format(e))
@@ -260,7 +258,7 @@ class PortConfiger(object):
         active_1q_bridge_ports = []
         for index in range(0, len(port_list)):
             for bp in default_1q_bridge_port_list:
-                attr = self.get_bridge_port_all_attribute(bp)            
+                attr = self.get_bridge_port_all_attribute(bp)
                 port_id = port_list[index].oid
                 if port_id == attr['port_id']:
                     port_list[index].bridge_port_oid = bp
@@ -294,13 +292,21 @@ class PortConfiger(object):
     def get_all_bridge_ports(self, bridge_id):
         """
         Loads default 1q bridge ports.
+
+        /* Get bridge ports in default 1Q bridge
+            * By default, there will be (m_portCount + m_systemPortCount) number of SAI_BRIDGE_PORT_TYPE_PORT
+            * ports and one SAI_BRIDGE_PORT_TYPE_1Q_ROUTER port. The former type of
+            * ports will be removed. */
+        vector<sai_object_id_t> bridge_port_list(m_portCount + m_systemPortCount + 1);
         """
         print("Get bridge ports...")
+              
+        bridge_size = self.test_obj.dut.system_port_no + self.test_obj.dut.active_ports_no + 1
         attr = sai_thrift_get_bridge_attribute(
                     self.client, 
                     bridge_oid=bridge_id,
                     port_list=sai_thrift_object_list_t(
-                        idlist=[], count=self.test_obj.dut.active_ports_no))
+                        idlist=[], count=bridge_size))
         default_1q_bridge_port_list = attr['port_list'].idlist
         self.test_obj.assertEqual(self.test_obj.status(), SAI_STATUS_SUCCESS)
         return default_1q_bridge_port_list
@@ -312,10 +318,14 @@ class PortConfiger(object):
         """
         print("Remove all bridge ports...")
         bp_ports = self.test_obj.dut.def_bridge_port_list
+        removed_list = []
         for index, port in enumerate(bp_ports):
             sai_thrift_remove_bridge_port(self.client, port)
             #print("Removed bridge port {}".format(port))
-            self.test_obj.dut.def_bridge_port_list.remove(port)
+            removed_list.append(port)
+        for bridge_id in removed_list:
+            self.test_obj.dut.def_bridge_port_list.remove(bridge_id)
+        print("Removed bridge {}, left {}".format(len(removed_list), len(bp_ports)))
         self.test_obj.assertEqual(self.test_obj.status(), SAI_STATUS_SUCCESS)
 
     def get_default_1q_bridge(self):
@@ -353,20 +363,14 @@ class PortConfiger(object):
             dev_port_list.append(port)
         return dev_port_list
 
-    def get_lane_sorted_port_list(self):
+    def get_port_default_lane(self) -> List[Port]:
         """
-        Get the port list sorted by lanes name(defined in port_config.ini).
-        This method will shrime the ports base on the lanes.
-        i.e. If device has 64 ports but just define 32 in lanes, then just generate 32 ports
+        Get Port default lane.
 
         Returns:
             port_list
         """
-        port_obj_list: List[Port] = []
-        port_id_list = []
-        attr = sai_thrift_get_switch_attribute(
-            self.client, number_of_active_ports=True)
-        self.test_obj.dut.active_ports_no = attr['number_of_active_ports']
+        port_obj_list_with_lane: List[Port] = []
         # the active number must match the actual account, or might return null
         port_list = sai_thrift_object_list_t(
             idlist=[], count=self.test_obj.dut.active_ports_no)
@@ -379,24 +383,41 @@ class PortConfiger(object):
             attr = sai_thrift_get_port_attribute(
                 self.client, port_oid=port.oid, hw_lane_list=temp_list)
             port.default_lane_list = attr['hw_lane_list'].uint32list
-            port_obj_list.append(port)
+            port_obj_list_with_lane.append(port)
+        return port_obj_list_with_lane
+
+
+    def get_lane_sorted_port_list(self, port_obj_list_with_lane: List[Port]):
+        """
+        Get the port list sorted by lanes name(defined in port_config.ini).
+        This method will shrime the ports base on the lanes.
+        i.e. If device has 64 ports but just define 32 in lanes, then just generate 32 ports
+
+        Args:
+            port_obj_list_with_lane: port obj with default lane info
+
+        Returns:
+            port_list
+        """
+        port_id_list = []
         self.test_obj.dut.active_port_obj_list = self.sort_port_list_by_config(
-            self.test_obj.ports_config, port_obj_list)
+            self.test_obj.port_configs, port_obj_list_with_lane)
         for item in self.test_obj.dut.active_port_obj_list:
             port_id_list.append(item.oid)
         print("Base on lanes config file[{}], init {} ports from {} device posts"
         .format("port_config.ini",
                 len(self.test_obj.dut.active_port_obj_list),
-                len(port_obj_list)
+                len(port_obj_list_with_lane)
              ))
         #print("port_list {}".format(port_id_list))
 
         return port_id_list
 
-    def sort_port_list_by_config(self, ports_config: Dict, port_list: List[Port]):
+    def sort_port_list_by_config(self, port_configs: List[PortConfig], port_list: List[Port]):
         """
         Sort the port list base on the port_config.ini.
-        This method will match the default_lane_list in the port object with the lane defined in 
+        This method will match the default_lane_list in the port object
+        with the lane defined in 
         port config for a ordered port list.
         This method will create the port list base on the mini number of interfaces from
         command parameters or port_config.ini
@@ -406,32 +427,16 @@ class PortConfiger(object):
             port_list: port list
         """
         sorted_port_list: List[Port] = []
-        for index, key in enumerate(ports_config):
+        for index, item in enumerate(port_configs):
         # index: sequence number, key: port config order, should be equals to index
-            lane_list = ports_config[key]['lanes']
+            lane_list = item.lanes
             for port in port_list:
                 if lane_list == port.default_lane_list:
                     sorted_port_list.append(port)
+                    port.config = port_configs[index]
                     break
         return sorted_port_list
 
-    def assign_port_config(self, portConfigs: Dict):
-        """
-        Assign the PortConfig object to the Port Object
-        """
-        for index, key in enumerate(portConfigs):
-        # index: sequence number, key: port config order, should be equals to index
-            #print ("index: {}, key: {}".format(index, key))
-            self.test_obj.dut.active_port_obj_list[index].port_config = portConfigs[key]
-
-    def assign_config_db(self, port_config_db: Dict, portConfigs: Dict):
-        """
-        Assign the PortConfig object to the Port Object
-        """
-        for index, key in enumerate(portConfigs):
-        # index: sequence number, key: port config order, should be equals to index
-            self.test_obj.dut.active_port_obj_list[index].config_db \
-                = port_config_db[portConfigs[key].name]
 
     def remove_bridge_port(self):
         """
@@ -476,9 +481,9 @@ class PortConfiger(object):
         for index, port in enumerate(port_list):
             #self.log_port_state(port, index)
             sai_thrift_set_port_attribute(
-                self.client, port_oid=port.oid, mtu=self.get_mtu(port),
+                self.client, port_oid=port.oid, mtu=port.config.mtu,
                 fec_mode=self.get_fec_mode(port),
-                speed=self.get_speed(port))
+                speed=port.config.speed)
 
     def turn_up_and_get_checked_ports(self, port_list: List['Port']):
         '''
@@ -501,7 +506,7 @@ class PortConfiger(object):
         for index, port in enumerate(port_list):
             if not port.dev_port_index and index != 0:
                 print("Skip turn up port {} , local index {} id {} name{}.".format(
-                        index, port.port_index, port.oid, port.port_config.name))
+                        index, port.port_index, port.oid, port.config.name))
                 continue
             test_port_list.append(port)
             sai_thrift_set_port_attribute(
@@ -543,34 +548,13 @@ class PortConfiger(object):
         RETURN:
              int: SAI_PORT_FEC_MODE_X
         '''
-        if 'fec' in port.config_db:
-            fec_mode = port.config_db['fec']
-        else:
-            fec_mode = None
         fec_change = {
             None: SAI_PORT_FEC_MODE_NONE,
             'rs': SAI_PORT_FEC_MODE_RS,
             'fc': SAI_PORT_FEC_MODE_FC,
         }
-        return fec_change[fec_mode]
+        return fec_change[port.config.fec]
 
-    def get_mtu(self, port: Port):
-        '''
-        get mtu from config_db.json
-
-        RETURN:
-            int: mtu number
-        '''
-        return int(port.config_db['mtu'])
-
-    def get_speed(self, port: Port):
-        '''
-        get speed from config_db.json
-
-        RETURN:
-            int: speed
-        '''
-        return int(port.config_db['speed'])
 
     def get_cpu_port_queue(self):
 
@@ -597,13 +581,12 @@ class PortConfiger(object):
             self.test_obj.assertEqual(queue, q_attr['index'])
 
     def log_port_state(self, port:Port, index):
-        print("port index:{} hardIdx: {} ptf_dev_idx: {} name:{} config lane:{} db lane:{} mtu:{} fec:{} speed:{}".format(
+        print("port index:{} hardIdx: {} ptf_dev_idx: {} name:{} config lane:{} mtu:{} fec:{} speed:{}".format(
             index,
             port.port_index,
             port.dev_port_index,
-            port.port_config.name,
-            port.port_config.lanes,
-            port.config_db['lanes'],
-            self.get_mtu(port),
+            port.config.name,
+            port.config.lanes,
+            port.config.mtu,
             self.get_fec_mode(port),
-            self.get_speed(port)))
+            port.config.speed))

--- a/test/sai_test/config/switch_configer.py
+++ b/test/sai_test/config/switch_configer.py
@@ -22,6 +22,7 @@ from sai_thrift.sai_adapter import *
 from constant import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 from sai_utils import *  # pylint: disable=wildcard-import; lgtm[py/polluting-import]
 from typing import TYPE_CHECKING
+import sai_thrift.sai_adapter as adapter
 
 if TYPE_CHECKING:
     from sai_test_base import T0TestBase
@@ -78,4 +79,35 @@ class SwitchConfiger(object):
         print("Waiting for switch to get ready, {} seconds ...".format(
             switch_init_wait))
         time.sleep(switch_init_wait)
+        self.get_default_switch_attr()
         return switch_id
+
+    def get_default_switch_attr(self):
+        """
+        Get default switch attr.
+        includes:
+            system_port_no: number_of_system_ports
+            active_ports_no: number_of_active_ports
+
+        """
+
+        print("Ignore all the expect error code and exception captures.")
+        capture_status = adapter.CATCH_EXCEPTIONS
+        expected_code = adapter.EXPECTED_ERROR_CODE
+
+        adapter.CATCH_EXCEPTIONS = True
+        adapter.EXPECTED_ERROR_CODE = []
+
+        attr = sai_thrift_get_switch_attribute(
+            self.client, number_of_system_ports=True)
+        number_of_system_ports = 0
+        if attr and 'number_of_system_ports' in attr:
+            number_of_system_ports = attr['number_of_system_ports']
+        self.test_obj.dut.system_port_no = number_of_system_ports
+        print("Get number_of_system_ports {}".format(self.test_obj.dut.system_port_no))
+
+        attr = sai_thrift_get_switch_attribute(
+            self.client, number_of_active_ports=True)
+        self.test_obj.dut.active_ports_no = attr['number_of_active_ports']
+        print("Get number_of_active_ports {}".format(self.test_obj.dut.active_ports_no))
+        print("Restore all the expect error code and exception captures.")

--- a/test/sai_test/config/vlan_configer.py
+++ b/test/sai_test/config/vlan_configer.py
@@ -62,6 +62,16 @@ def t0_vlan_config_helper(test_obj: 'T0TestBase', is_reset_default_vlan=True, is
     test_obj.dut.default_vlan_id = default_vlan_id
 
 
+def remove_default_vlan(test_obj: 'T0TestBase'):
+    """
+    Remove default Vlan
+    test_obj: test object from a test class
+    """
+    configer = VlanConfiger(test_obj)
+    default_vlan_id = configer.get_default_vlan()
+    members = configer.get_vlan_member(default_vlan_id)
+    configer.remove_vlan_members(members)
+
 def t0_vlan_tear_down_helper(test_obj: 'T0TestBase'):
     '''
     Args:
@@ -157,8 +167,7 @@ class VlanConfiger(object):
             default_vlan_id
         """
         print("Get default vlan...")
-        def_attr = sai_thrift_get_switch_attribute(
-            self.client, default_vlan_id=True)
+        def_attr = sai_thrift_get_switch_attribute(self.client, default_vlan_id=True)
         return def_attr['default_vlan_id']
 
     def get_vlan_member(self, vlan_id):
@@ -171,10 +180,10 @@ class VlanConfiger(object):
         Returns:
             list: vlan member oid list
         """
-        vlan_member_list = sai_thrift_object_list_t(
-            count=self.test_obj.dut.active_ports_no)
-        mbr_list = sai_thrift_get_vlan_attribute(
-            self.client, vlan_id, member_list=vlan_member_list)
+        vlan_member_size = self.test_obj.dut.active_ports_no + self.test_obj.dut.system_port_no
+        vlan_member_list = sai_thrift_object_list_t(count=vlan_member_size)
+        mbr_list = sai_thrift_get_vlan_attribute(self.client, vlan_id, member_list=vlan_member_list)
+        self.test_obj.assertEqual(self.test_obj.status(), SAI_STATUS_SUCCESS)
         return mbr_list['SAI_VLAN_ATTR_MEMBER_LIST'].idlist
 
     def remove_vlan(self, vlan_oid):
@@ -200,5 +209,4 @@ class VlanConfiger(object):
 
         for vlan_member in vlan_members:
             sai_thrift_remove_vlan_member(self.client, vlan_member)
-            self.test_obj.assertEqual(
-                self.test_obj.status(), SAI_STATUS_SUCCESS)
+            self.test_obj.assertEqual(self.test_obj.status(), SAI_STATUS_SUCCESS)

--- a/test/sai_test/data_module/dut.py
+++ b/test/sai_test/data_module/dut.py
@@ -172,6 +172,11 @@ class Dut(object):
         Device active ports.
         """
 
+        self.system_port_no = 0
+        """
+        Device system ports.
+        """
+
         self.active_port_obj_list: List['Port'] = []
         """
         Device active port obj list.

--- a/test/sai_test/data_module/port.py
+++ b/test/sai_test/data_module/port.py
@@ -21,6 +21,7 @@
 from typing import List, Dict
 from typing import TYPE_CHECKING
 from data_module.data_obj import auto_str
+from data_module.port_config import PortConfig
 if TYPE_CHECKING:
     from sai_test_base import T0TestBase
     from data_module.nexthop import Nexthop
@@ -81,8 +82,10 @@ class Port(route_item):
         """
         bridge port object id
         """
-        self.port_config:Dict = {}
-        self.config_db:Dict = {}
+        self.config:PortConfig = None
+        """
+        Port Config
+        """
         self.host_itf_id = None
         """
         Port binded host interface id, the object saved in dut.hostif_list

--- a/test/sai_test/data_module/port_config.py
+++ b/test/sai_test/data_module/port_config.py
@@ -1,0 +1,38 @@
+from data_module.data_obj import auto_str
+
+@auto_str
+class PortConfig(object):
+    """
+    Represent the PortConfig Object
+
+    Attrs:
+        name: interface name
+        lanes: lanes
+        speed: port speed
+        fec: fec mode
+        alias: alias
+        index: index
+        mtu: mtu
+        pfc_asym: pfc_asym
+        tpid: tpid
+    """
+
+    def __init__(self,
+    name=None,
+    lanes=None,
+    speed=None,
+    fec=None,
+    alias=None,
+    index=None,
+    mtu=None,
+    pfc_asym=None,
+    tpid=None):
+        self.name = name
+        self.lanes = lanes
+        self.alias = alias
+        self.index = index
+        self.mtu = mtu
+        self.pfc_asym = pfc_asym
+        self.speed = speed
+        self.fec=fec
+        self.tpid = tpid

--- a/test/sai_test/sai_fdb_test.py
+++ b/test/sai_test/sai_fdb_test.py
@@ -36,7 +36,13 @@ class L2PortForwardingTest(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        # in mlnx, cannot add lag on bridge port
+        # str-msn2700-04 ERR saiserverv2#SDK: 
+        # [SAI_LAG.ERR] mlnx_sai_lag.c[617]- validate_port: Can't add port which is under bridge
+        T0TestBase.setUp(self,
+                        is_reset_default_vlan=False,
+                        is_create_lag=False,
+                        is_create_route_for_lag=False)
         
 
     @warm_test(is_test_rebooting=True)


### PR DESCRIPTION
why
In current structure, it depends on a config ini file, but in this file, the file format is not very friendly, and the default config.ini file copied from DUT not contains enough configurations. In order to get more config data, depends on the json config file.

how
construct a new data object port config (we can have more config) remove dependences from config ini
add depends on json config

Verify
DUT test with command
```
ptf --test-dir test/sai_test sai_fdb_test.L2PortForwardingTest --relax --xunit --xunit-dir "/tmp/sai_qualify/test_results_tmp" --interface '0-0@eth0' --interface '0-1@eth1' --interface '0-2@eth2' --interface '0-3@eth3' --interface '0-4@eth4' --interface '0-5@eth5' --interface '0-6@eth6' --interface '0-7@eth7' --interface '0-8@eth8' --interface '0-9@eth9' --interface '0-10@eth10' --interface '0-11@eth11' --interface '0-12@eth12' --interface '0-13@eth13' --interface '0-14@eth14' --interface '0-15@eth15' --interface '0-16@eth16' --interface '0-17@eth17' --interface '0-18@eth18' --interface '0-19@eth19' --interface '0-20@eth20' --interface '0-21@eth21' --interface '0-22@eth22' --interface '0-23@eth23' --interface '0-24@eth24' --interface '0-25@eth25' --interface '0-26@eth26' --interface '0-27@eth27' --interface '0-28@eth28' --interface '0-29@eth29' --interface '0-30@eth30' --interface '0-31@eth31' --relax "--test-params=thrift_server='$DUTIP';config_db_json='/tmp/sai_qualify/resources/config_db.json'"
```
```
FDB basic forwarding test.
L2 Forwarding from 1 to port: 2
L2 Forwarding from 1 to port: 3
L2 Forwarding from 1 to port: 4
L2 Forwarding from 1 to port: 5
L2 Forwarding from 1 to port: 6
L2 Forwarding from 1 to port: 7
L2 Forwarding from 1 to port: 8
  sai_fdb_test.L2PortForwardingTest ... OK (53.095s)

----------------------------------------------------------------------
Ran 1 test in 53.095s

OK
```