### PR TITLE
[SAI-PTF]Add back the skipped cases for reporting the failure

### DIFF
--- a/test/sai_test/sai_ecmp_test.py
+++ b/test/sai_test/sai_ecmp_test.py
@@ -518,7 +518,7 @@ class EcmpHashFieldProtoTestV4(T0TestBase):
         T0TestBase.setUp(self,
                          is_create_route_for_nhopgrp=True,
                          is_create_route_for_lag=False,
-                         skip_reason ="SKIP! Skip test for broadcom, can't load balance on protocol such as tcp and udp. Item: 15023123",
+                         #skip_reason ="SKIP! Skip test for broadcom, can't load balance on protocol such as tcp and udp. Item: 15023123",
                         )
         
     def test_load_balance_on_protocolv4(self):
@@ -639,7 +639,7 @@ class EcmpHashFieldProtoTestV6(T0TestBase):
         T0TestBase.setUp(self,
                          is_create_route_for_nhopgrp=True,
                          is_create_route_for_lag=False,
-                         skip_reason ="SKIP! Skip test for broadcom, can't load balance on protocol such as tcp and udp. Item: 15023123",
+                         #skip_reason ="SKIP! Skip test for broadcom, can't load balance on protocol such as tcp and udp. Item: 15023123",
                         )
         
     def test_load_balance_on_protocolv6(self):
