### PR TITLE
[SAI-PTF] Refactor ptf case by reading configuration from json file

### DIFF
--- a/ptf/config/config_db_loader.py
+++ b/ptf/config/config_db_loader.py
@@ -23,7 +23,7 @@ from os.path import exists
 import json
 
 from typing import TYPE_CHECKING
-from typing import Dict
+from typing import Dict, List
 
 from data_module.port_config import PortConfig
 
@@ -84,7 +84,7 @@ class ConfigDBLoader():
         port_conf = self.config_json.get('PORT')
         port_Configs = []
         for index, key in enumerate(port_conf):
-            PortConfig = PortConfig()
+            portConfig = PortConfig()
             portConfig.name = key
             portConfig.alias = port_conf[key]['alias']
             portConfig.index = int(port_conf[key]['index'])

--- a/ptf/config/config_db_loader.py
+++ b/ptf/config/config_db_loader.py
@@ -23,6 +23,9 @@ from os.path import exists
 import json
 
 from typing import TYPE_CHECKING
+from typing import Dict
+
+from data_module.port_config import PortConfig
 
 DEFAULT_CONFIG_DB = "../resources/config_db.json"
 
@@ -71,13 +74,30 @@ class ConfigDBLoader():
         return config_path
 
 
-    def get_port_config(self):
+    def get_port_config(self) -> List['PortConfig']:
         '''
         Method for get the configuration for port config.
         RETURN:
-            dict: port config
+            dict: port config, key is the interface name
         '''
         
         port_conf = self.config_json.get('PORT')
-        self.port_config = port_conf
-        return port_conf
+        port_Configs = []
+        for index, key in enumerate(port_conf):
+            PortConfig = PortConfig()
+            portConfig.name = key
+            portConfig.alias = port_conf[key]['alias']
+            portConfig.index = int(port_conf[key]['index'])
+            portConfig.lanes = [int(i) for i in port_conf[key]['lanes'].split(',')]
+            portConfig.mtu = 0 if not 'mtu' in  port_conf[key] else int(port_conf[key]['mtu'])
+            portConfig.pfc_asym = None \
+                if not 'pfc_asym' in  port_conf[key] else port_conf[key]['pfc_asym']
+            portConfig.speed = 0 \
+                if not 'speed' in  port_conf[key] else int(port_conf[key]['speed'])
+            portConfig.fec = None \
+                if not 'fec' in  port_conf[key] else port_conf[key]['fec']
+            portConfig.tpid = None if not 'tpid' in  port_conf[key] else port_conf[key]['tpid']
+            port_Configs.append(portConfig)
+
+        self.port_config = port_Configs
+        return port_Configs

--- a/ptf/config/port_config_ini_loader.py
+++ b/ptf/config/port_config_ini_loader.py
@@ -139,18 +139,4 @@ class PortConfigInILoader():
         except Exception as e:
             raise e
 
-@auto_str
-class PortConfig(object):
-    """
-    Represent the PortConfig Object
 
-    Attrs:
-        name: interface name
-        lanes: lanes
-        speed: port speed
-    """
-
-    def __init__(self, name=None, lanes=None, speed=None):
-        self.name = name
-        self.lanes = lanes
-        self.speed = speed

--- a/ptf/config/port_configer.py
+++ b/ptf/config/port_configer.py
@@ -146,7 +146,7 @@ class PortConfiger(object):
 
         bridge_size = self.test_obj.system_port_no + self.test_obj.active_ports_no + 1
         attr = sai_thrift_get_bridge_attribute(
-                    self.client, 
+                    self.client,
                     bridge_oid=bridge_id,
                     port_list=sai_thrift_object_list_t(
                         idlist=[], count=bridge_size))

--- a/ptf/config/port_configer.py
+++ b/ptf/config/port_configer.py
@@ -363,7 +363,7 @@ class PortConfiger(object):
 
     def get_lane_sorted_port_list(self, port_obj_list_with_lane: List[Port]):
         """
-        Get the port list sorted by lanes name(defined in port_config.ini).
+        Get the port list sorted by lanes name(defined in config_db.json).
         This method will cut the ports list base on the lanes.
         i.e. If device has 64 ports but just define 32 in lanes, then just generate 32 ports
 
@@ -385,14 +385,14 @@ class PortConfiger(object):
 
     def sort_port_list_by_config(self, ports_config: List[PortConfig], port_list: List[Port]):
         """
