### PR TITLE
improve enum values integration check (#1727)

### DIFF
--- a/meta/checkenumlock.sh
+++ b/meta/checkenumlock.sh
@@ -30,6 +30,7 @@ rm -rf temp
 mkdir temp
 
 git --work-tree=temp/ checkout origin/master inc
+git --work-tree=temp/ checkout origin/master experimental
 
 echo "Checking for possible enum values shift (current branch vs origin/master) ..."
 

--- a/meta/checkheaders.pl
+++ b/meta/checkheaders.pl
@@ -149,7 +149,7 @@ sub GetValues
 
     my ($fhb, $bin) = tempfile( SUFFIX => '.bin', UNLINK => 1  );
 
-    system("gcc $src -I. -I ../experimental -I '$dir' -o $bin") == 0 or die "gcc failed! $!";
+    system("gcc $src -I. -I '$dir'/../experimental -I '$dir' -o $bin") == 0 or die "gcc failed! $!";
 
     close $fhs;
     close $fhb;


### PR DESCRIPTION
it allows to use two different 'experimental' dirs during integration check, one belongs to current repository and another to origin/master

Signed-off-by: Anton Parkhomenko <aparkhomenko@larch-networks.com>