@@ -2095,7 +2095,8 @@ class EcmpCoExistLagRouteV4(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self,
-                         skip_reason = "SKIP! Skip test for broadcom, learn_disable, report error code -196608, no error log. Item: 16384090")
+                         #skip_reason = "SKIP! Skip test for broadcom, learn_disable, report error code -196608, no error log. Item: 16384090"
+                         )
         nhop_groupv4_id = sai_thrift_create_next_hop_group(self.client, type=SAI_NEXT_HOP_GROUP_TYPE_ECMP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
@@ -2187,7 +2188,8 @@ class EcmpCoExistLagRouteV6(T0TestBase):
         Test the basic setup process
         """
         T0TestBase.setUp(self,
-                         skip_reason = "SKIP! Skip test for broadcom, learn_disable, report error code -196608, no error log. Item: 16384090")
+                         #skip_reason = "SKIP! Skip test for broadcom, learn_disable, report error code -196608, no error log. Item: 16384090"
+                         )
         nhop_groupv6_id = sai_thrift_create_next_hop_group(self.client, type=SAI_NEXT_HOP_GROUP_TYPE_ECMP)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 

--- a/test/sai_test/sai_fdb_test.py
+++ b/test/sai_test/sai_fdb_test.py
@@ -100,7 +100,8 @@ class VlanLearnDisableTest(T0TestBase):
         T0TestBase.setUp(
             self, 
             is_reset_default_vlan=False, 
-            skip_reason = "SKIP! Skip test for broadcom, learn_disable, report error code -196608, no error log. Item: 15000933")
+            #skip_reason = "SKIP! Skip test for broadcom, learn_disable, report error code -196608, no error log. Item: 15000933"
+            )
         status = sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
@@ -285,7 +286,8 @@ class NonBridgePortNoLearnTest(T0TestBase):
         T0TestBase.setUp(
             self, 
             is_reset_default_vlan=False,
-            skip_reason ="SKIP! Skip test for broadcom, non bridge port still can learn. Item: 15000950")
+            #skip_reason ="SKIP! Skip test for broadcom, non bridge port still can learn. Item: 15000950"
+            )
         status = sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)
 
@@ -1038,7 +1040,8 @@ class FdbFlushVlanStaticTest(T0TestBase):
         T0TestBase.setUp(
             self, 
             is_reset_default_vlan=False,
-            skip_reason ="SKIP! Static flush Not support by broadcom. Item:15419274")
+            #skip_reason ="SKIP! Static flush Not support by broadcom. Item:15419274"
+            )
         status = sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_STATIC)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
@@ -1092,7 +1095,8 @@ class FdbFlushPortStaticTest(T0TestBase):
         T0TestBase.setUp(
             self, 
             is_reset_default_vlan=False,
-            skip_reason ="SKIP! Static flush Not support by broadcom. Item:15419274")
+            #skip_reason ="SKIP! Static flush Not support by broadcom. Item:15419274"
+            )
         sai_thrift_flush_fdb_entries(
             self.client, bridge_port_id=self.dut.port_obj_list[1].bridge_port_oid, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_STATIC)
 
@@ -1145,7 +1149,8 @@ class FdbFlushAllStaticTest(T0TestBase):
         T0TestBase.setUp(
             self, 
             is_reset_default_vlan=False,
-            skip_reason = "SKIP! Static flush Not support by broadcom. Item:15419274")
+            #skip_reason = "SKIP! Static flush Not support by broadcom. Item:15419274"
+            )
         sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_STATIC)
 
@@ -1455,7 +1460,8 @@ class FdbFlushAllTest(T0TestBase):
         T0TestBase.setUp(
             self, 
             is_reset_default_vlan=False,
-            skip_reason = "SKIP! Unstable, flood cannot be recovered. Item:15002648")
+            #skip_reason = "SKIP! Unstable, flood cannot be recovered. Item:15002648
+            )
 
     @warm_test(is_test_rebooting=False)
     def runTest(self):

--- a/test/sai_test/sai_lag_test.py
+++ b/test/sai_test/sai_lag_test.py
@@ -316,7 +316,8 @@ class LoadbalanceOnProtocolTest(T0TestBase):
         """                  
         T0TestBase.setUp(
             self,
-            skip_reason ="SKIP! Skip test for broadcom, can't load balance on protocol such as tcp and udp.Item: 15023123")
+            #skip_reason ="SKIP! Skip test for broadcom, can't load balance on protocol such as tcp and udp.Item: 15023123"
+            )
 
     def runTest(self):
         """
@@ -482,7 +483,8 @@ class DisableIngressTest(T0TestBase):
         """                        
         T0TestBase.setUp(
             self,
-            skip_reason = "SKIP! Skip test for broadcom, can't disable ingress of lag member. Item: 14988584")
+            #skip_reason = "SKIP! Skip test for broadcom, can't disable ingress of lag member. Item: 14988584"
+            )
 
     def runTest(self):
         """


### PR DESCRIPTION
Why
Some cases with known issue have been skipped, but it is not very easy to get known the result, add back the skipped test cases for reporting the failure and check the status.

how
Add back the skipped test cases for reporting the failure and check the status.

Verification
run with command
```
ptf --test-dir ./ sai_vlan_test.VlanLearnDisableTest  --interface '0-0@eth0' --interface '0-1@eth1' --interface '0-2@eth2' --interface '0-3@eth3' --interface '0-4@eth4' --interface '0-5@eth5' --interface '0-6@eth6' --interface '0-7@eth7' --interface '0-8@eth8' --interface '0-9@eth9' --interface '0-10@eth10' --interface '0-11@eth11' --interface '0-12@eth12' --interface '0-13@eth13' --interface '0-14@eth14' --interface '0-15@eth15' --interface '0-16@eth16' --interface '0-17@eth17' --interface '0-18@eth18' --interface '0-19@eth19' --interface '0-20@eth20' --interface '0-21@eth21' --interface '0-22@eth22' --interface '0-23@eth23' --interface '0-24@eth24' --interface '0-25@eth25' --interface '0-26@eth26' --interface '0-27@eth27' --interface '0-28@eth28' --interface '0-29@eth29' --interface '0-30@eth30' --interface '0-31@eth31' --relax --xunit --xunit-dir /tmp/sai_qualify/test_results_tmp "--test-params=thrift_server='$DUTIP';port_config_ini='/tmp/sai_qualify/resources/port_config.ini'"
```