### PR TITLE
[cherry-pick][202211]Enhance the check enum lock script (#1741)

### DIFF
--- a/meta/checkenumlock.sh
+++ b/meta/checkenumlock.sh
@@ -27,10 +27,9 @@ set -e
 
 rm -rf temp
 
-mkdir temp
+sairepo=`git remote get-url origin`
 
-git --work-tree=temp/ checkout origin/master inc
-git --work-tree=temp/ checkout origin/master experimental
+git clone $sairepo temp
 
 echo "Checking for possible enum values shift (current branch vs origin/master) ..."
 


### PR DESCRIPTION
* Enhance the check enum lock script Why
workaround fix for git --work-tree=temp/ checkout ... after checkout from other branch, data will be left in git

then in when running command from sonic-buildimage/rules/sairedis.dep, it will report
```
sonic-buildimage/rules/sairedis.dep
```

How
clean up the git env

Verify
run script

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>

* enhance

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>

---------

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>