### PR TITLE
Hybrid mode

### DIFF
--- a/inc/saibridge.h
+++ b/inc/saibridge.h
@@ -98,6 +98,11 @@ typedef enum _sai_bridge_port_tagging_mode_t
     /** Tagged mode */
     SAI_BRIDGE_PORT_TAGGING_MODE_TAGGED,
 
+
+    /** Hybrid mode */
+    SAI_BRIDGE_PORT_TAGGING_MODE_HYBRID,
+
+
 } sai_bridge_port_tagging_mode_t;
 
 /**


### PR DESCRIPTION
This PR brings in a new Bridge Port Tagging Attribute in SAI (saibridge.h)

Currently,  there are two tagging modes for a bridge port (untagged, tagged). 
A Hybrid Switchport Mode allows both untagged or tagged traffic which needs this hybrid bridge port tagging attribute.

Signed-off-by: Rida Hanif [rida.hanif@xflowresearch.com](mailto:rida.hanif@xflowresearch.com)