-        Sort the port list base on the port_config.ini.
+        Sort the port list base on the config_db.json.
         This method will match the default_lane_list in the port object with the lane defined in 
         port config for a ordered port list.
         This method will create the port list base on the mini number of interfaces from
-        command parameters or port_config.ini
+        command parameters or config_db.json
 
         Attrs:
-            ports_config: port config, which gets from the port_config.ini
+            ports_config: port config, which gets from the config_db.json
             port_list: port list
         """
         sorted_port_list: List[Port] = []

--- a/ptf/config/port_configer.py
+++ b/ptf/config/port_configer.py
@@ -498,7 +498,7 @@ class PortConfiger(object):
                         port_up = True
                         break
                     time.sleep(3)
-                    # self.log_port_state(port, index)
+                    self.log_port_state(port, index)
                     print("port {} , local index {} id {} is not up, status: {}. Retry. Reset Admin State.".format(
                         index, port.port_index, port.oid, port_attr['oper_status']))
                     sai_thrift_set_port_attribute(
@@ -525,9 +525,7 @@ class PortConfiger(object):
         return fec_change[port.config.fec]
 
     def log_port_state(self, port:Port, index):
-        print("port index:{} hardIdx: {} "
-        .join("ptf_dev_idx: {} name:{}")
-        .join("config lane:{} mtu:{} fec:{} speed:{}").format(
+        print("port index:{} hardIdx: {} ptf_dev_idx: {} name:{} config lane:{} mtu:{} fec:{} speed:{}".format(
             index,
             port.port_index,
             port.dev_port_index,

--- a/ptf/config/port_configer.py
+++ b/ptf/config/port_configer.py
@@ -144,7 +144,7 @@ class PortConfiger(object):
         """
         print("Get bridge ports...")
 
-        bridge_size = self.test_obj.dut.system_port_no + self.test_obj.dut.active_ports_no + 1
+        bridge_size = self.test_obj.system_port_no + self.test_obj.active_ports_no + 1
         attr = sai_thrift_get_bridge_attribute(
                     self.client, 
                     bridge_oid=bridge_id,
@@ -349,13 +349,12 @@ class PortConfiger(object):
         port_obj_list_with_lane: List[Port] = []
         # the active number must match the actual account, or might return null
         port_list = sai_thrift_object_list_t(
-            idlist=[], count=self.test_obj.dut.active_ports_no)
+            idlist=[], count=self.test_obj.active_ports_no)
         p_list = sai_thrift_get_switch_attribute(self.client, port_list=port_list)
         for index, item in enumerate(p_list['port_list'].idlist):
-            port: Port = Port(oid=item, port_index=index, rif_list=[
-            ], nexthopv4_list=[], nexthopv6_list=[])
+            port: Port = Port(oid=item, port_index=index)
             temp_list = sai_thrift_object_list_t(
-                count=self.test_obj.dut.active_ports_no)
+                count=self.test_obj.active_ports_no)
             attr = sai_thrift_get_port_attribute(
                 self.client, port_oid=port.oid, hw_lane_list=temp_list)
             port.default_lane_list = attr['hw_lane_list'].uint32list
@@ -499,7 +498,7 @@ class PortConfiger(object):
                         port_up = True
                         break
                     time.sleep(3)
