### PR TITLE
Add SAI_UDF_MATCH_ATTR_L4_DST_PORT_TYPE  attribute to _sai_udf_match_attr_t

### DIFF
--- a/inc/saiudf.h
+++ b/inc/saiudf.h
@@ -178,6 +178,18 @@ typedef enum _sai_udf_match_attr_t
     SAI_UDF_MATCH_ATTR_PRIORITY,
 
     /**
+     * @brief UDF L4 Dst port rule
+     *
+     * Default to None
+     *
+     * @type sai_acl_field_data_t sai_uint16_t
+     * @flags CREATE_ONLY
+     * @isvlan false
+     * @default 0
+     */
+    SAI_UDF_MATCH_ATTR_L4_DST_PORT_TYPE,
+
+    /**
      * @brief End of attributes
      */
     SAI_UDF_MATCH_ATTR_END,


### PR DESCRIPTION


This SAI enhancement proposal adds a new attribute to _sai_udf_match_attr_t which specifies the layer 4 destination port that can be associated with the given UDF packet matcher. Current UDF specification allows us to match on a specific l2, l3, l4 type of packet but some of the ASICs also can help narrow down packet matching further to a subset of l4 traffic type.  For example if we want to apply UDF on only UDP traffic with 319 UDP port (PTP packets) or any other user defined port 1234.

Example usage is:

sai_object_id_t udf_match1_id;
sai_attribute_t udf_match1_attrs[3];
udf_match1_attrs[0].id = (sai_attr_id_t)SAI_UDF_ATTR_MATCH_L2_TYPE; udf_match1_attrs[0].value.u16 = 0x0800;
udf_match1_attrs[1].id = (sai_attr_id_t)SAI_UDF_ATTR_MATCH_L3_TYPE; udf_match1_attrs[1].value.u8 = 0x11;  // UDP
udf_match1_attrs[2].id = (sai_attr_id_t)SAI_UDF_MATCH_ATTR_L4_DST_PORT_TYPE; udf_match1_attrs[2].value.u16 = 1234; // some UDP port number

sai_udf_match_api->create_udf_match(&udf_match1_id, 3, udf_match1_attrs);

Signed-off-by: Rohit Puri <rohitpuri@meta.com>
Signed-off-by: Shrikrishna Khare <skhare@meta.com>

Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:
Signed-off-by: Rohit Puri <rohitpuri@meta.com>