### PR TITLE
[1.10]Enhance the check enum lock script

### DIFF
--- a/meta/checkenumlock.sh
+++ b/meta/checkenumlock.sh
@@ -27,17 +27,12 @@ set -e
 
 rm -rf temp
 
-mkdir temp
+sairepo=`git remote get-url origin`
 
-git --work-tree=temp/ checkout origin/master inc
-git --work-tree=temp/ checkout origin/master experimental
+git clone $sairepo temp
 
 echo "Checking for possible enum values shift (current branch vs origin/master) ..."
 
 ./checkheaders.pl -s ../inc/ temp/inc/
 
 rm -rf temp
-# clean up the git changes as well
-# workaround fix for git --work-tree=temp/ checkout ...
-# after checkout from other branch, data will be left in git
-git stash

--- a/meta/checkenumlock.sh
+++ b/meta/checkenumlock.sh
@@ -37,3 +37,7 @@ echo "Checking for possible enum values shift (current branch vs origin/master) 
 ./checkheaders.pl -s ../inc/ temp/inc/
 
 rm -rf temp
+# clean up the git changes as well
+# workaround fix for git --work-tree=temp/ checkout ...
+# after checkout from other branch, data will be left in git
+git stash


### PR DESCRIPTION
Why
fix for
```
 git --work-tree=temp/ checkout 
```
after checkout from other branch, data will be left in git

then in when running command from sonic-buildimage/rules/sairedis.dep, it will report
```
[sonic-buildimage/rules/sairedis.dep](make: *** No rule to make target 'src/sonic-sairedis/SAI/inc/saigenericprogrammable.h', needed by 'target/debs/buster/libsairedis_1.0.0_amd64.deb.smdep'.)
```

How
clean up the git env

Verify
run script
```
checkenumlock.sh
```

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>