### PR TITLE
[SAI-PTF] Refactor stats counter related method

### DIFF
--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -693,7 +693,8 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
     def tearDown(self):
         try:
             for port in self.port_list:
-                sai_thrift_clear_port_stats(self.client, port)
+                clear_counter(
+                    self, sai_thrift_clear_port_stats, port)
                 sai_thrift_set_port_attribute(
                     self.client, port, port_vlan_id=0)
             #Todo: Remove this condition after brcm's remove_switch issue fixed

--- a/ptf/saibuffer.py
+++ b/ptf/saibuffer.py
@@ -105,14 +105,16 @@ class BufferStatistics(MinimalPortVlanConfig):
         traffic.start()
 
         while traffic.is_alive():
-            stats = query_counter(self, sai_thrift_get_buffer_pool_stats, self.ingr_pool)
+            stats = query_counter(
+                    self, sai_thrift_get_buffer_pool_stats, self.ingr_pool)
 
             if (stats["SAI_BUFFER_POOL_STAT_CURR_OCCUPANCY_BYTES"]
                     > bp_curr_occupancy_bytes):
                 bp_curr_occupancy_bytes = stats["SAI_BUFFER_POOL_STAT_"
                                                 "CURR_OCCUPANCY_BYTES"]
 
-            stats = query_counter(self, sai_thrift_get_ingress_priority_group_stats, self.ipg)
+            stats = query_counter(
+                    self, sai_thrift_get_ingress_priority_group_stats, self.ipg)
 
             if (stats["SAI_INGRESS_PRIORITY_GROUP_STAT_CURR_OCCUPANCY_BYTES"]
                     > ipg_curr_occupancy_bytes):
@@ -130,7 +132,8 @@ class BufferStatistics(MinimalPortVlanConfig):
 
         time.sleep(self.sleep_time)
 
-        stats = query_counter(self, sai_thrift_get_buffer_pool_stats, self.ingr_pool)
+        stats = query_counter(
+                    self, sai_thrift_get_buffer_pool_stats, self.ingr_pool)
 
         if verify_reserved_buffer_size:
             expected_watermark = self.reserved_buf_size
@@ -146,7 +149,8 @@ class BufferStatistics(MinimalPortVlanConfig):
         self.assertGreaterEqual(
             stats["SAI_BUFFER_POOL_STAT_WATERMARK_BYTES"], expected_watermark)
 
-        stats = query_counter(self, sai_thrift_get_ingress_priority_group_stats, self.ipg)
+        stats = query_counter(
+                    self, sai_thrift_get_ingress_priority_group_stats, self.ipg)
 
         print("SAI_INGRESS_PRIORITY_GROUP_STAT_CURR_OCCUPANCY_BYTES "
               "(max measured)", ipg_curr_occupancy_bytes)
@@ -183,20 +187,24 @@ class BufferStatistics(MinimalPortVlanConfig):
         print()
         print("Clear bufer pool and ingress priority group stats")
 
-        status = clear_counter(self, sai_thrift_clear_buffer_pool_stats, self.ingr_pool)
+        status = clear_counter(
+                    self, sai_thrift_clear_buffer_pool_stats, self.ingr_pool)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
-        status = clear_counter(self, sai_thrift_clear_ingress_priority_group_stats, self.ipg)
+        status = clear_counter(
+                    self, sai_thrift_clear_ingress_priority_group_stats, self.ipg)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
         print("Get stats and verify they are cleared")
 
-        stats = query_counter(self, sai_thrift_get_buffer_pool_stats, self.ingr_pool)
+        stats = query_counter(
+                    self, sai_thrift_get_buffer_pool_stats, self.ingr_pool)
 
         self.assertEqual(
             stats["SAI_BUFFER_POOL_STAT_WATERMARK_BYTES"], 0)
 
-        stats = query_counter(self, sai_thrift_get_ingress_priority_group_stats, self.ipg)
+        stats = query_counter(
+                    self, sai_thrift_get_ingress_priority_group_stats, self.ipg)
 
         self.assertEqual(
             stats["SAI_INGRESS_PRIORITY_GROUP_STAT_PACKETS"], 0)
@@ -211,10 +219,12 @@ class BufferStatistics(MinimalPortVlanConfig):
         print()
 
         # Make sure test starts with cleared counters.
-        status = clear_counter(self, sai_thrift_clear_buffer_pool_stats, self.ingr_pool)
+        status = clear_counter(
+                    self, sai_thrift_clear_buffer_pool_stats, self.ingr_pool)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
-        status = clear_counter(self, sai_thrift_clear_ingress_priority_group_stats, self.ipg)
+        status = clear_counter(
+                    self, sai_thrift_clear_ingress_priority_group_stats, self.ipg)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
         print("Buffer pool size:", self.buf_size)
