### PR TITLE
WatchDog Timer Configuration for VoQ

### DIFF
--- a/inc/saiqueue.h
+++ b/inc/saiqueue.h
@@ -390,6 +390,9 @@ typedef enum _sai_queue_stat_t
     /** Get watermark queue occupancy percentage [uint64_t] */
     SAI_QUEUE_STAT_WATERMARK_LEVEL = 0x00000025,
 
+    /** Get packets deleted when the credit watch dog expires for VOQ System [uint64_t] */
+    SAI_QUEUE_STAT_CREDIT_WD_DELETED_PACKETS = 0x00000026,
+
     /** Custom range base value */
     SAI_QUEUE_STAT_CUSTOM_RANGE_BASE = 0x10000000
 

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -2890,6 +2890,9 @@ typedef enum _sai_switch_stat_t
     /** Discards not counted in other switch stat type [switch | fabric] */
     SAI_SWITCH_STAT_GLOBAL_DROP,
 
+    /** Get integrity discards [fabric] */
+    SAI_SWITCH_STAT_PACKET_INTEGRITY_DROP,
+
     /** Switch stat fabric drop reasons range end */
     SAI_SWITCH_STAT_FABRIC_DROP_REASON_RANGE_END = 0x00003fff,
 

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -2796,6 +2796,30 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_ACL_STAGE_POST_INGRESS,
 
     /**
+     * @brief Enable or disable credit watchdog
+     *
+     * Credit Watchdog can be enabled or disabled using this attribute for VOQ based system
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default true
+     * @validonly SAI_SWITCH_ATTR_TYPE == SAI_SWITCH_TYPE_VOQ
+     */
+    SAI_SWITCH_ATTR_CREDIT_WD,
+
+    /**
+     * @brief Credit watchdog threshold timer in milliseconds
+     * Value must be within 10ms - 1000ms range
+     * Queue is set to delete state and all packets in queue are deleted after the timer expiry
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 500
+     * @validonly SAI_SWITCH_ATTR_TYPE == SAI_SWITCH_TYPE_VOQ
+     */
+    SAI_SWITCH_ATTR_CREDIT_WD_TIMER,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,


### PR DESCRIPTION
This PR introduces attributes to enable/disable the watch dog credit timer for VoQs.
If SAI_SWITCH_ATTR_CREDIT_WD is enabled and SAI_SWITCH_ATTR_CREDIT_WD_TIMER expires since the last credit for an active queue, the queue will be set to delete state and all packets in queue will be deleted.

https://github.com/opencomputeproject/SAI/pull/1748 is closed