-                    self.log_port_state(port, index)
+                    # self.log_port_state(port, index)
                     print("port {} , local index {} id {} is not up, status: {}. Retry. Reset Admin State.".format(
                         index, port.port_index, port.oid, port_attr['oper_status']))
                     sai_thrift_set_port_attribute(

--- a/ptf/data_module/port.py
+++ b/ptf/data_module/port.py
@@ -22,6 +22,7 @@ from typing import List, Dict
 from typing import TYPE_CHECKING
 from data_module.data_obj import auto_str
 from data_module.data_obj import data_item
+from data_module.port_config import PortConfig
 
 
 @auto_str
@@ -72,8 +73,7 @@ class Port(data_item):
         """
         bridge port object id
         """
-        self.port_config:Dict = {}
-        self.config_db:Dict = {}
+        self.config:PortConfig = None
         self.host_itf_id = None
         """
         Port binded host interface id, the object saved in dut.hostif_list

--- a/ptf/data_module/port_config.py
+++ b/ptf/data_module/port_config.py
@@ -33,5 +33,5 @@ class PortConfig(object):
         self.mtu = mtu
         self.pfc_asym = pfc_asym
         self.speed = speed
-        self.fec=fec
+        self.fec = fec
         self.tpid = tpid

--- a/ptf/data_module/port_config.py
+++ b/ptf/data_module/port_config.py
@@ -1,0 +1,37 @@
+from data_module.data_obj import auto_str
+
+@auto_str
+class PortConfig(object):
+    """
+    Represent the PortConfig Object
+    Attrs:
+        name: interface name
+        lanes: lanes
+        speed: port speed
+        fec: fec mode
+        alias: alias
+        index: index
+        mtu: mtu
+        pfc_asym: pfc_asym
+        tpid: tpid
+    """
+
+    def __init__(self,
+    name=None,
+    lanes=None,
+    speed=None,
+    fec=None,
+    alias=None,
+    index=None,
+    mtu=None,
+    pfc_asym=None,
+    tpid=None):
+        self.name = name
+        self.lanes = lanes
+        self.alias = alias
+        self.index = index
+        self.mtu = mtu
+        self.pfc_asym = pfc_asym
+        self.speed = speed
+        self.fec=fec
+        self.tpid = tpid

--- a/ptf/platform_helper/brcm_sai_helper.py
+++ b/ptf/platform_helper/brcm_sai_helper.py
@@ -234,4 +234,4 @@ class BrcmSaiHelper(CommonSaiHelper):
         #Port needs to be init and setup at same time.
         #Make the process happened in turn_up_and_check_ports
         print("BrcmSaiHelperBase::recreate_ports does not support. Just Parse Port Config")
-        self.ports_config = self.port_config_ini_loader.ports_config
+        # self.ports_config = self.port_config_ini_loader.ports_config

--- a/ptf/platform_helper/brcm_sai_helper.py
+++ b/ptf/platform_helper/brcm_sai_helper.py
@@ -196,14 +196,9 @@ class BrcmSaiHelper(CommonSaiHelper):
 
     def config_port(self):
 
-        self.port_list = self.port_configer.get_lane_sorted_port_list()
+        port_obj_list_with_lane = self.port_configer.get_port_default_lane()
+        self.port_list = self.port_configer.get_lane_sorted_port_list(port_obj_list_with_lane)
         self.port_configer.generate_port_obj_list_by_interface_config()
-        self.port_configer.assign_port_config(self.port_config_ini_loader.portConfigs)
-        self.port_configer.assign_config_db(
-            self.config_db_loader.port_config,
-            self.port_config_ini_loader.portConfigs)
-        
-        
 
         attr = sai_thrift_get_switch_attribute(
             self.client, default_trap_group=True)

--- a/ptf/platform_helper/mlnx_sai_helper.py
+++ b/ptf/platform_helper/mlnx_sai_helper.py
@@ -23,6 +23,15 @@ from platform_helper.common_sai_helper import * # pylint: disable=wildcard-impor
 
 class MlnxSaiHelper(CommonSaiHelper):
     """
-    This class contains Mellanox(brcm) specified functions for the platform setup and test context configuration.
+    This class contains Mellanox(mlnx) specified functions for the platform setup and test context configuration.
     """
     platform = 'mlnx'
+
+    def __init__(self, *args, **kwargs) -> None:
+        """
+        Init the Port configer.
+
+        Args:
+            test_obj: the test object
+        """
+        super().__init__(*args, **kwargs)

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -43,7 +43,7 @@ import sai_thrift.sai_adapter as adapter
 
 from config.port_configer import PortConfiger
 from config.config_db_loader import ConfigDBLoader
-from config.port_config_ini_loader import PortConfig, PortConfigInILoader
+from config.port_config_ini_loader import PortConfigInILoader
 
 ROUTER_MAC = '00:77:66:55:44:00'
 THRIFT_PORT = 9092
@@ -392,11 +392,11 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         self.active_ports_no = attr['number_of_active_ports']
 
         # get number of system ports
-        attr = sai_thrift_get_switch_attribute(
-            self.client, number_of_system_ports=True)
+        # attr = sai_thrift_get_switch_attribute(
+        #     self.client, number_of_system_ports=True)
         number_of_active_ports = 0
-        if attr and 'number_of_system_ports' in attr:
-            number_of_active_ports = attr['number_of_system_ports']
+        # if attr and 'number_of_system_ports' in attr:
+        #     number_of_active_ports = attr['number_of_system_ports']
         self.system_port_no = number_of_active_ports
 
         # get port_list and portX objects

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -391,6 +391,8 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         self.active_ports_no = attr['number_of_active_ports']
         print("Get number_of_active_ports {}".format(self.active_ports_no))
 
+        adapter.CATCH_EXCEPTIONS = capture_status
+        adapter.EXPECTED_ERROR_CODE = expected_code
         print("Restore all the expect error code and exception captures.")
 
 

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -346,7 +346,7 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         self.config_db_loader: ConfigDBLoader = None
         self.port_config_ini_loader: PortConfigInILoader = None
         # TODO: Below two attributes should be move to port_configer
-        self.ports_config: Dict = None
+        self.ports_config = None
         """
         ports_config dict, use to compatiable with old data module
         """
@@ -390,6 +390,14 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         attr = sai_thrift_get_switch_attribute(
             self.client, number_of_active_ports=True)
         self.active_ports_no = attr['number_of_active_ports']
+
+        # get number of system ports
+        attr = sai_thrift_get_switch_attribute(
+            self.client, number_of_system_ports=True)
+        number_of_active_ports = 0
+        if attr and 'number_of_system_ports' in attr:
+            number_of_active_ports = attr['number_of_system_ports']
+        self.system_port_no = number_of_active_ports
 
         # get port_list and portX objects
         attr = sai_thrift_get_switch_attribute(
@@ -567,17 +575,13 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
 
     def setUp(self):
         super(SaiHelperBase, self).setUp()
-        if 'port_config_ini' in self.test_params:
-            self.port_config_ini_loader = PortConfigInILoader(self.test_params['port_config_ini'])
-        else:
-            self.port_config_ini_loader = PortConfigInILoader()        
-        self.port_config_ini_loader.parse_port_config()
-        self.ports_config = self.port_config_ini_loader.ports_config
 
         if 'config_db_json' in self.test_params:
             self.config_db_loader = ConfigDBLoader(self.test_params['config_db_json'])
         else:
             self.config_db_loader = ConfigDBLoader()
+        self.ports_config = self.config_db_loader.get_port_config()
+        
         self.port_configer = PortConfiger(self)
         self.def_bridge_port_list = []
         self.def_bridge_port_list = []

--- a/test/sai_test/config/switch_configer.py
+++ b/test/sai_test/config/switch_configer.py
@@ -110,4 +110,7 @@ class SwitchConfiger(object):
             self.client, number_of_active_ports=True)
         self.test_obj.dut.active_ports_no = attr['number_of_active_ports']
         print("Get number_of_active_ports {}".format(self.test_obj.dut.active_ports_no))
+
+        adapter.CATCH_EXCEPTIONS = capture_status
+        adapter.EXPECTED_ERROR_CODE = expected_code
         print("Restore all the expect error code and exception captures.")

--- a/test/sai_test/config/switch_configer.py
+++ b/test/sai_test/config/switch_configer.py
@@ -68,7 +68,7 @@ class SwitchConfiger(object):
         Returns:
             Vlan: vlan object
         """
-        if self.test_obj.test_reboot_stage  == WARM_TEST_POST_REBOOT:
+        if self.test_obj.test_reboot_stage == WARM_TEST_POST_REBOOT:
             switch_id = sai_thrift_create_switch(
                 self.test_obj.client, init_switch=True, warm_recover=True)
         else:

--- a/test/sai_test/config/vlan_configer.py
+++ b/test/sai_test/config/vlan_configer.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from sai_test_base import T0TestBase
 
 
-def t0_vlan_config_helper(test_obj: 'T0TestBase', is_reset_default_vlan=True, is_create_vlan=True):
+def t0_vlan_config_helper(test_obj: 'T0TestBase', is_reset_default_vlan=False, is_create_vlan=True):
     """
     Make t0 Vlan configurations base on the configuration in the test plan.
     Set the configuration in test directly.

--- a/test/sai_test/sai_fdb_test.py
+++ b/test/sai_test/sai_fdb_test.py
@@ -40,10 +40,8 @@ class L2PortForwardingTest(T0TestBase):
         # str-msn2700-04 ERR saiserverv2#SDK: 
         # [SAI_LAG.ERR] mlnx_sai_lag.c[617]- validate_port: Can't add port which is under bridge
         T0TestBase.setUp(self,
-                        is_reset_default_vlan=False,
                         is_create_lag=False,
                         is_create_route_for_lag=False)
-        
 
     @warm_test(is_test_rebooting=True)
     def runTest(self):
@@ -98,8 +96,7 @@ class VlanLearnDisableTest(T0TestBase):
         Set up test
         """
         T0TestBase.setUp(
-            self, 
-            is_reset_default_vlan=False, 
+            self
             #skip_reason = "SKIP! Skip test for broadcom, learn_disable, report error code -196608, no error log. Item: 15000933"
             )
         status = sai_thrift_flush_fdb_entries(
@@ -181,7 +178,7 @@ class BridgePortLearnDisableTest(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
         status = sai_thrift_flush_fdb_entries(
             self.client, entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
@@ -284,8 +281,7 @@ class NonBridgePortNoLearnTest(T0TestBase):
         Set up test
         """
         T0TestBase.setUp(
-            self, 
-            is_reset_default_vlan=False,
+            self
             #skip_reason ="SKIP! Skip test for broadcom, non bridge port still can learn. Item: 15000950"
             )
         status = sai_thrift_flush_fdb_entries(
@@ -389,7 +385,7 @@ class NewVlanmemberLearnTest(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
         self.new_vlan10_member = sai_thrift_create_vlan_member(self.client,
                                                                vlan_id=self.dut.vlans[10].oid,
                                                                bridge_port_id=self.dut.port_obj_list[24].bridge_port_oid)
@@ -552,7 +548,7 @@ class InvalidateVlanmemberNoLearnTest(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
     @warm_test(is_test_rebooting=False)
@@ -608,7 +604,7 @@ class BroadcastNoLearnTest(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
 
     @warm_test(is_test_rebooting=False)
     def runTest(self):
@@ -662,7 +658,7 @@ class MulticastNoLearnTest(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
 
     @warm_test(is_test_rebooting=False)
     def runTest(self):
@@ -720,7 +716,7 @@ class FdbAgingTest(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
         sw_attr = sai_thrift_get_switch_attribute(
             self.client, fdb_aging_time=True)
         self.default_wait_time = sw_attr["fdb_aging_time"]
@@ -812,7 +808,7 @@ class FdbAgingAfterMoveTest(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
         sw_attr = sai_thrift_get_switch_attribute(
             self.client, fdb_aging_time=True)
         self.default_wait_time = sw_attr["fdb_aging_time"]
@@ -929,7 +925,7 @@ class FdbMacMovingAfterAgingTest(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
         sw_attr = sai_thrift_get_switch_attribute(
             self.client, fdb_aging_time=True)
         self.default_wait_time = sw_attr["fdb_aging_time"]
@@ -1038,8 +1034,7 @@ class FdbFlushVlanStaticTest(T0TestBase):
         Set up test
         """
         T0TestBase.setUp(
-            self, 
-            is_reset_default_vlan=False,
+            self
             #skip_reason ="SKIP! Static flush Not support by broadcom. Item:15419274"
             )
         status = sai_thrift_flush_fdb_entries(
@@ -1093,8 +1088,7 @@ class FdbFlushPortStaticTest(T0TestBase):
         Set up test
         """ 
         T0TestBase.setUp(
-            self, 
-            is_reset_default_vlan=False,
+            self
             #skip_reason ="SKIP! Static flush Not support by broadcom. Item:15419274"
             )
         sai_thrift_flush_fdb_entries(
@@ -1147,8 +1141,7 @@ class FdbFlushAllStaticTest(T0TestBase):
         Set up test
         """      
         T0TestBase.setUp(
-            self, 
-            is_reset_default_vlan=False,
+            self
             #skip_reason = "SKIP! Static flush Not support by broadcom. Item:15419274"
             )
         sai_thrift_flush_fdb_entries(
@@ -1195,7 +1188,7 @@ class FdbFlushVlanDynamicTest(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
         # disable fdb aging
         # age time used in tests (in sec)
         self.age_time = 0
@@ -1288,7 +1281,7 @@ class FdbFlushPortDynamicTest(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
 
     @warm_test(is_test_rebooting=False)
     def runTest(self):
@@ -1371,7 +1364,7 @@ class FdbFlushAllDynamicTest(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
 
     @warm_test(is_test_rebooting=False)
     def runTest(self):
@@ -1458,8 +1451,7 @@ class FdbFlushAllTest(T0TestBase):
         Set up test
         """     
         T0TestBase.setUp(
-            self, 
-            is_reset_default_vlan=False,
+            self
             #skip_reason = "SKIP! Unstable, flood cannot be recovered. Item:15002648
             )
 
@@ -1543,7 +1535,7 @@ class FdbDisableMacMoveDropTest(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
         self.fdb_entry = sai_thrift_fdb_entry_t(switch_id=self.dut.switch_id,
                                                 mac_address=self.servers[1][1].mac,
                                                 bv_id=self.dut.vlans[10].oid)
@@ -1593,7 +1585,7 @@ class FdbDynamicMacMoveTest(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
         sai_thrift_flush_fdb_entries(
             self.client,
             entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)
@@ -1659,7 +1651,7 @@ class FdbStaticMacMoveTest(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
         sai_thrift_flush_fdb_entries(
             self.client,
             entry_type=SAI_FDB_FLUSH_ENTRY_TYPE_ALL)

--- a/test/sai_test/sai_route_test.py
+++ b/test/sai_test/sai_route_test.py
@@ -1376,7 +1376,7 @@ class SviMacAgingTest(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
         sw_attr = sai_thrift_get_switch_attribute(
             self.client, fdb_aging_time=True)
         self.default_wait_time = sw_attr["fdb_aging_time"]
@@ -1455,7 +1455,7 @@ class SviMacAgingV6Test(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
         sw_attr = sai_thrift_get_switch_attribute(
             self.client, fdb_aging_time=True)
         self.default_wait_time = sw_attr["fdb_aging_time"]

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -362,9 +362,10 @@ class T0TestBase(ThriftInterfaceDataPlane):
 
     def setUp(self,
               force_config=False,
+              is_remove_default_vlan=True,
               is_create_hostIf=True,
               is_recreate_bridge=True,
-              is_reset_default_vlan=True,
+              is_reset_default_vlan=False,
               is_create_vlan=True,
               is_create_fdb=True,
               is_create_default_route=True,
@@ -397,7 +398,8 @@ class T0TestBase(ThriftInterfaceDataPlane):
         if force_config or not self.common_configured:
             self.create_device()
             t0_switch_config_helper(self)
-            remove_default_vlan(self)
+            if is_remove_default_vlan:
+                remove_default_vlan(self)
             t0_port_config_helper(
                 test_obj=self,
                 is_create_hostIf=is_create_hostIf,

--- a/test/sai_test/sai_test_base.py
+++ b/test/sai_test/sai_test_base.py
@@ -365,7 +365,6 @@ class T0TestBase(ThriftInterfaceDataPlane):
               is_remove_default_vlan=True,
               is_create_hostIf=True,
               is_recreate_bridge=True,
-              is_reset_default_vlan=False,
               is_create_vlan=True,
               is_create_fdb=True,
               is_create_default_route=True,
@@ -406,7 +405,6 @@ class T0TestBase(ThriftInterfaceDataPlane):
                 is_recreate_bridge=is_recreate_bridge)
             t0_vlan_config_helper(
                 test_obj=self,
-                is_reset_default_vlan=is_reset_default_vlan,
                 is_create_vlan=is_create_vlan)
             t0_fdb_config_helper(
                 test_obj=self,

--- a/test/sai_test/sai_vlan_test.py
+++ b/test/sai_test/sai_vlan_test.py
@@ -38,7 +38,7 @@ class Vlan_Domain_Forwarding_Test(T0TestBase):
         """
         Set up test
         """
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
     
     @warm_test(is_test_rebooting=True)
     def runTest(self):
@@ -565,7 +565,7 @@ class VlanMemberInvalidTest(T0TestBase):
     This test verifies when adding a VLAN member to a non-exist VLAN, it will fail.
     """
     def setUp(self):
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
 
     @warm_test(is_test_rebooting=False)
     def runTest(self):
@@ -591,12 +591,11 @@ class DisableMacLearningTaggedTest(T0TestBase):
     """
     def setUp(self):
         T0TestBase.setUp(
-            self, 
-            is_reset_default_vlan=False,
-            is_create_vlan_itf=False, 
-            is_create_route_for_vlan_itf=False, 
-            is_create_route_for_lag=False, 
-            is_create_lag=False, 
+            self,
+            is_create_vlan_itf=False,
+            is_create_route_for_vlan_itf=False,
+            is_create_route_for_lag=False,
+            is_create_lag=False,
             is_create_default_route=False)
         print("DisableMacLearningTaggedTest")
         sai_thrift_set_vlan_attribute(
@@ -638,12 +637,11 @@ class DisableMacLearningUntaggedTest(T0TestBase):
     """
     def setUp(self):
         T0TestBase.setUp(
-            self, 
-            is_reset_default_vlan=False, 
-            is_create_vlan_itf=False, 
-            is_create_route_for_vlan_itf=False, 
-            is_create_route_for_lag=False, 
-            is_create_lag=False, 
+            self,
+            is_create_vlan_itf=False,
+            is_create_route_for_vlan_itf=False,
+            is_create_route_for_lag=False,
+            is_create_lag=False,
             is_create_default_route=False)
         print("DisableMacLearningUntaggedTest")
         sai_thrift_set_vlan_attribute(
@@ -682,7 +680,7 @@ class ArpRequestFloodingTest(T0TestBase):
     This test verifies the flooding when receive a arp request
     """
     def setUp(self):
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
         ip2 = "192.168.0.2"
         self.arp_request = simple_arp_packet(
             eth_dst=self.servers[1][2].mac,
@@ -710,7 +708,7 @@ class ArpRequestLearningTest(T0TestBase):
     This test verifies the mac learning when receive a arp request
     """
     def setUp(self):
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
 
     @warm_test(is_test_rebooting=True)
     def runTest(self):
@@ -745,7 +743,7 @@ class TaggedVlanStatusTest(T0TestBase):
     This test verifies VLAN-related counters with tagged pkt 
     """
     def setUp(self):
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
 
     @warm_test(is_test_rebooting=False)
     def runTest(self):
@@ -840,7 +838,7 @@ class UntaggedVlanStatusTest(T0TestBase):
     This test verifies VLAN-related counters with untagged pkt 
     """
     def setUp(self):
-        T0TestBase.setUp(self, is_reset_default_vlan=False)
+        T0TestBase.setUp(self)
 
     @warm_test(is_test_rebooting=False)
     def runTest(self):


### PR DESCRIPTION
# Why
In the current structure, it depends on a config.ini file whose format is not very friendly, and the default config.ini file copied from DUT does not contain enough configurations. In order to get more config data, depends on the json config file.

# How
construct a new data object port config (we can have more config) remove dependencies from config ini
add depends on json config

# Verify
The DUT test and pipeline test all passed.

Signed-off-by: zitingguo <zitingguo@microsoft.com>