@@ -305,10 +315,12 @@ class Forwarding(MinimalPortVlanConfig):
         """
 
         for i in range(3):
-            status = clear_counter(self, sai_thrift_clear_port_stats, self.port_list[i])
+            status = clear_counter(
+                    self, sai_thrift_clear_port_stats, self.port_list[i])
             self.assertEqual(status, SAI_STATUS_SUCCESS)
 
-        status = clear_counter(self, sai_thrift_clear_ingress_priority_group_stats, self.ipg)
+        status = clear_counter(
+                    self, sai_thrift_clear_ingress_priority_group_stats, self.ipg)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
         print("Send {} pkts, pkt size: {} B".format(self.tx_cnt, self.pkt_len))
@@ -318,9 +330,12 @@ class Forwarding(MinimalPortVlanConfig):
         print("Verify traffic\n")
         time.sleep(2)
 
-        stats_ipg = query_counter(self, sai_thrift_get_ingress_priority_group_stats, self.ipg)
-        stats_p1 = query_counter(self, sai_thrift_get_port_stats, self.port1)
-        stats_p2 = query_counter(self, sai_thrift_get_port_stats, self.port2)
+        stats_ipg = query_counter(
+                    self, sai_thrift_get_ingress_priority_group_stats, self.ipg)
+        stats_p1 = query_counter(
+                    self, sai_thrift_get_port_stats, self.port1)
+        stats_p2 = query_counter(
+                    self, sai_thrift_get_port_stats, self.port2)
 
         self.assertEqual(
             stats_ipg["SAI_INGRESS_PRIORITY_GROUP_STAT_PACKETS"], self.tx_cnt)
@@ -606,12 +621,14 @@ class BufferPoolNumber(MinimalPortVlanConfig):
         time.sleep(2)
 
         for i in range(ingr_pool_num):
-            stats = query_counter(self, sai_thrift_get_ingress_priority_group_stats, self.ipgs[i])
+            stats = query_counter(
+                    self, sai_thrift_get_ingress_priority_group_stats, self.ipgs[i])
             self.assertEqual(
                 stats["SAI_INGRESS_PRIORITY_GROUP_STAT_PACKETS"], 1)
 
         for i in range(egr_pool_num):
-            stats = query_counter(self, sai_thrift_get_queue_stats, self.queues[i])
+            stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.queues[i])
             self.assertEqual(stats["SAI_QUEUE_STAT_PACKETS"], 1)
 
     def tearDown(self):

--- a/ptf/saifdb.py
+++ b/ptf/saifdb.py
@@ -3065,15 +3065,15 @@ class FdbMissTest(SaiHelper):
                              SAI_PACKET_ACTION_COPY)
 
             time.sleep(4)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet on port %d, %s -> %s - will be copied to "
                   "CPU" % (self.send_port, self.src_mac, self.dst_mac))
             send_packet(self, self.send_port, self.ucast_pkt)
             verify_packets(self, self.ucast_pkt, self.flood_ports)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"] -
                 pre_stats["SAI_QUEUE_STAT_PACKETS"],
@@ -3120,14 +3120,14 @@ class FdbMissTest(SaiHelper):
                              SAI_PACKET_ACTION_TRAP)
 
             time.sleep(4)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet on port %d, %s -> %s - will be redirected "
                   "to CPU" % (self.send_port, self.src_mac, self.dst_mac))
             send_packet(self, self.send_port, self.ucast_pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"] -
                 pre_stats["SAI_QUEUE_STAT_PACKETS"],
@@ -3181,16 +3181,16 @@ class FdbMissTest(SaiHelper):
             print("\tOK")
 
             time.sleep(4)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             print("Checking if LLDP packes are still forwarded to CPU")
             print("Sending multicast LLDP packet on port %d, %s -> %s - will "
                   "be redirected to CPU" % (self.send_port, self.src_mac,
                                             self.lldp_mac))
             send_packet(self, self.send_port, self.lldp_pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"] -
                 pre_stats["SAI_QUEUE_STAT_PACKETS"],
@@ -3237,16 +3237,16 @@ class FdbMissTest(SaiHelper):
                              SAI_PACKET_ACTION_COPY)
 
             time.sleep(4)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending multicast packet on port %d, %s -> %s - will be "
                   "copied to CPU" % (self.send_port, self.src_mac,
                                      self.mcast_mac))
             send_packet(self, self.send_port, self.mcast_pkt)
             verify_packets(self, self.mcast_pkt, self.flood_ports)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"] -
                 pre_stats["SAI_QUEUE_STAT_PACKETS"],
@@ -3254,16 +3254,16 @@ class FdbMissTest(SaiHelper):
             print("\tOK")
 
             time.sleep(4)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             print("Checking if LLDP packes are still forwarded to CPU")
             print("Sending multicast LLDP packet on port %d, %s -> %s - will "
                   "be redirected to CPU" % (self.send_port, self.src_mac,
                                             self.lldp_mac))
             send_packet(self, self.send_port, self.lldp_pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"] -
                 pre_stats["SAI_QUEUE_STAT_PACKETS"],
@@ -3311,15 +3311,15 @@ class FdbMissTest(SaiHelper):
                              SAI_PACKET_ACTION_TRAP)
 
             time.sleep(4)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending multicast packet on port %d, %s -> %s - will be "
                   "redirected to CPU" % (self.send_port, self.src_mac,
                                          self.mcast_mac))
             send_packet(self, self.send_port, self.mcast_pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"] -
                 pre_stats["SAI_QUEUE_STAT_PACKETS"],
@@ -3327,16 +3327,16 @@ class FdbMissTest(SaiHelper):
             print("\tOK")
 
             time.sleep(4)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             print("Checking if LLDP packes are still forwarded to CPU")
             print("Sending multicast LLDP packet on port %d, %s -> %s - will "
                   "be redirected to CPU" % (self.send_port, self.src_mac,
                                             self.lldp_mac))
             send_packet(self, self.send_port, self.lldp_pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"] -
                 pre_stats["SAI_QUEUE_STAT_PACKETS"],
@@ -3390,15 +3390,15 @@ class FdbMissTest(SaiHelper):
             print("\tOK")
 
             time.sleep(4)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             print("Checking if ARP packes are still forwarded to CPU")
             print("Sending ARP packet on port %d - will be redirected to CPU" %
                   (self.send_port))
             send_packet(self, self.send_port, self.arp_pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"] -
                 pre_stats["SAI_QUEUE_STAT_PACKETS"],
@@ -3445,16 +3445,16 @@ class FdbMissTest(SaiHelper):
                              SAI_PACKET_ACTION_COPY)
 
             time.sleep(4)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending broadcast packet on port %d, %s -> %s - will be "
                   "copied to CPU" % (self.send_port, self.src_mac,
                                      self.bcast_mac))
             send_packet(self, self.send_port, self.bcast_pkt)
             verify_packets(self, self.bcast_pkt, self.flood_ports)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"] -
                 pre_stats["SAI_QUEUE_STAT_PACKETS"],
@@ -3462,15 +3462,15 @@ class FdbMissTest(SaiHelper):
             print("\tOK")
 
             time.sleep(4)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             print("Checking if ARP packes are still forwarded to CPU")
             print("Sending ARP packet on port %d - will be redirected to CPU" %
                   (self.send_port))
             send_packet(self, self.send_port, self.arp_pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"] -
                 pre_stats["SAI_QUEUE_STAT_PACKETS"],
@@ -3518,15 +3518,15 @@ class FdbMissTest(SaiHelper):
                              SAI_PACKET_ACTION_TRAP)
 
             time.sleep(4)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending broadcast packet on port %d, %s -> %s - will be "
                   "redirected to CPU" % (self.send_port, self.src_mac,
                                          self.bcast_mac))
             send_packet(self, self.send_port, self.bcast_pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"] -
                 pre_stats["SAI_QUEUE_STAT_PACKETS"],
@@ -3534,15 +3534,15 @@ class FdbMissTest(SaiHelper):
             print("\tOK")
 
             time.sleep(4)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             print("Checking if ARP packes are still forwarded to CPU")
             print("Sending ARP packet on port %d - will be redirected to CPU" %
                   (self.send_port))
             send_packet(self, self.send_port, self.arp_pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"] -
                 pre_stats["SAI_QUEUE_STAT_PACKETS"],

--- a/ptf/saihostif.py
+++ b/ptf/saihostif.py
@@ -118,8 +118,8 @@ class lagNetdevHostifCreationTest(HostifCreationTestHelper):
             lag10_member2 = sai_thrift_create_lag_member(
                 self.client, lag_id=lag10, port_id=lag_ports[1])
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
 
             for dev_port in lag_dev_ports:
                 print("Sending LACP packet on LAG port %d" % dev_port)
@@ -131,8 +131,8 @@ class lagNetdevHostifCreationTest(HostifCreationTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + len(lag_dev_ports))
@@ -149,8 +149,8 @@ class lagNetdevHostifCreationTest(HostifCreationTestHelper):
             print("Verifying CPU port queue stats")
             pre_stats = post_stats
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -298,8 +298,8 @@ class vlanSviNetdevHostifCreationTest(HostifCreationTestHelper):
 
             hif2_socket = open_packet_socket(hostif2_name)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
 
             print("Sending ARP packet on port %d (untagged VLAN member)"
                   % vlan_dev_ports[0])
@@ -328,8 +328,8 @@ class vlanSviNetdevHostifCreationTest(HostifCreationTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 4)
@@ -419,8 +419,8 @@ class portNetdevHostifCreationTest(PlatformSaiHelper):
                 type=SAI_HOSTIF_TABLE_ENTRY_TYPE_WILDCARD)
             self.assertNotEqual(hif_tbl_entry, 0)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
 
             print("Sending LLDP packet on port %d" % hostif1_dev_port)
             send_packet(self, hostif1_dev_port, lldp_pkt)
@@ -438,8 +438,8 @@ class portNetdevHostifCreationTest(PlatformSaiHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 2)
@@ -741,8 +741,8 @@ class HostifTrapActionTestHelper(PlatformSaiHelper):
         self.arp_tagged_pkt = simple_arp_packet(arp_op=1,
                                                 vlan_vid=vid,
                                                 pktlen=104)
-        self.cpu_queue_state = sai_thrift_get_queue_stats(
-            self.client, self.cpu_queue0)["SAI_QUEUE_STAT_PACKETS"]
+        self.cpu_queue_state = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)["SAI_QUEUE_STAT_PACKETS"]
 
     def tearDown(self):
         sai_thrift_flush_fdb_entries(
@@ -847,8 +847,8 @@ class copyTrapActionTest(HostifTrapActionTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 1)
@@ -882,8 +882,8 @@ class copyTrapActionTaggedTest(HostifTrapActionTestHelper):
                 trap_type=SAI_HOSTIF_TRAP_TYPE_ARP_REQUEST)
             self.assertTrue(copy_trap != 0)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
 
             print("Sending ARP packet on port %d" % self.iport_dev)
             send_packet(self, self.iport_dev, self.arp_pkt)
@@ -893,8 +893,8 @@ class copyTrapActionTaggedTest(HostifTrapActionTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 1)
@@ -913,8 +913,8 @@ class copyTrapActionTaggedTest(HostifTrapActionTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 1)
@@ -960,8 +960,8 @@ class trapTrapActionTest(HostifTrapActionTestHelper):
             print("Verifying LLDP packet is trapped by "
                   "checkig CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 1)
@@ -1004,8 +1004,8 @@ class logTrapActionTest(HostifTrapActionTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 1)
@@ -1287,16 +1287,16 @@ class arpRxTxTest(PlatformSaiHelper):
 
             self.assertEqual(hostif_ip.rstrip(), rif_ip)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
 
             print("Sending ARP request on port %d" % test_dev_port)
             send_packet(self, test_dev_port, arp_req_pkt)
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -1407,8 +1407,8 @@ class HostifTableMatchTestHelper(PlatformSaiHelper):
         sai_thrift_set_port_attribute(
             self.client, self.eport, port_vlan_id=self.vid)
 
-        self.cpu_queue_state = sai_thrift_get_queue_stats(
-            self.client, self.cpu_queue0)["SAI_QUEUE_STAT_PACKETS"]
+        self.cpu_queue_state = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)["SAI_QUEUE_STAT_PACKETS"]
 
     def tearDown(self):
         sai_thrift_flush_fdb_entries(
@@ -1471,8 +1471,8 @@ class wildcardEntryCbChannelLldp(HostifTableMatchTestHelper):
             verify_packet(self, lldp_pkt, self.eport_dev)
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 1)
@@ -1552,8 +1552,8 @@ class wildcardEntryCbChannelLacp(HostifTableMatchTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + len(lag_dev_ports))
@@ -1659,8 +1659,8 @@ class wildcardEntryCbChannelStp(HostifTableMatchTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 2)
@@ -1807,8 +1807,8 @@ class HostifTrapTypesTestHelper(PlatformSaiHelper):
         sai_thrift_create_route_entry(self.client, self.ip2me_v6_route,
                                       next_hop_id=cpu_port)
 
-        self.cpu_queue_state = sai_thrift_get_queue_stats(
-            self.client, self.cpu_queue0)["SAI_QUEUE_STAT_PACKETS"]
+        self.cpu_queue_state = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)["SAI_QUEUE_STAT_PACKETS"]
 
     def tearDown(self):
         sai_thrift_flush_fdb_entries(
@@ -1919,8 +1919,8 @@ class arpTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 4)
@@ -2057,8 +2057,8 @@ class bgpTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 4)
@@ -2120,8 +2120,8 @@ class dhcpTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 2)
@@ -2164,8 +2164,8 @@ class ip2meTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 2)
@@ -2211,8 +2211,8 @@ class lacpTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 2)
@@ -2273,8 +2273,8 @@ class lldpTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 4)
@@ -2332,8 +2332,8 @@ class ospfTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 4)
@@ -2397,8 +2397,8 @@ class igmpTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + len(trap_info_list))
@@ -2493,8 +2493,8 @@ class ipv6MldTrapTest(HostifTrapTypesTestHelper):
             print("\tOK")
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 4)
@@ -2542,8 +2542,8 @@ class stpTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 1)
@@ -2586,8 +2586,8 @@ class pvrstTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 1)
@@ -2630,8 +2630,8 @@ class pimTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 1)
@@ -2674,8 +2674,8 @@ class udldTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 1)
@@ -2780,8 +2780,8 @@ class ipv6NDTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 10)
@@ -2826,8 +2826,8 @@ class bfdRxTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 1)
@@ -2887,8 +2887,8 @@ class dhcpv6TrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + len(dhcpv6_pkt_params_list))
@@ -2943,8 +2943,8 @@ class ptpTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 2)
@@ -2993,8 +2993,8 @@ class isisTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 6)
@@ -3039,8 +3039,8 @@ class bfdv6RxTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 1)
@@ -3101,8 +3101,8 @@ class dhcpL2TrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 2)
@@ -3162,8 +3162,8 @@ class dhcpv6L2TrapTest(HostifTrapTypesTestHelper):
                 print("\tOK")
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + len(dhcpv6_pkt_params_list))
@@ -3208,8 +3208,8 @@ class vrrpTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 1)
@@ -3254,8 +3254,8 @@ class vrrpv6TrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 1)
@@ -3297,8 +3297,8 @@ class eapolTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 self.cpu_queue_state + 1)
@@ -3339,8 +3339,8 @@ class mplsRouterAlertTrapTest(HostifTrapTypesTestHelper):
                                           mpls_tags=[mpls_tag, mpls_tag_2],
                                           inner_frame=inner_pkt[IP])
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
 
             print("Tx MPLS packet with Router Alert Label 1  ")
             send_packet(self, self.iport_dev, mpls_pkt)
@@ -3349,8 +3349,8 @@ class mplsRouterAlertTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -3390,8 +3390,8 @@ class mplsTtlErrorTrapTest(HostifTrapTypesTestHelper):
                                           mpls_tags=[mpls_tag],
                                           inner_frame=inner_pkt[IP])
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
 
             print("Tx MPLS packet with TTL=1 --> trap")
             send_packet(self, self.iport_dev, mpls_pkt)
@@ -3400,8 +3400,8 @@ class mplsTtlErrorTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(5)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -3410,8 +3410,8 @@ class mplsTtlErrorTrapTest(HostifTrapTypesTestHelper):
                                           mpls_tags=[mpls_tag_ttl_0],
                                           inner_frame=inner_pkt[IP])
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
 
             print("Tx MPLS packet with TTL=0 --> trap")
             send_packet(self, self.iport_dev, mpls_pkt)
@@ -3420,8 +3420,8 @@ class mplsTtlErrorTrapTest(HostifTrapTypesTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(5)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -3430,8 +3430,8 @@ class mplsTtlErrorTrapTest(HostifTrapTypesTestHelper):
                                           mpls_tags=[mpls_tag_ttl_2],
                                           inner_frame=inner_pkt[IP])
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
 
             print("Tx MPLS packet with TTL=2 --> dp")
             send_packet(self, self.iport_dev, mpls_pkt)
@@ -3633,8 +3633,8 @@ class aclIpSrcNetdevTrapTest(HostifUserDefinedTrapACLTestHelper):
             self.assertTrue(acl_entry2 != 0)
             acl_entries.append(acl_entry2)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
 
             # Send packets and verify they are properly trapped
             print("Sending IP packet 1")
@@ -3657,8 +3657,8 @@ class aclIpSrcNetdevTrapTest(HostifUserDefinedTrapACLTestHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 2)
@@ -3957,8 +3957,8 @@ class hostIfOperStatusTest(PlatformSaiHelper):
                 type=SAI_HOSTIF_TABLE_ENTRY_TYPE_WILDCARD)
             self.assertTrue(hif_tbl_entry != 0)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
 
             print("Sending LLDP packet on port %d" % hostif1_dev_port)
             send_packet(self, hostif1_dev_port, lldp_pkt)
@@ -3976,8 +3976,8 @@ class hostIfOperStatusTest(PlatformSaiHelper):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 2)
@@ -4232,8 +4232,8 @@ class neighborTrapTest(HostifUserDefinedTrapNeighborTest):
             sai_thrift_set_route_entry_attribute(self.client, route2_entry,
                                                  next_hop_id=nhop2)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             cpu_queue_pkt_count = 0
             print("Sending IP packet from port {} to {}".format(
                 self.dev_port12, self.hostif1_name))
@@ -4257,8 +4257,8 @@ class neighborTrapTest(HostifUserDefinedTrapNeighborTest):
 
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + cpu_queue_pkt_count)
@@ -4284,8 +4284,8 @@ class neighborTrapTest(HostifUserDefinedTrapNeighborTest):
             verify_no_other_packets(self)
             print("Verifying CPU port queue stats")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"])

--- a/ptf/sailag.py
+++ b/ptf/sailag.py
@@ -97,7 +97,7 @@ class LAGCreateLagMember(SaiHelper):
         self.assertNotEqual(status, SAI_STATUS_SUCCESS)
 
 
-def print_ports_stats(client, ports):
+def print_ports_stats(test_obj, ports):
     '''
     Print ports statistics
 
@@ -107,7 +107,8 @@ def print_ports_stats(client, ports):
     '''
 
     for port in ports:
-        counter_results = sai_thrift_get_port_stats(client, port)
+        counter_results = query_counter(
+                    test_obj, sai_thrift_get_port_stats, port)
 
         print("PORT%d if_in_discards=%d if_out_discards=%d "
               "if_in_ucast_pakts=%d if_out_ucast_pkts=%d" % (
@@ -197,7 +198,7 @@ class LAGDisableIngressLagMember(SaiHelper):
         print("Sending packet on port %d; %s -> %s - will flood"
               % (self.dev_port4, src_mac, dst_mac))
         send_packet(self, self.dev_port4, pkt)
-        print_ports_stats(self.client,
+        print_ports_stats(self,
                           [self.port0,
                            self.port1,
                            self.port2,

--- a/ptf/saimirror.py
+++ b/ptf/saimirror.py
@@ -1212,15 +1212,18 @@ class MirrorConfigData(SaiHelper):
                                     ip_ttl=64)
         try:
             print("\tSending packet PORT26 -> PORT25")
-            sai_thrift_clear_queue_stats(self.client, queue_id)
-            stats = sai_thrift_get_queue_stats(self.client, queue_id)
+            clear_counter(
+                    self, sai_thrift_clear_queue_stats, queue_id)
+            stats = query_counter(
+                    self, sai_thrift_get_queue_stats, queue_id)
             pkt_cnt_before = stats["SAI_QUEUE_STAT_PACKETS"]
 
             send_packet(self, self.dev_port26, pkt)
             verify_packets(self,
                            exp_pkt,
                            ports=[self.dev_port24, self.dev_port25])
-            stats = sai_thrift_get_queue_stats(self.client, queue_id)
+            stats = query_counter(
+                    self, sai_thrift_get_queue_stats, queue_id)
             pkt_cnt_after = stats["SAI_QUEUE_STAT_PACKETS"]
             assert(pkt_cnt_after == pkt_cnt_before + 1), ("Mirrored packet "
                                                           "does not get to the"
@@ -2133,8 +2136,10 @@ class MirrorConfigData(SaiHelper):
                                                     "unknown2")
         try:
             print("\tSending packet PORT13 -> PORT12")
-            sai_thrift_clear_queue_stats(self.client, queue_id)
-            stats = sai_thrift_get_queue_stats(self.client, queue_id)
+            clear_counter(
+                    self, sai_thrift_clear_queue_stats, queue_id)
+            stats = query_counter(
+                    self, sai_thrift_get_queue_stats, queue_id)
             pkt_cnt_before = stats["SAI_QUEUE_STAT_PACKETS"]
             send_packet(self, self.dev_port13, pkt)
             verify_packet(self, exp_pkt, self.dev_port12)
@@ -2142,7 +2147,8 @@ class MirrorConfigData(SaiHelper):
             verify_packet(self, exp_mask_mirrored_pkt, self.dev_port28)
             print("\tPacket mirrored on port 28")
             verify_no_other_packets(self, timeout=1)
-            stats = sai_thrift_get_queue_stats(self.client, queue_id)
+            stats = query_counter(
+                    self, sai_thrift_get_queue_stats, queue_id)
             pkt_cnt_after = stats["SAI_QUEUE_STAT_PACKETS"]
             assert(pkt_cnt_after == pkt_cnt_before + 1), ("Mirrored packet "
                                                           "does not get to the"
@@ -2310,7 +2316,8 @@ class MirrorConfigData(SaiHelper):
                                     pktlen=1000)
 
         try:
-            stats = sai_thrift_get_policer_stats(self.client, self.pol_id)
+            stats = query_counter(
+                    self, sai_thrift_get_policer_stats, self.pol_id)
             g_pkts0 = stats["SAI_POLICER_STAT_GREEN_PACKETS"]
             r_pkts0 = stats["SAI_POLICER_STAT_RED_PACKETS"]
             pkt_cnt = 10
@@ -2336,7 +2343,8 @@ class MirrorConfigData(SaiHelper):
             print("\tReceived packet number is correct")
 
             print("\tChecking policer statistics...")
-            stats = sai_thrift_get_policer_stats(self.client, self.pol_id)
+            stats = query_counter(
+                    self, sai_thrift_get_policer_stats, self.pol_id)
             g_pkts1 = stats["SAI_POLICER_STAT_GREEN_PACKETS"]
             r_pkts1 = stats["SAI_POLICER_STAT_RED_PACKETS"]
             # Only green packets are mirrored that is why total mirrored
@@ -2394,7 +2402,8 @@ class MirrorConfigData(SaiHelper):
                                     pktlen=1000)
 
         try:
-            stats = sai_thrift_get_policer_stats(self.client, self.pol_id)
+            stats = query_counter(
+                    self, sai_thrift_get_policer_stats, self.pol_id)
             g_pkts0 = stats["SAI_POLICER_STAT_GREEN_PACKETS"]
             r_pkts0 = stats["SAI_POLICER_STAT_RED_PACKETS"]
             pkt_cnt = 10
@@ -2420,7 +2429,8 @@ class MirrorConfigData(SaiHelper):
             print("\tReceived packet number is correct")
 
             print("\tChecking policer statistics...")
-            stats = sai_thrift_get_policer_stats(self.client, self.pol_id)
+            stats = query_counter(
+                    self, sai_thrift_get_policer_stats, self.pol_id)
             g_pkts1 = stats["SAI_POLICER_STAT_GREEN_PACKETS"]
             r_pkts1 = stats["SAI_POLICER_STAT_RED_PACKETS"]
             # Only green packets are mirrored that is why total mirrored
@@ -2534,7 +2544,8 @@ class MirrorConfigData(SaiHelper):
                                                     "unknown2")
 
         try:
-            stats = sai_thrift_get_policer_stats(self.client, self.pol_id)
+            stats = query_counter(
+                    self, sai_thrift_get_policer_stats, self.pol_id)
             g_pkts0 = stats["SAI_POLICER_STAT_GREEN_PACKETS"]
             r_pkts0 = stats["SAI_POLICER_STAT_RED_PACKETS"]
             pkt_cnt = 10
@@ -2560,7 +2571,8 @@ class MirrorConfigData(SaiHelper):
             print("\tReceived packet number is correct")
 
             print("\tChecking policer statistics...")
-            stats = sai_thrift_get_policer_stats(self.client, self.pol_id)
+            stats = query_counter(
+                    self, sai_thrift_get_policer_stats, self.pol_id)
             g_pkts1 = stats["SAI_POLICER_STAT_GREEN_PACKETS"]
             r_pkts1 = stats["SAI_POLICER_STAT_RED_PACKETS"]
             # Only green packets are mirrored that is why total mirrored
@@ -2668,7 +2680,8 @@ class MirrorConfigData(SaiHelper):
                                                     "unknown2")
 
         try:
-            stats = sai_thrift_get_policer_stats(self.client, self.pol_id)
+            stats = query_counter(
+                    self, sai_thrift_get_policer_stats, self.pol_id)
             g_pkts0 = stats["SAI_POLICER_STAT_GREEN_PACKETS"]
             r_pkts0 = stats["SAI_POLICER_STAT_RED_PACKETS"]
             pkt_cnt = 10
@@ -2694,7 +2707,8 @@ class MirrorConfigData(SaiHelper):
             print("\tReceived packet number is correct")
 
             print("\tChecking policer statistics...")
-            stats = sai_thrift_get_policer_stats(self.client, self.pol_id)
+            stats = query_counter(
+                    self, sai_thrift_get_policer_stats, self.pol_id)
             g_pkts1 = stats["SAI_POLICER_STAT_GREEN_PACKETS"]
             r_pkts1 = stats["SAI_POLICER_STAT_RED_PACKETS"]
             # Only green packets are mirrored that is why total mirrored

--- a/ptf/saimpls.py
+++ b/ptf/saimpls.py
@@ -28,19 +28,21 @@ class MplsCpuTrapTest(SaiHelper):
     def setUp(self):
         super(MplsCpuTrapTest, self).setUp()
 
-        status = sai_thrift_clear_port_stats(self.client, self.port10)
+        status = clear_counter(
+                    self, sai_thrift_clear_port_stats, self.port10)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
-        status = sai_thrift_clear_router_interface_stats(
-            self.client, self.port10_rif)
+        status = clear_counter(
+                    self, sai_thrift_clear_router_interface_stats, self.port10_rif)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
-        stats = sai_thrift_get_port_stats(self.client, self.port10)
+        stats = query_counter(
+                    self, sai_thrift_get_port_stats, self.port10)
         self.port10_disc_stats = stats['SAI_PORT_STAT_IF_IN_DISCARDS']
         self.assertEqual(self.port10_disc_stats, 0)
 
-        stats = sai_thrift_get_router_interface_stats(
-            self.client, self.port10_rif)
+        stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.port10_rif)
         self.port10_rif_in_stats = \
             stats['SAI_ROUTER_INTERFACE_STAT_IN_PACKETS']
         self.assertEqual(self.port10_rif_in_stats, 0)
@@ -70,10 +72,11 @@ class MplsCpuTrapTest(SaiHelper):
             Return:
                 bool: True if statistics are correct, otherwise False
         '''
-        rif_stats = sai_thrift_get_router_interface_stats(
-            self.client, self.port10_rif)
+        rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.port10_rif)
 
-        port_stats = sai_thrift_get_port_stats(self.client, self.port10)
+        port_stats = query_counter(
+                    self, sai_thrift_get_port_stats, self.port10)
 
         if self.port10_rif_in_stats != \
                 rif_stats['SAI_ROUTER_INTERFACE_STAT_IN_PACKETS'] or \
@@ -105,13 +108,13 @@ class MplsCpuTrapTest(SaiHelper):
             inner_frame=send_pkt['IP'])
 
         try:
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Implicit null label action trap")
             send_packet(self, self.dev_port10, mpls_pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -637,7 +640,8 @@ class MplsIpv6Test(SaiHelper):
                     self.egress_rif_3, self.egress_rif_4, self.egress_rif_5,
                     self.egress_rif_6, self.egress_rif_7, self.egress_rif_8,
                     self.egress_rif_9, self.mpls_rif]:
-            status = sai_thrift_clear_router_interface_stats(self.client, rif)
+            status = clear_counter(
+                    self, sai_thrift_clear_router_interface_stats, rif)
             self.assertEqual(status, SAI_STATUS_SUCCESS)
 
         self.ingress_rif_in_stats = 0     # port 10
@@ -760,7 +764,8 @@ class MplsIpv6Test(SaiHelper):
                  self.egress_rif_2_out_stats, self.egress_rif_3_out_stats,
                  self.egress_rif_4_out_stats, self.egress_rif_5_out_stats,
                  self.egress_rif_9_out_stats, self.mpls_rif_out_stats]):
-            stats = sai_thrift_get_router_interface_stats(self.client, rif)
+            stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, rif)
 
             if in_cnt != stats['SAI_ROUTER_INTERFACE_STAT_IN_PACKETS'] or \
                     out_cnt != stats['SAI_ROUTER_INTERFACE_STAT_OUT_PACKETS']:
@@ -1221,12 +1226,12 @@ class MplsIpv6Test(SaiHelper):
             inner_frame=send_pkt['IPv6'])
 
         rif_cntr_id = 'SAI_ROUTER_INTERFACE_STAT_OUT_PACKETS'
-        rif6_stats_start = sai_thrift_get_router_interface_stats(
-            self.client, self.egress_rif_6)
-        rif7_stats_start = sai_thrift_get_router_interface_stats(
-            self.client, self.egress_rif_7)
-        rif8_stats_start = sai_thrift_get_router_interface_stats(
-            self.client, self.egress_rif_8)
+        rif6_stats_start = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.egress_rif_6)
+        rif7_stats_start = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.egress_rif_7)
+        rif8_stats_start = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.egress_rif_8)
 
         print("ECMP - Send MPLS tag packet 7000")
         send_packet(self, self.dev_port10, mpls_pkt)
@@ -1234,12 +1239,12 @@ class MplsIpv6Test(SaiHelper):
         verify_any_packet_any_port(
             self, [recv_mpls_7070, recv_mpls_7171, recv_mpls_7272],
             [self.dev_port27, self.dev_port28, self.dev_port29])
-        rif6_stats_end = sai_thrift_get_router_interface_stats(
-            self.client, self.egress_rif_6)
-        rif7_stats_end = sai_thrift_get_router_interface_stats(
-            self.client, self.egress_rif_7)
-        rif8_stats_end = sai_thrift_get_router_interface_stats(
-            self.client, self.egress_rif_8)
+        rif6_stats_end = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.egress_rif_6)
+        rif7_stats_end = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.egress_rif_7)
+        rif8_stats_end = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.egress_rif_8)
 
         if (rif6_stats_end[rif_cntr_id] -
                 rif6_stats_start[rif_cntr_id] == 1):
@@ -1254,8 +1259,8 @@ class MplsIpv6Test(SaiHelper):
             final_egress_rif = 0
 
         iter_count = 10
-        rif_lb_start_count = sai_thrift_get_router_interface_stats(
-            self.client, final_egress_rif)
+        rif_lb_start_count = query_counter(
+                    self, sai_thrift_get_router_interface_stats, final_egress_rif)
 
         for _ in range(0, iter_count):
             l4_sport = random.randint(5000, 65535)
@@ -1266,8 +1271,8 @@ class MplsIpv6Test(SaiHelper):
             self.ingress_rif_in_stats += 1
 
         time.sleep(2)
-        rif_lb_end_count = sai_thrift_get_router_interface_stats(
-            self.client, final_egress_rif)
+        rif_lb_end_count = query_counter(
+                    self, sai_thrift_get_router_interface_stats, final_egress_rif)
         diff = (rif_lb_end_count[rif_cntr_id] -
                 rif_lb_start_count[rif_cntr_id])
         self.assertEqual(diff, iter_count)
@@ -1737,7 +1742,8 @@ class MplsIpv4Test(SaiHelper):
         for rif in [self.ingress_rif, self.egress_rif_1, self.egress_rif_2,
                     self.egress_rif_3, self.egress_rif_4, self.egress_rif_5,
                     self.egress_rif_9, self.egress_rif_vrf, self.mpls_rif]:
-            status = sai_thrift_clear_router_interface_stats(self.client, rif)
+            status = clear_counter(
+                    self, sai_thrift_clear_router_interface_stats, rif)
             self.assertEqual(status, SAI_STATUS_SUCCESS)
 
         self.ingress_rif_in_stats = 0     # port 10
@@ -1872,7 +1878,8 @@ class MplsIpv4Test(SaiHelper):
                  self.egress_rif_4_out_stats, self.egress_rif_5_out_stats,
                  self.egress_rif_9_out_stats, self.egress_rif_vrf_out_stats,
                  self.mpls_rif_out_stats]):
-            stats = sai_thrift_get_router_interface_stats(self.client, rif)
+            stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, rif)
 
             if in_cnt != stats['SAI_ROUTER_INTERFACE_STAT_IN_PACKETS'] or \
                     out_cnt != stats['SAI_ROUTER_INTERFACE_STAT_OUT_PACKETS']:
@@ -2419,12 +2426,12 @@ class MplsIpv4Test(SaiHelper):
             inner_frame=send_pkt['IP'])
 
         rif_cntr_id = 'SAI_ROUTER_INTERFACE_STAT_OUT_PACKETS'
-        rif6_stats_start = sai_thrift_get_router_interface_stats(
-            self.client, self.egress_rif_6)
-        rif7_stats_start = sai_thrift_get_router_interface_stats(
-            self.client, self.egress_rif_7)
-        rif8_stats_start = sai_thrift_get_router_interface_stats(
-            self.client, self.egress_rif_8)
+        rif6_stats_start = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.egress_rif_6)
+        rif7_stats_start = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.egress_rif_7)
+        rif8_stats_start = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.egress_rif_8)
 
         print("ECMP - Send MPLS tag packet 7000")
         send_packet(self, self.dev_port10, mpls_pkt)
@@ -2432,12 +2439,12 @@ class MplsIpv4Test(SaiHelper):
         verify_any_packet_any_port(
             self, [recv_mpls_7070, recv_mpls_7171, recv_mpls_7272],
             [self.dev_port27, self.dev_port28, self.dev_port29])
-        rif6_stats_end = sai_thrift_get_router_interface_stats(
-            self.client, self.egress_rif_6)
-        rif7_stats_end = sai_thrift_get_router_interface_stats(
-            self.client, self.egress_rif_7)
-        rif8_stats_end = sai_thrift_get_router_interface_stats(
-            self.client, self.egress_rif_8)
+        rif6_stats_end = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.egress_rif_6)
+        rif7_stats_end = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.egress_rif_7)
+        rif8_stats_end = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.egress_rif_8)
 
         if (rif6_stats_end[rif_cntr_id] -
                 rif6_stats_start[rif_cntr_id] == 1):
@@ -2452,8 +2459,8 @@ class MplsIpv4Test(SaiHelper):
             final_egress_rif = 0
 
         iter_count = 10
-        rif_lb_start_count = sai_thrift_get_router_interface_stats(
-            self.client, final_egress_rif)
+        rif_lb_start_count = query_counter(
+                    self, sai_thrift_get_router_interface_stats, final_egress_rif)
 
         for _ in range(0, iter_count):
             l4_sport = random.randint(5000, 65535)
@@ -2464,8 +2471,8 @@ class MplsIpv4Test(SaiHelper):
             self.ingress_rif_in_stats += 1
 
         time.sleep(2)
-        rif_lb_end_count = sai_thrift_get_router_interface_stats(
-            self.client, final_egress_rif)
+        rif_lb_end_count = query_counter(
+                    self, sai_thrift_get_router_interface_stats, final_egress_rif)
         diff = (rif_lb_end_count[rif_cntr_id] -
                 rif_lb_start_count[rif_cntr_id])
         self.assertEqual(diff, iter_count)

--- a/ptf/sainat.py
+++ b/ptf/sainat.py
@@ -1327,12 +1327,12 @@ class NatTest(SaiHelper):
                                     ip_id=105,
                                     ip_ttl=64)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             send_packet(self, self.dev_port24, pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)

--- a/ptf/sainexthop.py
+++ b/ptf/sainexthop.py
@@ -94,13 +94,13 @@ class removeNexthopTest(L3NexthopTestHelper):
             verify_packet(self, exp_pkt, self.dev_port0)
 
             sai_thrift_remove_next_hop(self.client, nhop)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet on port %d, forward" % self.dev_port1)
             send_packet(self, self.dev_port1, pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"] -
                 pre_stats["SAI_QUEUE_STAT_PACKETS"],
@@ -192,8 +192,8 @@ class cpuNexthopTest(L3NexthopTestHelper):
             ipv6_hlim=64)
 
         try:
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
 
             print("Sending packet on port %d, forward to CPU, host ipv4" %
                   self.dev_port0)
@@ -212,8 +212,8 @@ class cpuNexthopTest(L3NexthopTestHelper):
             send_packet(self, self.dev_port0, pkt4)
 
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"] -
                 pre_stats["SAI_QUEUE_STAT_PACKETS"],

--- a/ptf/saipolicer.py
+++ b/ptf/saipolicer.py
@@ -414,7 +414,8 @@ class BindPolicerToAclEntry(MinimalPortVlanConfig):
         self.assertLess(rx_cnt, tx_cnt * 2)
         verify_no_other_packets(self)
 
-        stats = sai_thrift_get_policer_stats(self.client, self.pol_id)
+        stats = query_counter(
+                    self, sai_thrift_get_policer_stats, self.pol_id)
         # Remove entry which is not a statistic.
         del stats["SAI_POLICER_STAT_CUSTOM_RANGE_BASE"]
         for stat, value in stats.items():
@@ -500,7 +501,8 @@ class NoIncrementAfterUnbind(PolicerTrafficTests):
     def runTest(self):
         print()
 
-        pre_stats = sai_thrift_get_queue_stats(self.client, self.cpu_queue2)
+        pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue2)
         tx_cnt = 5
         for i in range(tx_cnt):
             print("Sending ARP packet", i)
@@ -511,13 +513,15 @@ class NoIncrementAfterUnbind(PolicerTrafficTests):
         time.sleep(4)
         print("Check SAI_POLICER_STAT_PACKETS incremented by {}".format(
             tx_cnt))
-        stats = sai_thrift_get_policer_stats(self.client, self.pol_id)
+        stats = query_counter(
+                    self, sai_thrift_get_policer_stats, self.pol_id)
         self.assertEqual(tx_cnt, stats["SAI_POLICER_STAT_PACKETS"])
         print("Check SAI_QUEUE_STAT_PACKETS incremented by {}".format(tx_cnt))
         print("Check number of packets that ingressed on CPU port "
               "equals number of green packets ({})".format(
                   stats["SAI_POLICER_STAT_GREEN_PACKETS"]))
-        post_stats = sai_thrift_get_queue_stats(self.client, self.cpu_queue2)
+        post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue2)
         self.assertEqual(
             post_stats["SAI_QUEUE_STAT_PACKETS"],
             pre_stats["SAI_QUEUE_STAT_PACKETS"] +
@@ -532,7 +536,8 @@ class NoIncrementAfterUnbind(PolicerTrafficTests):
             self.client, self.arp_trap_group, policer=True)
         self.assertEqual(0, attr["policer"])
 
-        pre_stats = sai_thrift_get_queue_stats(self.client, self.cpu_queue2)
+        pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue2)
         print("Send traffic again, policer counters shall not change\n")
         for i in range(tx_cnt):
             print("Sending ARP packet", i)
@@ -541,14 +546,16 @@ class NoIncrementAfterUnbind(PolicerTrafficTests):
         print()
 
         print("Check policer counters didn\"t change")
-        stats_new = sai_thrift_get_policer_stats(self.client, self.pol_id)
+        stats_new = query_counter(
+                    self, sai_thrift_get_policer_stats, self.pol_id)
         # Remove entry which is not a statistic.
         del stats["SAI_POLICER_STAT_CUSTOM_RANGE_BASE"]
         del stats_new["SAI_POLICER_STAT_CUSTOM_RANGE_BASE"]
         self.assertEqual(stats_new, stats)
 
         time.sleep(4)
-        post_stats = sai_thrift_get_queue_stats(self.client, self.cpu_queue2)
+        post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue2)
         self.assertEqual(
             post_stats["SAI_QUEUE_STAT_PACKETS"],
             pre_stats["SAI_QUEUE_STAT_PACKETS"] + tx_cnt)
@@ -575,8 +582,10 @@ class Overflow1Policer2TrapGroups(PolicerTrafficTests):
             self.client, self.lldp_trap_group, policer=self.pol_id)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
-        q2_pre_stat = sai_thrift_get_queue_stats(self.client, self.cpu_queue2)
-        q4_pre_stat = sai_thrift_get_queue_stats(self.client, self.cpu_queue4)
+        q2_pre_stat = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue2)
+        q4_pre_stat = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
 
         tx_cnt = 5
         for i in range(tx_cnt):
@@ -615,13 +624,16 @@ class Overflow1Policer2TrapGroups(PolicerTrafficTests):
         time.sleep(4)
         print("Check SAI_POLICER_STAT_PACKETS incremented by {}".format(
             tx_cnt * 3))
-        stats = sai_thrift_get_policer_stats(self.client, self.pol_id)
+        stats = query_counter(
+                    self, sai_thrift_get_policer_stats, self.pol_id)
         self.assertEqual(tx_cnt * 3, stats["SAI_POLICER_STAT_PACKETS"])
 
         rx_cnt_cpu = stats["SAI_POLICER_STAT_GREEN_PACKETS"]
 
-        q2_post_stat = sai_thrift_get_queue_stats(self.client, self.cpu_queue2)
-        q4_post_stat = sai_thrift_get_queue_stats(self.client, self.cpu_queue4)
+        q2_post_stat = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue2)
+        q4_post_stat = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
         t = "SAI_QUEUE_STAT_PACKETS"
         q_stats = (q4_post_stat[t] - q4_pre_stat[t]) + \
             (q2_post_stat[t] - q2_pre_stat[t])
@@ -653,8 +665,10 @@ class Underflow1Policer2TrapGroups(PolicerTrafficTests):
             self.client, self.lldp_trap_group, policer=self.pol_id)
         self.assertEqual(status, SAI_STATUS_SUCCESS)
 
-        q2_pre_stat = sai_thrift_get_queue_stats(self.client, self.cpu_queue2)
-        q4_pre_stat = sai_thrift_get_queue_stats(self.client, self.cpu_queue4)
+        q2_pre_stat = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue2)
+        q4_pre_stat = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
 
         tx_cnt = 5
         for i in range(tx_cnt):
@@ -678,7 +692,8 @@ class Underflow1Policer2TrapGroups(PolicerTrafficTests):
             self.client, self.arp_trap_group, policer=True)
         self.assertEqual(0, get_attr["policer"])
 
-        stats_unbind = sai_thrift_get_policer_stats(self.client, self.pol_id)
+        stats_unbind = query_counter(
+                    self, sai_thrift_get_policer_stats, self.pol_id)
 
         for i in range(tx_cnt):
             print("Sending ARP packet", i)
@@ -688,7 +703,8 @@ class Underflow1Policer2TrapGroups(PolicerTrafficTests):
 
         self.assertEqual(
             stats_unbind,
-            sai_thrift_get_policer_stats(self.client, self.pol_id))
+            query_counter(
+                    self, sai_thrift_get_policer_stats, self.pol_id))
 
         for i in range(tx_cnt):
             print("Sending LLDP packet", i)
@@ -696,15 +712,18 @@ class Underflow1Policer2TrapGroups(PolicerTrafficTests):
             time.sleep(0.1)
         print()
 
-        stats = sai_thrift_get_policer_stats(self.client, self.pol_id)
+        stats = query_counter(
+                    self, sai_thrift_get_policer_stats, self.pol_id)
 
         print("Check SAI_POLICER_STAT_PACKETS incremented by", tx_cnt * 3)
         self.assertEqual(tx_cnt * 3, stats["SAI_POLICER_STAT_PACKETS"])
 
         rx_cnt_cpu = stats["SAI_POLICER_STAT_GREEN_PACKETS"]
 
-        q2_post_stat = sai_thrift_get_queue_stats(self.client, self.cpu_queue2)
-        q4_post_stat = sai_thrift_get_queue_stats(self.client, self.cpu_queue4)
+        q2_post_stat = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue2)
+        q4_post_stat = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
         t = "SAI_QUEUE_STAT_PACKETS"
         q_stats = (q4_post_stat[t] - q4_pre_stat[t]) + \
             (q2_post_stat[t] - q2_pre_stat[t])
@@ -798,7 +817,8 @@ class StormControlTests(MinimalPortVlanConfig):
             self, pkt, [self.dev_port1, self.dev_port2])
         verify_no_other_packets(self)
 
-        stats = sai_thrift_get_policer_stats(self.client, pol_id)
+        stats = query_counter(
+                    self, sai_thrift_get_policer_stats, pol_id)
 
         print("Packets flooded to ports 1 and 2:", rx_cnt)
         print("SAI_POLICER_STAT_PACKETS:",
@@ -888,7 +908,8 @@ class VerifyColors(MinimalPortVlanConfig):
         print()
 
         time.sleep(2.0)
-        stats = sai_thrift_get_policer_stats(self.client, self.pol_id)
+        stats = query_counter(
+                    self, sai_thrift_get_policer_stats, self.pol_id)
         print("SAI_POLICER_STAT_GREEN_PACKETS:",
               stats["SAI_POLICER_STAT_GREEN_PACKETS"])
         print("SAI_POLICER_STAT_YELLOW_PACKETS:",

--- a/ptf/saiport.py
+++ b/ptf/saiport.py
@@ -1717,8 +1717,8 @@ class PortAclBindingClass(PortFloodClass):
             # Find the port object for a given port
             port_obj = self.findPortObj(port)
             for port_stat in port_stats:
-                initial_stats = sai_thrift_get_port_stats(self.client,
-                                                          port_obj)
+                initial_stats = query_counter(
+                    self, sai_thrift_get_port_stats, port_obj)
                 stat = initial_stats[port_stat]
                 total_cnt += stat
         return total_cnt

--- a/ptf/saiqosmap.py
+++ b/ptf/saiqosmap.py
@@ -309,7 +309,8 @@ class L2QosMapBaseClass(SaiHelperBase):
         attr = sai_thrift_get_queue_attribute(self.client, queue, index=True)
         self.assertTrue(attr['index'] == index, "Failed to get the queue")
         for q_stat in qstats:
-            stats = sai_thrift_get_queue_stats(self.client, queue)
+            stats = query_counter(
+                    self, sai_thrift_get_queue_stats, queue)
             total_cnt += stats[q_stat]
         return total_cnt
 
@@ -447,7 +448,8 @@ class L3QosMapBaseClass(SaiHelperBase):
         attr = sai_thrift_get_queue_attribute(self.client, queue, index=True)
         self.assertTrue(attr['index'] == index, "Failed to get the queue")
         for q_stat in qstats:
-            stats = sai_thrift_get_queue_stats(self.client, queue)
+            stats = query_counter(
+                    self, sai_thrift_get_queue_stats, queue)
             total_cnt += stats[q_stat]
         return total_cnt
 
@@ -461,7 +463,8 @@ class L3QosMapBaseClass(SaiHelperBase):
         '''
         total_cnt = 0
         for queue_oid in queues:
-            stats = sai_thrift_get_queue_stats(self.client, queue_oid)
+            stats = query_counter(
+                    self, sai_thrift_get_queue_stats, queue_oid)
             for q_stat in qstats:
                 total_cnt += stats[q_stat]
         return total_cnt
@@ -516,8 +519,8 @@ class L3QosMapBaseClass(SaiHelperBase):
         '''
         total_cnt = 0
         for ppg_oid in ppg_oids:
-            stats = sai_thrift_get_ingress_priority_group_stats(
-                self.client, ppg_oid)
+            stats = query_counter(
+                    self, sai_thrift_get_ingress_priority_group_stats, ppg_oid)
             for ppg_stat in ppg_stats:
                 total_cnt += stats[ppg_stat]
         return total_cnt

--- a/ptf/saiqueue.py
+++ b/ptf/saiqueue.py
@@ -248,7 +248,8 @@ class bufferQueueTest(QueueConfigDataHelper):
                 buffer_profile_id=buff_prof)
             self.assertEqual(status, SAI_STATUS_SUCCESS)
 
-            clear_counter(self, sai_thrift_clear_queue_stats, queue_id[0])
+            clear_counter(
+                    self, sai_thrift_clear_queue_stats, queue_id[0])
             pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                     eth_src="00:00:00:00:00:22",
                                     ip_dst="172.16.1.1",
@@ -266,7 +267,8 @@ class bufferQueueTest(QueueConfigDataHelper):
             send_packet(self, self.dev_port25, pkt)
             verify_packet(self, exp_pkt, self.dev_port26)
             print("\tPacket received on PORT26")
-            stats = query_counter(self, sai_thrift_get_queue_stats, queue_id[0])
+            stats = query_counter(
+                    self, sai_thrift_get_queue_stats, queue_id[0])
             cnt = stats["SAI_QUEUE_STAT_PACKETS"]
             self.assertEqual(cnt, 1)
 
@@ -287,7 +289,8 @@ class bufferQueueTest(QueueConfigDataHelper):
                                                   buffer_profile_id=True)
             self.assertEqual(attr["buffer_profile_id"], default_buff_prof)
 
-            clear_counter(self, sai_thrift_clear_queue_stats, queue_id[0])
+            clear_counter(
+                    self, sai_thrift_clear_queue_stats, queue_id[0])
             pkt = simple_tcp_packet(eth_dst=ROUTER_MAC,
                                     eth_src="00:00:00:00:00:22",
                                     ip_dst="172.16.1.1",
@@ -305,7 +308,8 @@ class bufferQueueTest(QueueConfigDataHelper):
             send_packet(self, self.dev_port25, pkt)
             verify_packet(self, exp_pkt, self.dev_port26)
             print("\tPacket received on PORT26")
-            stats = query_counter(self, sai_thrift_get_queue_stats, queue_id[0])
+            stats = query_counter(
+                    self, sai_thrift_get_queue_stats, queue_id[0])
             cnt = stats["SAI_QUEUE_STAT_PACKETS"]
             self.assertEqual(cnt, 1)
             print("\tTest completed successfully")
@@ -315,7 +319,8 @@ class bufferQueueTest(QueueConfigDataHelper):
                     self, sai_thrift_get_queue_stats_ext, queue_id[0], SAI_STATS_MODE_READ_AND_CLEAR)
             cnt = stats["SAI_QUEUE_STAT_PACKETS"]
             self.assertEqual(cnt, 1)
-            stats = query_counter(self, sai_thrift_get_queue_stats, queue_id[0])
+            stats = query_counter(
+                    self, sai_thrift_get_queue_stats, queue_id[0])
             cnt = stats["SAI_QUEUE_STAT_PACKETS"]
             self.assertEqual(cnt, 0)
             print("\tTest completed successfully")
@@ -1074,9 +1079,11 @@ class dwrrBandwidthDistributionTest(QueueConfigDataHelper):  # noqa pylint: disa
             map_list2.append(tc_to_queue)
 
             # Clear statistics for each queue in PORT25
-            clear_counter(self, sai_thrift_clear_queue_stats, queue_id_list_port25[i])
+            clear_counter(
+                    self, sai_thrift_clear_queue_stats, queue_id_list_port25[i])
             # Clear statistics for each queue in PORT26
-            clear_counter(self, sai_thrift_clear_queue_stats, queue_id_list_port26[i])
+            clear_counter(
+                    self, sai_thrift_clear_queue_stats, queue_id_list_port26[i])
 
         qos_map_list2 = sai_thrift_qos_map_list_t(
             count=len(map_list2),
@@ -1186,7 +1193,8 @@ class dwrrBandwidthDistributionTest(QueueConfigDataHelper):  # noqa pylint: disa
             for queue in range(0, num_queues):
                 time.sleep(5)
 
-                q_stats = query_counter(self, sai_thrift_get_queue_stats,
+                q_stats = query_counter(
+                    self, sai_thrift_get_queue_stats,
                     queue_id_list_port26[queue])
                 rec_pkt_num = q_stats["SAI_QUEUE_STAT_PACKETS"]
                 print("Queue:", queue)
@@ -1199,12 +1207,14 @@ class dwrrBandwidthDistributionTest(QueueConfigDataHelper):  # noqa pylint: disa
             print("\tTest completed successfully")
 
         finally:
-            stats = query_counter(self, sai_thrift_get_queue_stats_ext,
+            stats = query_counter(
+                    self, sai_thrift_get_queue_stats_ext,
                 queue_id_list_port26[0],
                 SAI_STATS_MODE_READ_AND_CLEAR)
             cnt = stats["SAI_QUEUE_STAT_PACKETS"]
             self.assertEqual(cnt, 2)
-            stats = query_counter(self, sai_thrift_get_queue_stats,
+            stats = query_counter(
+                    self, sai_thrift_get_queue_stats,
                   queue_id_list_port26[0])
             cnt = stats["SAI_QUEUE_STAT_PACKETS"]
             self.assertEqual(cnt, 0)
@@ -1307,9 +1317,11 @@ class strictPriorityQueueTest(QueueConfigDataHelper):
             map_list2.append(tc_to_queue)
 
             # Clear statistics for each queue in PORT25
-            clear_counter(self, sai_thrift_clear_queue_stats, queue_id_list_port25[i])
+            clear_counter(
+                    self, sai_thrift_clear_queue_stats, queue_id_list_port25[i])
             # Clear statistics for each queue in PORT26
-            clear_counter(self, sai_thrift_clear_queue_stats, queue_id_list_port26[i])
+            clear_counter(
+                    self, sai_thrift_clear_queue_stats, queue_id_list_port26[i])
 
         qos_map_list2 = sai_thrift_qos_map_list_t(
             count=len(map_list2),
@@ -1394,17 +1406,20 @@ class strictPriorityQueueTest(QueueConfigDataHelper):
             time.sleep(4)
 
             # Statistics read
-            q_stats_port26 = query_counter(self, sai_thrift_get_queue_stats,
+            q_stats_port26 = query_counter(
+                    self, sai_thrift_get_queue_stats,
                 queue_id_list_port26[1])
             received_pkt_num = q_stats_port26["SAI_QUEUE_STAT_PACKETS"]
             print("\tqueue[1] of PORT26, no. packets:", received_pkt_num)
             # queue[0]
-            q_stats_port27 = query_counter(self, sai_thrift_get_queue_stats,
+            q_stats_port27 = query_counter(
+                    self, sai_thrift_get_queue_stats,
                 queue_id_list_port27[0])
             forwarded_pkt_num = q_stats_port27["SAI_QUEUE_STAT_PACKETS"]
             print("\tqueue[0] of PORT27, no. packets:", forwarded_pkt_num)
             # queue[1]
-            q_stats_port27 = query_counter(self, sai_thrift_get_queue_stats,
+            q_stats_port27 = query_counter(
+                    self, sai_thrift_get_queue_stats,
                 queue_id_list_port27[1])
             forwarded_pkt_num = q_stats_port27["SAI_QUEUE_STAT_PACKETS"]
             print("\tqueue[1] of PORT27, no. packets:", forwarded_pkt_num)

--- a/ptf/sairif.py
+++ b/ptf/sairif.py
@@ -1173,13 +1173,15 @@ class Ipv4DisableTest(L3InterfaceSimplifiedTestHelper):
             self.client, self.port1_rif, admin_v4_state=False)
         time.sleep(3)
 
-        initial_stats = sai_thrift_get_port_stats(self.client, self.port1)
+        initial_stats = query_counter(
+                    self, sai_thrift_get_port_stats, self.port1)
         if_in_discards_pre = initial_stats['SAI_PORT_STAT_IF_IN_DISCARDS']
 
         print("Sending packet on port %d, discard" % self.dev_port1)
         send_packet(self, self.dev_port1, pkt)
         verify_no_other_packets(self, timeout=3)
-        stats = sai_thrift_get_port_stats(self.client, self.port1)
+        stats = query_counter(
+                    self, sai_thrift_get_port_stats, self.port1)
         if_in_discards = stats['SAI_PORT_STAT_IF_IN_DISCARDS']
         self.assertTrue(if_in_discards_pre + 1 == if_in_discards)
         self.port1_rif_counter_in += 1
@@ -1239,13 +1241,13 @@ class RifMyIPTest(L3InterfaceSimplifiedTestHelper):
                                     ip_ttl=64,
                                     pktlen=100)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             print("Sending MYIP packet")
             send_packet(self, self.dev_port1, pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -1293,13 +1295,15 @@ class Ipv6DisableTest(L3InterfaceSimplifiedTestHelper):
         print("Disable IPv6 on ingress RIF")
         sai_thrift_set_router_interface_attribute(
             self.client, self.port1_rif, admin_v6_state=False)
-        initial_stats = sai_thrift_get_port_stats(self.client, self.port1)
+        initial_stats = query_counter(
+                    self, sai_thrift_get_port_stats, self.port1)
         if_in_discards_pre = initial_stats['SAI_PORT_STAT_IF_IN_DISCARDS']
 
         print("Sending packet on port %d, discard" % self.dev_port1)
         send_packet(self, self.dev_port1, pkt)
         verify_no_other_packets(self, timeout=1)
-        stats = sai_thrift_get_port_stats(self.client, self.port1)
+        stats = query_counter(
+                    self, sai_thrift_get_port_stats, self.port1)
         if_in_discards = stats['SAI_PORT_STAT_IF_IN_DISCARDS']
         self.assertTrue(if_in_discards_pre + 1 == if_in_discards)
         self.port1_rif_counter_in += 1
@@ -4463,8 +4467,8 @@ class SubPortMyIPTest(L3SubPortTestHelper):
                 ['40.40.4.51', 500, 25]   # self.subport25_500
             ]
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             for data in pkt_data:
                 ingress_port = getattr(self, 'dev_port%s' % data[2])
 
@@ -4474,8 +4478,8 @@ class SubPortMyIPTest(L3SubPortTestHelper):
                 send_packet(self, ingress_port, pkt)
 
             time.sleep(6)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + len(pkt_data))
@@ -7402,12 +7406,12 @@ class SviMyIPTest(L3SviTestHelper):
                                     ip_id=105,
                                     ip_ttl=64,
                                     pktlen=100)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             send_packet(self, untagged_port, pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -7421,12 +7425,12 @@ class SviMyIPTest(L3SviTestHelper):
                                     ip_id=105,
                                     ip_ttl=64,
                                     pktlen=100)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             send_packet(self, tagged_port, pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -7451,12 +7455,14 @@ class SviStatsTest(L3SviTestHelper):
     def runTest(self):
         print("\nsviStatsTest()")
 
-        vlan100_rif_stats = sai_thrift_get_router_interface_stats(
-            self.client, self.vlan100_rif)
-        vlan200_rif_stats = sai_thrift_get_router_interface_stats(
-            self.client, self.vlan200_rif)
-        vlan100_stats = sai_thrift_get_vlan_stats(self.client, self.vlan100)
-        vlan200_stats = sai_thrift_get_vlan_stats(self.client, self.vlan200)
+        vlan100_rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.vlan100_rif)
+        vlan200_rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.vlan200_rif)
+        vlan100_stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, self.vlan100)
+        vlan200_stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, self.vlan200)
 
         self.assertTrue(self.vlan100_rif_counter_in == vlan100_rif_stats[
             'SAI_ROUTER_INTERFACE_STAT_IN_PACKETS'])
@@ -7660,23 +7666,23 @@ class SviArpReplyTest(L3SviTestHelper):
                                  % tg_hostif_name).read()
             self.assertEqual(hostif_ip.rstrip(), tg_port_ip)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             print("Sending ARP request on untagged port")
             send_packet(self, untagged_dev_port, arp_req_pkt)
             self.assertTrue(socket_verify_packet(arp_req_pkt, utg_hif_socket))
             verify_packet(self, arp_resp_pkt, untagged_dev_port)
             print("Response received on the untagged port")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
             print("Request received on CPU port")
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             print("Sending ARP request on tagged port")
             send_packet(self, tagged_dev_port, tg_arp_req_pkt)
             self.assertTrue(
@@ -7684,8 +7690,8 @@ class SviArpReplyTest(L3SviTestHelper):
             verify_packet(self, tg_arp_resp_pkt, tagged_dev_port)
             print("Response received on the tagged port")
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -8037,30 +8043,30 @@ class Ipv4MtuTrapTest(L3MtuTrapTestHelper):
                                         ip_ttl=63,
                                         pktlen=201 + 14)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet port %d" % self.dev_port11, " -> cpu")
             send_packet(self, self.dev_port11, pkt)
             self.port11_rif_counter_in += 1
             self.port10_rif_counter_out += 1
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
 
             pkt['IP'].dst = '12.10.10.1'
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet port %d" % self.dev_port11, " -> cpu")
             send_packet(self, self.dev_port11, pkt)
             self.port11_rif_counter_in += 1
             self.lag1_rif_counter_out += 1
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -8163,30 +8169,30 @@ class Ipv6MtuTrapTest(L3MtuTrapTestHelper):
                 ipv6_hlim=63,
                 pktlen=201 + 14 + 40)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet port %d" % self.dev_port11, " -> cpu")
             send_packet(self, self.dev_port11, pkt)
             self.port11_rif_counter_in += 1
             self.port10_rif_counter_out += 1
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
 
             pkt['IPv6'].dst = '1234:5678:9abc:def0:1122:3344:5566:7788'
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet port %d" % self.dev_port11, " -> cpu")
             send_packet(self, self.dev_port11, pkt)
             self.port11_rif_counter_in += 1
             self.lag1_rif_counter_out += 1
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -8269,13 +8275,13 @@ class SubPortIpv4MtuTrapTest(L3MtuTrapTestHelper):
                                         vlan_vid=100,
                                         pktlen=201 + 18)
             print("Max MTU is 200, send pkt size 201, punt to cpu")
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet port %d" % self.dev_port11, " -> cpu")
             send_packet(self, self.dev_port11, pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -8359,13 +8365,13 @@ class SubPortIpv6MtuTrapTest(L3MtuTrapTestHelper):
                 vlan_vid=100,
                 pktlen=201 + 40 + 18)
             print("Max MTU is 200, send pkt size 201, punt to cpu")
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet port %d" % self.dev_port11, " -> cpu")
             send_packet(self, self.dev_port11, pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -8448,15 +8454,15 @@ class SviIpv4MtuTrapTest(L3MtuTrapTestHelper):
                                         ip_ttl=63,
                                         pktlen=201 + 14)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet port %d" % self.dev_port10, " -> cpu")
             send_packet(self, self.dev_port10, pkt)
             self.port10_rif_counter_in += 1
             self.vlan100_rif_counter_out += 1
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -8542,15 +8548,15 @@ class SviIpv6MtuTrapTest(L3MtuTrapTestHelper):
                 ipv6_hlim=63,
                 pktlen=201 + 14 + 40)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet port %d" % self.dev_port10, " -> cpu")
             send_packet(self, self.dev_port10, pkt)
             self.port10_rif_counter_in += 1
             self.vlan100_rif_counter_out += 1
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -8575,18 +8581,18 @@ class MtuPacketStatsTest(L3MtuTrapTestHelper):
         print("\nmtuPacketStatsTest()")
 
         time.sleep(4)
-        port10_rif_stats = sai_thrift_get_router_interface_stats(
-            self.client, self.port10_rif)
-        port11_rif_stats = sai_thrift_get_router_interface_stats(
-            self.client, self.port11_rif)
-        lag1_rif_stats = sai_thrift_get_router_interface_stats(
-            self.client, self.lag1_rif)
-        subport10_100_stats = sai_thrift_get_router_interface_stats(
-            self.client, self.subport10_100)
-        subport11_200_stats = sai_thrift_get_router_interface_stats(
-            self.client, self.subport11_200)
-        vlan100_rif_stats = sai_thrift_get_router_interface_stats(
-            self.client, self.vlan100_rif)
+        port10_rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.port10_rif)
+        port11_rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.port11_rif)
+        lag1_rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.lag1_rif)
+        subport10_100_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.subport10_100)
+        subport11_200_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.subport11_200)
+        vlan100_rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, self.vlan100_rif)
 
         self.assertTrue(self.port10_rif_counter_in == port10_rif_stats[
             'SAI_ROUTER_INTERFACE_STAT_IN_PACKETS'])

--- a/ptf/sairoute.py
+++ b/ptf/sairoute.py
@@ -134,13 +134,13 @@ class dropRouteTest(PlatformSaiHelper):
             ip_id=105,
             ip_ttl=64)
         try:
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet on port %d, forward" % self.dev_port11)
             send_packet(self, self.dev_port11, pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -243,13 +243,13 @@ class routeUpdateTest(PlatformSaiHelper):
             sai_thrift_set_route_entry_attribute(
                 self.client, route_entry, packet_action=SAI_PACKET_ACTION_TRAP)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet on port %d, forward" % self.dev_port11)
             send_packet(self, self.dev_port11, pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -567,14 +567,14 @@ class cpuForwardTest(PlatformSaiHelper):
                 trap_group=trap_group, trap_type=SAI_HOSTIF_TRAP_TYPE_IP2ME,
                 packet_action=SAI_PACKET_ACTION_TRAP)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             print("Sending packet on port %d, forward to CPU" %
                   self.dev_port10)
             send_packet(self, self.dev_port10, pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue4)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue4)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -676,13 +676,13 @@ class routeNbrColisionTest(PlatformSaiHelper):
             print("Removes neighbor")
             sai_thrift_remove_neighbor_entry(self.client, nbr_entry)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet on port %d, glean to cpu" % self.dev_port11)
             send_packet(self, self.dev_port11, pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -716,13 +716,13 @@ class routeNbrColisionTest(PlatformSaiHelper):
             sai_thrift_create_route_entry(self.client, route_entry,
                                           next_hop_id=self.port10_rif)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet on port %d, glean to cpu" % self.dev_port11)
             send_packet(self, self.dev_port11, pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -844,13 +844,13 @@ class L3DirBcastRouteTestHelper(PlatformSaiHelper):
                                     ip_src=pkt_ip_src,
                                     ip_id=105,
                                     ip_ttl=64)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet on port %d, glean to cpu" % self.dev_port10)
             send_packet(self, self.dev_port10, pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -861,13 +861,13 @@ class L3DirBcastRouteTestHelper(PlatformSaiHelper):
                                     ip_src=pkt_ip_src,
                                     ip_id=105,
                                     ip_ttl=64)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet on port %d, glean to cpu" % self.dev_port24)
             send_packet(self, self.dev_port24, pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -888,13 +888,13 @@ class L3DirBcastRouteTestHelper(PlatformSaiHelper):
                                     ip_src=pkt_ip_src,
                                     ip_id=105,
                                     ip_ttl=64)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet on port %d, glean to cpu" % self.dev_port10)
             send_packet(self, self.dev_port10, pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -906,13 +906,13 @@ class L3DirBcastRouteTestHelper(PlatformSaiHelper):
                                     ip_src=pkt_ip_src,
                                     ip_id=105,
                                     ip_ttl=64)
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             print("Sending packet on port %d, glean to cpu" % self.dev_port24)
             send_packet(self, self.dev_port24, pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)

--- a/ptf/saisrv6.py
+++ b/ptf/saisrv6.py
@@ -1819,12 +1819,12 @@ class Srv6MySidTest(SaiHelper):
                 self.end_b6_encap_sid,
                 packet_action=SAI_PACKET_ACTION_TRAP)
 
-            pre_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            pre_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             send_packet(self, self.dev_port11, sr6_pkt)
             time.sleep(4)
-            post_stats = sai_thrift_get_queue_stats(
-                self.client, self.cpu_queue0)
+            post_stats = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)
             self.assertEqual(
                 post_stats["SAI_QUEUE_STAT_PACKETS"],
                 pre_stats["SAI_QUEUE_STAT_PACKETS"] + 1)
@@ -1916,18 +1916,19 @@ class Srv6MySidTest(SaiHelper):
             self.client, self.end_sid, counter_id=True)
         self.assertEqual(my_sid_cntr['counter_id'], self.end_sid_counter)
 
-        counter_stats = sai_thrift_get_counter_stats(
-            self.client, self.end_sid_counter)
+        counter_stats = query_counter(
+                    self, sai_thrift_get_counter_stats, self.end_sid_counter)
         self.assertEqual(counter_stats['SAI_COUNTER_STAT_PACKETS'],
                          self.end_sid_stats)
         self.asserNotEqual(counter_stats['SAI_COUNTER_STAT_BYTES'], 0)
 
         print("My SID counter correct")
 
-        sai_thrift_clear_counter_stats(self.client, self.end_sid_counter)
+        clear_counter(
+                    self, sai_thrift_clear_counter_stats, self.end_sid_counter)
 
-        counter_stats = sai_thrift_get_counter_stats(
-            self.client, self.end_sid_counter)
+        counter_stats = query_counter(
+                    self, sai_thrift_get_counter_stats, self.end_sid_counter)
         self.assertEqual(counter_stats['SAI_COUNTER_STAT_PACKETS'], 0)
         self.assertEqual(counter_stats['SAI_COUNTER_STAT_BYTES'], 0)
 
@@ -2713,7 +2714,8 @@ class Srv6MySidDropTest(SaiHelper):
 
         self.drop_stats = 0
 
-        sai_thrift_clear_port_stats(self.client, self.port11)
+        clear_counter(
+                    self, sai_thrift_clear_port_stats, self.port11)
 
         # tests packets
         self.inner_v4_pkt = simple_tcp_packet(ip_dst=self.ip_dst,
@@ -2729,7 +2731,8 @@ class Srv6MySidDropTest(SaiHelper):
         self.nonZeroSlEndDTxDropTest()
 
     def tearDown(self):
-        sai_thrift_clear_port_stats(self.client, self.port11)
+        clear_counter(
+                    self, sai_thrift_clear_port_stats, self.port11)
 
         sai_thrift_remove_debug_counter(self.client, self.debug_cnt)
         sai_thrift_remove_route_entry(self.client, self.und_route4)
@@ -2799,8 +2802,8 @@ class Srv6MySidDropTest(SaiHelper):
             self.drop_stats += drop_pkt_no
 
             print("Checking SRv6 debug counter")
-            dc_stats = sai_thrift_get_debug_counter_port_stats(
-                self.client, self.port11, [self.dc_index])
+            dc_stats = query_counter(
+                    self, sai_thrift_get_debug_counter_port_stats, self.port11, [self.dc_index])
             self.assertEqual(dc_stats[self.dc_index], self.drop_stats,
                              "SRv6 debug counter value = %d incorrect! "
                              "Should be: %d"
@@ -2846,8 +2849,8 @@ class Srv6MySidDropTest(SaiHelper):
             self.drop_stats += drop_pkt_no
 
             print("Checking SRv6 debug counter")
-            dc_stats = sai_thrift_get_debug_counter_port_stats(
-                self.client, self.port11, [self.dc_index])
+            dc_stats = query_counter(
+                    self, sai_thrift_get_debug_counter_port_stats, self.port11, [self.dc_index])
             self.assertEqual(dc_stats[self.dc_index], self.drop_stats,
                              "SRv6 debug counter value = %d incorrect! "
                              "Should be: %d"
@@ -2868,8 +2871,8 @@ class Srv6MySidDropTest(SaiHelper):
             self.drop_stats += drop_pkt_no
 
             print("Checking SRv6 debug counter")
-            dc_stats = sai_thrift_get_debug_counter_port_stats(
-                self.client, self.port11, [self.dc_index])
+            dc_stats = query_counter(
+                    self, sai_thrift_get_debug_counter_port_stats, self.port11, [self.dc_index])
             self.assertEqual(dc_stats[self.dc_index], self.drop_stats,
                              "SRv6 debug counter value = %d incorrect! "
                              "Should be: %d"
@@ -2892,8 +2895,8 @@ class Srv6MySidDropTest(SaiHelper):
             self.drop_stats += drop_pkt_no
 
             print("Checking SRv6 debug counter")
-            dc_stats = sai_thrift_get_debug_counter_port_stats(
-                self.client, self.port11, [self.dc_index])
+            dc_stats = query_counter(
+                    self, sai_thrift_get_debug_counter_port_stats, self.port11, [self.dc_index])
             self.assertEqual(dc_stats[self.dc_index], self.drop_stats,
                              "SRv6 debug counter value = %d incorrect! "
                              "Should be: %d"

--- a/ptf/saiswitch.py
+++ b/ptf/saiswitch.py
@@ -893,11 +893,12 @@ class RefreshIntervalTest(PlatformSaiHelper):
         test_rif_port = self.dev_port10
         test_interval = 10
 
-        vlan_stats = sai_thrift_get_vlan_stats(self.client, test_vlan)
+        vlan_stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)
         init_vlan_counter = vlan_stats['SAI_VLAN_STAT_IN_PACKETS']
 
-        rif_stats = sai_thrift_get_router_interface_stats(
-            self.client, test_rif)
+        rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)
         init_rif_counter = rif_stats['SAI_ROUTER_INTERFACE_STAT_IN_PACKETS']
 
         pkt = simple_udp_packet()
@@ -906,13 +907,15 @@ class RefreshIntervalTest(PlatformSaiHelper):
             print("\nTesting VLAN stats counters refresh time")
             # compensate refresh time shift
             send_packet(self, test_vlan_port, pkt)
-            while sai_thrift_get_vlan_stats(self.client, test_vlan)[
+            while query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)[
                     'SAI_VLAN_STAT_IN_PACKETS'] == init_vlan_counter:
                 time.sleep(0.1)
             init_vlan_counter += 1
 
             send_packet(self, test_vlan_port, pkt)
-            vlan_stats = sai_thrift_get_vlan_stats(self.client, test_vlan)
+            vlan_stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)
             counter = vlan_stats['SAI_VLAN_STAT_IN_PACKETS']
             self.assertEqual(counter, init_vlan_counter)
 
@@ -920,7 +923,8 @@ class RefreshIntervalTest(PlatformSaiHelper):
             timer_start = time.time()
             timer_end = time.time()
             while counter == init_vlan_counter:
-                vlan_stats = sai_thrift_get_vlan_stats(self.client, test_vlan)
+                vlan_stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)
                 counter = vlan_stats['SAI_VLAN_STAT_IN_PACKETS']
                 timer_end = time.time()
             init_vlan_counter += 1
@@ -929,7 +933,8 @@ class RefreshIntervalTest(PlatformSaiHelper):
             print("VLAN stats refreshed after %d sec" % interval)
             self.assertEqual(init_interval, int(round(interval)))
 
-            vlan_stats = sai_thrift_get_vlan_stats(self.client, test_vlan)
+            vlan_stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)
             counter = vlan_stats['SAI_VLAN_STAT_IN_PACKETS']
             self.assertEqual(counter, init_vlan_counter)
 
@@ -945,13 +950,15 @@ class RefreshIntervalTest(PlatformSaiHelper):
 
             # compensate refresh time shift
             send_packet(self, test_vlan_port, pkt)
-            while sai_thrift_get_vlan_stats(self.client, test_vlan)[
+            while query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)[
                     'SAI_VLAN_STAT_IN_PACKETS'] == init_vlan_counter:
                 time.sleep(0.1)
             init_vlan_counter += 1
 
             send_packet(self, test_vlan_port, pkt)
-            vlan_stats = sai_thrift_get_vlan_stats(self.client, test_vlan)
+            vlan_stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)
             counter = vlan_stats['SAI_VLAN_STAT_IN_PACKETS']
             self.assertEqual(counter, init_vlan_counter)
 
@@ -959,7 +966,8 @@ class RefreshIntervalTest(PlatformSaiHelper):
             timer_start = time.time()
             timer_end = time.time()
             while counter == init_vlan_counter:
-                vlan_stats = sai_thrift_get_vlan_stats(self.client, test_vlan)
+                vlan_stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)
                 counter = vlan_stats['SAI_VLAN_STAT_IN_PACKETS']
                 timer_end = time.time()
             init_vlan_counter += 1
@@ -968,7 +976,8 @@ class RefreshIntervalTest(PlatformSaiHelper):
             print("VLAN stats refreshed after %d sec" % interval)
             self.assertEqual(test_interval, interval)
 
-            vlan_stats = sai_thrift_get_vlan_stats(self.client, test_vlan)
+            vlan_stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)
             counter = vlan_stats['SAI_VLAN_STAT_IN_PACKETS']
             self.assertEqual(counter, init_vlan_counter)
 
@@ -980,15 +989,16 @@ class RefreshIntervalTest(PlatformSaiHelper):
             print("\nTesting RIF stats counters refresh time")
             # compensate refresh time shift
             send_packet(self, test_rif_port, pkt)
-            while sai_thrift_get_router_interface_stats(self.client, test_rif)[
+            while query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)[
                     'SAI_ROUTER_INTERFACE_STAT_IN_PACKETS'] == \
                     init_rif_counter:
                 time.sleep(0.1)
             init_rif_counter += 1
 
             send_packet(self, test_rif_port, pkt)
-            rif_stats = sai_thrift_get_router_interface_stats(
-                self.client, test_rif)
+            rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)
             counter = rif_stats['SAI_ROUTER_INTERFACE_STAT_IN_PACKETS']
             self.assertEqual(counter, init_rif_counter)
 
@@ -996,8 +1006,8 @@ class RefreshIntervalTest(PlatformSaiHelper):
             timer_start = time.time()
             timer_end = time.time()
             while counter == init_rif_counter:
-                rif_stats = sai_thrift_get_router_interface_stats(
-                    self.client, test_rif)
+                rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)
                 counter = rif_stats['SAI_ROUTER_INTERFACE_STAT_IN_PACKETS']
                 timer_end = time.time()
             init_rif_counter += 1
@@ -1006,8 +1016,8 @@ class RefreshIntervalTest(PlatformSaiHelper):
             print("RIF stats refreshed after %d sec" % interval)
             self.assertEqual(init_interval, int(round(interval)))
 
-            rif_stats = sai_thrift_get_router_interface_stats(
-                self.client, test_rif)
+            rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)
             counter = rif_stats['SAI_ROUTER_INTERFACE_STAT_IN_PACKETS']
             self.assertEqual(counter, init_rif_counter)
 
@@ -1023,15 +1033,16 @@ class RefreshIntervalTest(PlatformSaiHelper):
 
             # compensate refresh time shift
             send_packet(self, test_rif_port, pkt)
-            while sai_thrift_get_router_interface_stats(self.client, test_rif)[
+            while query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)[
                     'SAI_ROUTER_INTERFACE_STAT_IN_PACKETS'] == \
                     init_rif_counter:
                 time.sleep(0.1)
             init_rif_counter += 1
 
             send_packet(self, test_rif_port, pkt)
-            rif_stats = sai_thrift_get_router_interface_stats(
-                self.client, test_rif)
+            rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)
             counter = rif_stats['SAI_ROUTER_INTERFACE_STAT_IN_PACKETS']
             self.assertEqual(counter, init_rif_counter)
 
@@ -1039,8 +1050,8 @@ class RefreshIntervalTest(PlatformSaiHelper):
             timer_start = time.time()
             timer_end = time.time()
             while counter == init_rif_counter:
-                rif_stats = sai_thrift_get_router_interface_stats(
-                    self.client, test_rif)
+                rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)
                 counter = rif_stats['SAI_ROUTER_INTERFACE_STAT_IN_PACKETS']
                 timer_end = time.time()
             init_rif_counter += 1
@@ -1049,8 +1060,8 @@ class RefreshIntervalTest(PlatformSaiHelper):
             print("RIF stats refreshed after %d sec" % interval)
             self.assertEqual(test_interval, interval)
 
-            rif_stats = sai_thrift_get_router_interface_stats(
-                self.client, test_rif)
+            rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)
             counter = rif_stats['SAI_VLAN_STAT_IN_PACKETS']
             self.assertEqual(counter, init_vlan_counter)
 
@@ -2058,11 +2069,12 @@ class SwitchAttrTest(SaiHelper):
         test_rif_port = self.dev_port10
         test_interval = 10
 
-        vlan_stats = sai_thrift_get_vlan_stats(self.client, test_vlan)
+        vlan_stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)
         init_vlan_counter = vlan_stats['SAI_VLAN_STAT_IN_PACKETS']
 
-        rif_stats = sai_thrift_get_router_interface_stats(
-            self.client, test_rif)
+        rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)
         init_rif_counter = rif_stats['SAI_ROUTER_INTERFACE_STAT_IN_PACKETS']
 
         pkt = simple_udp_packet()
@@ -2071,13 +2083,15 @@ class SwitchAttrTest(SaiHelper):
             print("\nTesting VLAN stats counters refresh time")
             # compensate refresh time shift
             send_packet(self, test_vlan_port, pkt)
-            while sai_thrift_get_vlan_stats(self.client, test_vlan)[
+            while query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)[
                     'SAI_VLAN_STAT_IN_PACKETS'] == init_vlan_counter:
                 time.sleep(0.1)
             init_vlan_counter += 1
 
             send_packet(self, test_vlan_port, pkt)
-            vlan_stats = sai_thrift_get_vlan_stats(self.client, test_vlan)
+            vlan_stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)
             counter = vlan_stats['SAI_VLAN_STAT_IN_PACKETS']
             self.assertEqual(counter, init_vlan_counter)
 
@@ -2085,7 +2099,8 @@ class SwitchAttrTest(SaiHelper):
             timer_start = time.time()
             timer_end = time.time()
             while counter == init_vlan_counter:
-                vlan_stats = sai_thrift_get_vlan_stats(self.client, test_vlan)
+                vlan_stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)
                 counter = vlan_stats['SAI_VLAN_STAT_IN_PACKETS']
                 timer_end = time.time()
             init_vlan_counter += 1
@@ -2094,7 +2109,8 @@ class SwitchAttrTest(SaiHelper):
             print("VLAN stats refreshed after %d sec" % interval)
             self.assertEqual(init_interval, int(round(interval)))
 
-            vlan_stats = sai_thrift_get_vlan_stats(self.client, test_vlan)
+            vlan_stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)
             counter = vlan_stats['SAI_VLAN_STAT_IN_PACKETS']
             self.assertEqual(counter, init_vlan_counter)
 
@@ -2110,13 +2126,15 @@ class SwitchAttrTest(SaiHelper):
 
             # compensate refresh time shift
             send_packet(self, test_vlan_port, pkt)
-            while sai_thrift_get_vlan_stats(self.client, test_vlan)[
+            while query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)[
                     'SAI_VLAN_STAT_IN_PACKETS'] == init_vlan_counter:
                 time.sleep(0.1)
             init_vlan_counter += 1
 
             send_packet(self, test_vlan_port, pkt)
-            vlan_stats = sai_thrift_get_vlan_stats(self.client, test_vlan)
+            vlan_stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)
             counter = vlan_stats['SAI_VLAN_STAT_IN_PACKETS']
             self.assertEqual(counter, init_vlan_counter)
 
@@ -2124,7 +2142,8 @@ class SwitchAttrTest(SaiHelper):
             timer_start = time.time()
             timer_end = time.time()
             while counter == init_vlan_counter:
-                vlan_stats = sai_thrift_get_vlan_stats(self.client, test_vlan)
+                vlan_stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)
                 counter = vlan_stats['SAI_VLAN_STAT_IN_PACKETS']
                 timer_end = time.time()
             init_vlan_counter += 1
@@ -2133,7 +2152,8 @@ class SwitchAttrTest(SaiHelper):
             print("VLAN stats refreshed after %d sec" % interval)
             self.assertEqual(test_interval, interval)
 
-            vlan_stats = sai_thrift_get_vlan_stats(self.client, test_vlan)
+            vlan_stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, test_vlan)
             counter = vlan_stats['SAI_VLAN_STAT_IN_PACKETS']
             self.assertEqual(counter, init_vlan_counter)
 
@@ -2145,15 +2165,16 @@ class SwitchAttrTest(SaiHelper):
             print("\nTesting RIF stats counters refresh time")
             # compensate refresh time shift
             send_packet(self, test_rif_port, pkt)
-            while sai_thrift_get_router_interface_stats(self.client, test_rif)[
+            while query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)[
                     'SAI_ROUTER_INTERFACE_STAT_IN_PACKETS'] == \
                     init_rif_counter:
                 time.sleep(0.1)
             init_rif_counter += 1
 
             send_packet(self, test_rif_port, pkt)
-            rif_stats = sai_thrift_get_router_interface_stats(
-                self.client, test_rif)
+            rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)
             counter = rif_stats['SAI_ROUTER_INTERFACE_STAT_IN_PACKETS']
             self.assertEqual(counter, init_rif_counter)
 
@@ -2161,8 +2182,8 @@ class SwitchAttrTest(SaiHelper):
             timer_start = time.time()
             timer_end = time.time()
             while counter == init_rif_counter:
-                rif_stats = sai_thrift_get_router_interface_stats(
-                    self.client, test_rif)
+                rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)
                 counter = rif_stats['SAI_ROUTER_INTERFACE_STAT_IN_PACKETS']
                 timer_end = time.time()
             init_rif_counter += 1
@@ -2171,8 +2192,8 @@ class SwitchAttrTest(SaiHelper):
             print("RIF stats refreshed after %d sec" % interval)
             self.assertEqual(init_interval, int(round(interval)))
 
-            rif_stats = sai_thrift_get_router_interface_stats(
-                self.client, test_rif)
+            rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)
             counter = rif_stats['SAI_ROUTER_INTERFACE_STAT_IN_PACKETS']
             self.assertEqual(counter, init_rif_counter)
 
@@ -2188,15 +2209,16 @@ class SwitchAttrTest(SaiHelper):
 
             # compensate refresh time shift
             send_packet(self, test_rif_port, pkt)
-            while sai_thrift_get_router_interface_stats(self.client, test_rif)[
+            while query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)[
                     'SAI_ROUTER_INTERFACE_STAT_IN_PACKETS'] == \
                     init_rif_counter:
                 time.sleep(0.1)
             init_rif_counter += 1
 
             send_packet(self, test_rif_port, pkt)
-            rif_stats = sai_thrift_get_router_interface_stats(
-                self.client, test_rif)
+            rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)
             counter = rif_stats['SAI_ROUTER_INTERFACE_STAT_IN_PACKETS']
             self.assertEqual(counter, init_rif_counter)
 
@@ -2204,8 +2226,8 @@ class SwitchAttrTest(SaiHelper):
             timer_start = time.time()
             timer_end = time.time()
             while counter == init_rif_counter:
-                rif_stats = sai_thrift_get_router_interface_stats(
-                    self.client, test_rif)
+                rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)
                 counter = rif_stats['SAI_ROUTER_INTERFACE_STAT_IN_PACKETS']
                 timer_end = time.time()
             init_rif_counter += 1
@@ -2214,8 +2236,8 @@ class SwitchAttrTest(SaiHelper):
             print("RIF stats refreshed after %d sec" % interval)
             self.assertEqual(test_interval, interval)
 
-            rif_stats = sai_thrift_get_router_interface_stats(
-                self.client, test_rif)
+            rif_stats = query_counter(
+                    self, sai_thrift_get_router_interface_stats, test_rif)
             counter = rif_stats['SAI_VLAN_STAT_IN_PACKETS']
             self.assertEqual(counter, init_vlan_counter)
 

--- a/ptf/saivlan.py
+++ b/ptf/saivlan.py
@@ -935,7 +935,8 @@ class L2VlanTest(SaiHelper):
         self.i_pkt_count += 1
         self.e_pkt_count += 1
 
-        stats = sai_thrift_get_port_stats(self.client, self.port0)
+        stats = query_counter(
+                    self, sai_thrift_get_port_stats, self.port0)
         if_in_vlan_discards_pre = \
             stats['SAI_PORT_STAT_IF_IN_VLAN_DISCARDS']
 
@@ -944,7 +945,8 @@ class L2VlanTest(SaiHelper):
         send_packet(self, self.dev_port0, v11_pkt)
         verify_no_other_packets(self, timeout=1)
 
-        stats = sai_thrift_get_port_stats(self.client, self.port0)
+        stats = query_counter(
+                    self, sai_thrift_get_port_stats, self.port0)
         if_in_vlan_discards = stats['SAI_PORT_STAT_IF_IN_VLAN_DISCARDS']
         self.assertEqual(if_in_vlan_discards_pre + 1, if_in_vlan_discards)
 
@@ -1706,7 +1708,8 @@ class L2VlanTest(SaiHelper):
                                 ip_dst='172.16.0.1',
                                 ip_id=101,
                                 ip_ttl=64)
-        stats = sai_thrift_get_vlan_stats(self.client, self.vlan10)
+        stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, self.vlan10)
         in_bytes_pre = stats["SAI_VLAN_STAT_IN_OCTETS"]
         out_bytes_pre = stats["SAI_VLAN_STAT_OUT_OCTETS"]
         in_packets_pre = stats["SAI_VLAN_STAT_IN_PACKETS"]
@@ -1719,7 +1722,8 @@ class L2VlanTest(SaiHelper):
         verify_packet(self, pkt, self.dev_port24)
 
         # Check counters
-        stats = sai_thrift_get_vlan_stats(self.client, self.vlan10)
+        stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, self.vlan10)
         in_bytes = stats["SAI_VLAN_STAT_IN_OCTETS"]
         out_bytes = stats["SAI_VLAN_STAT_OUT_OCTETS"]
         in_packets = stats["SAI_VLAN_STAT_IN_PACKETS"]
@@ -1748,10 +1752,12 @@ class L2VlanTest(SaiHelper):
         verify_packet(self, pkt, self.dev_port24)
 
         # Clear bytes and packets counter
-        sai_thrift_clear_vlan_stats(self.client, self.vlan10)
+        clear_counter(
+                    self, sai_thrift_clear_vlan_stats, self.vlan10)
 
         # Check counters
-        stats = sai_thrift_get_vlan_stats(self.client, self.vlan10)
+        stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, self.vlan10)
         in_bytes = stats["SAI_VLAN_STAT_IN_OCTETS"]
         out_bytes = stats["SAI_VLAN_STAT_OUT_OCTETS"]
         in_packets = stats["SAI_VLAN_STAT_IN_PACKETS"]
@@ -1981,7 +1987,8 @@ class L2VlanTest(SaiHelper):
         statistics for VLAN
         """
         print("\nvlanStatsTest()")
-        stats = sai_thrift_get_vlan_stats(self.client, self.vlan10)
+        stats = query_counter(
+                    self, sai_thrift_get_vlan_stats, self.vlan10)
         in_bytes = stats["SAI_VLAN_STAT_IN_OCTETS"]
         out_bytes = stats["SAI_VLAN_STAT_OUT_OCTETS"]
         in_packets = stats["SAI_VLAN_STAT_IN_PACKETS"]

--- a/ptf/saiwred.py
+++ b/ptf/saiwred.py
@@ -408,9 +408,11 @@ class _WredIPv4NonECNTest(WredTestHelper):
     def runTest(self):
         print("\n\n_WredIPv4NonECNTest()")
         print("---------------------")
-        i_port_stats = sai_thrift_get_port_stats(self.client,
+        i_port_stats = query_counter(
+                    self, sai_thrift_get_port_stats,
                                                  self.port11)
-        i_queue_stats = sai_thrift_get_queue_stats(self.client,
+        i_queue_stats = query_counter(
+                    self, sai_thrift_get_queue_stats,
                                                    self.queues11[0])
         try:
             pkt1 = simple_tcp_packet(
@@ -438,9 +440,11 @@ class _WredIPv4NonECNTest(WredTestHelper):
             send_packet(self, self.dev_port10, pkt1)
             verify_packet(self, exp_pkt1, self.dev_port11)
             time.sleep(2)
-            e_port_stats = sai_thrift_get_port_stats(self.client,
+            e_port_stats = query_counter(
+                    self, sai_thrift_get_port_stats,
                                                      self.port11)
-            e_queue_stats = sai_thrift_get_queue_stats(self.client,
+            e_queue_stats = query_counter(
+                    self, sai_thrift_get_queue_stats,
                                                        self.queues11[0])
 
             # Verify stats

--- a/test/sai_test/sai_neighbor_test.py
+++ b/test/sai_test/sai_neighbor_test.py
@@ -295,8 +295,8 @@ class RemoveAddNeighborTestIPV4(T0TestBase):
         print("Packet dropped")
         post_cpu_queue_state = sai_thrift_get_queue_stats(
             self.client, self.cpu_queue0)["SAI_QUEUE_STAT_PACKETS"]
-        #self.assertEqual(post_cpu_queue_state - pre_cpu_queue_state, 1)
-        # Disable above check beacuse of bug 15205360
+        self.assertEqual(post_cpu_queue_state - pre_cpu_queue_state, 1)
+        # bug 15205360 above check 
         print(str(post_cpu_queue_state - pre_cpu_queue_state))
         sai_thrift_create_neighbor_entry(
             self.client,
@@ -390,8 +390,8 @@ class RemoveAddNeighborTestIPV6(T0TestBase):
         print("Packet dropped")
         post_cpu_queue_state = sai_thrift_get_queue_stats(
             self.client, self.cpu_queue0)["SAI_QUEUE_STAT_PACKETS"]
-        #self.assertEqual(post_cpu_queue_state - pre_cpu_queue_state, 1)
-        # Disable above check beacuse of bug 15205360
+        self.assertEqual(post_cpu_queue_state - pre_cpu_queue_state, 1)
+        # bug 15205360 above check 
         print(str(post_cpu_queue_state - pre_cpu_queue_state))
         sai_thrift_create_neighbor_entry(
             self.client,

--- a/test/sai_test/sai_neighbor_test.py
+++ b/test/sai_test/sai_neighbor_test.py
@@ -294,8 +294,8 @@ class RemoveAddNeighborTestIPV4(T0TestBase):
         send_packet(self, self.dev_port1, pkt)
         verify_no_other_packets(self)
         print("Packet dropped")
-        post_cpu_queue_state = sai_thrift_get_queue_stats(
-            self.client, self.cpu_queue0)["SAI_QUEUE_STAT_PACKETS"]
+        post_cpu_queue_state = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)["SAI_QUEUE_STAT_PACKETS"]
         self.assertEqual(post_cpu_queue_state - pre_cpu_queue_state, 1)
         # bug 15205360 above check 
         print(str(post_cpu_queue_state - pre_cpu_queue_state))
@@ -390,8 +390,8 @@ class RemoveAddNeighborTestIPV6(T0TestBase):
         send_packet(self, self.dev_port1, pkt_v6)
         verify_no_other_packets(self)
         print("Packet dropped")
-        post_cpu_queue_state = sai_thrift_get_queue_stats(
-            self.client, self.cpu_queue0)["SAI_QUEUE_STAT_PACKETS"]
+        post_cpu_queue_state = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)["SAI_QUEUE_STAT_PACKETS"]
         self.assertEqual(post_cpu_queue_state - pre_cpu_queue_state, 1)
         # bug 15205360 above check 
         print(str(post_cpu_queue_state - pre_cpu_queue_state))

--- a/test/sai_test/sai_neighbor_test.py
+++ b/test/sai_test/sai_neighbor_test.py
@@ -288,7 +288,8 @@ class RemoveAddNeighborTestIPV4(T0TestBase):
 
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v4)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
-        pre_cpu_queue_state = sai_thrift_get_queue_stats(self.client, self.cpu_queue0)[
+        pre_cpu_queue_state = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)[
             "SAI_QUEUE_STAT_PACKETS"]
         send_packet(self, self.dev_port1, pkt)
         verify_no_other_packets(self)
@@ -383,7 +384,8 @@ class RemoveAddNeighborTestIPV6(T0TestBase):
 
         sai_thrift_remove_neighbor_entry(self.client, self.nbr_entry_v6)
         self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
-        pre_cpu_queue_state = sai_thrift_get_queue_stats(self.client, self.cpu_queue0)[
+        pre_cpu_queue_state = query_counter(
+                    self, sai_thrift_get_queue_stats, self.cpu_queue0)[
             "SAI_QUEUE_STAT_PACKETS"]
         send_packet(self, self.dev_port1, pkt_v6)
         verify_no_other_packets(self)

--- a/test/sai_test/sai_vlan_test.py
+++ b/test/sai_test/sai_vlan_test.py
@@ -753,8 +753,8 @@ class TaggedVlanStatusTest(T0TestBase):
                                             vlan_vid=10,
                                             ip_id=101,
                                             ip_ttl=64)
-        stats = sai_thrift_get_vlan_stats(
-            self.client, self.dut.vlans[10].oid)
+        stats = query_counter(
+            self, sai_thrift_get_vlan_stats, self.dut.vlans[10].oid)
 
         in_bytes_pre = stats["SAI_VLAN_STAT_IN_OCTETS"]
         out_bytes_pre = stats["SAI_VLAN_STAT_OUT_OCTETS"]
@@ -769,8 +769,8 @@ class TaggedVlanStatusTest(T0TestBase):
         verify_packet(self, self.tagged_pkt,
                       self.dut.port_obj_list[2].dev_port_index)
 
-        stats = sai_thrift_get_vlan_stats(
-            self.client, self.dut.vlans[10].oid)
+        stats = query_counter(
+            self, sai_thrift_get_vlan_stats, self.dut.vlans[10].oid)
         in_bytes = stats["SAI_VLAN_STAT_IN_OCTETS"]
         out_bytes = stats["SAI_VLAN_STAT_OUT_OCTETS"]
         in_packets = stats["SAI_VLAN_STAT_IN_PACKETS"]
@@ -804,11 +804,12 @@ class TaggedVlanStatusTest(T0TestBase):
                       self.dut.port_obj_list[2].dev_port_index)
 
         # Clear bytes and packets counter
-        sai_thrift_clear_vlan_stats(self.client, self.dut.vlans[10].oid)
+        clear_counter(
+            self, sai_thrift_clear_vlan_stats, self.dut.vlans[10].oid)
 
         # Check counters
-        stats = sai_thrift_get_vlan_stats(
-            self.client, self.dut.vlans[10].oid)
+        stats = query_counter(
+            self, sai_thrift_get_vlan_stats, self.dut.vlans[10].oid)
         in_bytes = stats["SAI_VLAN_STAT_IN_OCTETS"]
         out_bytes = stats["SAI_VLAN_STAT_OUT_OCTETS"]
         in_packets = stats["SAI_VLAN_STAT_IN_PACKETS"]
@@ -847,7 +848,8 @@ class UntaggedVlanStatusTest(T0TestBase):
                                               eth_src=self.servers[1][1].mac,
                                               ip_id=101,
                                               ip_ttl=64)
-        stats = sai_thrift_get_vlan_stats(self.client, self.dut.vlans[10].oid)
+        stats = query_counter(
+            self, sai_thrift_get_vlan_stats, self.dut.vlans[10].oid)
 
         in_bytes_pre = stats["SAI_VLAN_STAT_IN_OCTETS"]
         out_bytes_pre = stats["SAI_VLAN_STAT_OUT_OCTETS"]
@@ -863,8 +865,8 @@ class UntaggedVlanStatusTest(T0TestBase):
                       self.dut.port_obj_list[2].dev_port_index)
 
         time.sleep(1)
-        stats = sai_thrift_get_vlan_stats(
-            self.client, self.dut.vlans[10].oid)
+        stats = query_counter(
+            self, sai_thrift_get_vlan_stats, self.dut.vlans[10].oid)
         in_bytes = stats["SAI_VLAN_STAT_IN_OCTETS"]
         out_bytes = stats["SAI_VLAN_STAT_OUT_OCTETS"]
         in_packets = stats["SAI_VLAN_STAT_IN_PACKETS"]
@@ -898,11 +900,12 @@ class UntaggedVlanStatusTest(T0TestBase):
                       self.dut.port_obj_list[2].dev_port_index)
 
         # Clear bytes and packets counter
-        sai_thrift_clear_vlan_stats(self.client, self.dut.vlans[10].oid)
+        clear_counter(
+            self, sai_thrift_clear_vlan_stats, self.dut.vlans[10].oid)
         # Check counters
 
-        stats = sai_thrift_get_vlan_stats(
-            self.client, self.dut.vlans[10].oid)
+        stats = query_counter(
+            self, sai_thrift_get_vlan_stats, self.dut.vlans[10].oid)
         in_bytes = stats["SAI_VLAN_STAT_IN_OCTETS"]
         out_bytes = stats["SAI_VLAN_STAT_OUT_OCTETS"]
         in_packets = stats["SAI_VLAN_STAT_IN_PACKETS"]


### PR DESCRIPTION
Why
Use the counter querier and cleaner to invoc the stats related APIs. It will use counter one by one, the unimplemented stats counter will not impact others. Add a switch case

How
Refactor stats counter related method

Verify
DUT test