### PR TITLE
[meta] Add check for struct/union binary backward compatibility

### DIFF
--- a/meta/Makefile
+++ b/meta/Makefile
@@ -83,8 +83,10 @@ SYMBOLS = $(OBJ:=.symbols)
 
 all: toolsversions saisanitycheck saimetadatatest saiserializetest saidepgraph.svg $(SYMBOLS)
 	./checkheaders.pl ../inc ../inc
+	./aspellcheck.pl
 	./checkenumlock.sh
 	./checkancestry.sh
+	./checkstructs.sh
 	./saimetadatatest >/dev/null
 	./saiserializetest >/dev/null
 	./saisanitycheck

--- a/meta/aspell.en.pws
+++ b/meta/aspell.en.pws
@@ -8,6 +8,7 @@ apache
 api
 APIs
 Args
+armhf
 attr
 attrid
 attrs
@@ -68,6 +69,7 @@ HQoS
 HQOS
 http
 idriver
+ifdef
 INET
 ingressing
 inout

--- a/meta/aspellcheck.pl
+++ b/meta/aspellcheck.pl
@@ -1,0 +1,206 @@
+#!/usr/bin/perl
+#
+# Copyright (c) 2023 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+# @file    aspellcheck.pl
+#
+# @brief   This module run aspell on meta source and headers
+#
+
+BEGIN { push @INC,'.'; }
+
+use strict;
+use warnings;
+use diagnostics;
+
+use Term::ANSIColor;
+
+use utils;
+use style;
+
+our $errors = 0;
+our $warnings = 0;
+
+sub GetSourceFilesAndHeaders
+{
+    my @files = `find . -name "*.cpp" -o -name "*.[ch]"`;
+
+    return @files;
+}
+
+sub ReadFile
+{
+    my $filename = shift;
+
+    local $/ = undef;
+
+    # first search file in meta directory
+
+    open FILE, $filename or die "Couldn't open file $filename: $!";
+
+    binmode FILE;
+
+    my $string = <FILE>;
+
+    close FILE;
+
+    return $string;
+}
+
+sub ExtractComments
+{
+    my $input = shift;
+
+    my $comments = "";
+
+    # good enough comments extractor C/C++ source
+
+    while ($input =~ m!(".*?")|//.*?[\r\n]|/\*.*?\*/!s)
+    {
+        $input = $';
+
+        $comments .= $& if not $1;
+    }
+
+    return $comments;
+}
+
+sub RunAspell
+{
+    my $hash = shift;
+
+    my %wordsToCheck = %{ $hash };
+
+    if (not -e "/usr/bin/aspell")
+    {
+        LogError "ASPELL IS NOT PRESENT, please install aspell";
+        return;
+    }
+
+    LogInfo "Running Aspell";
+
+    my @keys = sort keys %wordsToCheck;
+
+    my $count = @keys;
+
+    my $all = "@keys";
+
+    LogInfo "Words to check: $count";
+
+    my @result = `echo "$all" | /usr/bin/aspell -l en -a -p ./aspell.en.pws 2>&1`;
+
+    for my $res (@result)
+    {
+        if ($res =~ /error/i)
+        {
+            LogError "aspell error: $res";
+            last;
+        }
+
+        chomp $res;
+        next if $res =~ /^\*?$/;
+
+        print "$res\n";
+        next if not $res =~ /^\s*&\s*(\S+)/;
+
+        my $word = $1;
+
+        next if $word =~ /^wred$/i;
+
+        chomp $res;
+
+        my $where = "??";
+
+        if (not defined $wordsToCheck{$word})
+        {
+            for my $k (@keys)
+            {
+                if ($k =~ /(^$word|$word$)/)
+                {
+                    $where = $wordsToCheck{$k};
+                    last;
+                }
+
+                $where = $wordsToCheck{$k} if ($k =~ /$word/);
+            }
+        }
+        else
+        {
+            $where = $wordsToCheck{$word};
+        }
+
+        LogWarning "Word '$word' is misspelled $where";
+    }
+}
+
+my @acronyms = GetAcronyms();
+
+my %spellAcronyms = ();
+
+$spellAcronyms{$_} = 1 for @acronyms;
+
+my @exceptions = qw/ IPv4 IPv6 0xFF IPv SAIMETADATALOGGER auth objecttype saimetadatalogger sak /;
+
+my %spellExceptions = map { $_ => $_ } @exceptions;
+
+my @files = GetSourceFilesAndHeaders();
+
+my %wordsToCheck = ();
+
+for my $file (@files)
+{
+    chomp $file;
+    next if $file =~ m!saiswig.cpp!;
+    next if $file =~ m!temp!;
+    next if $file =~ m!xml!;
+    next if $file =~ m!saimetadata.[ch]!;
+
+    my $data = ReadFile $file;
+
+    my $comments = ExtractComments $data;
+
+    $comments =~ s!github.com\S+! !g;
+    $comments =~ s!l2mc! !g;
+    $comments =~ s!\s+\d+(th|nd) ! !g;
+    $comments =~ s!(/\*|\*/)! !g;
+    $comments =~ s!//! !g;
+    $comments =~ s!\s+\*\s+! !g;
+    $comments =~ s![^a-zA-Z0-9_]! !g;
+
+    my @words = split/\s+/,$comments;
+
+    for my $word (@words)
+    {
+        next if defined $spellAcronyms{$word};
+        next if defined $spellExceptions{$word};
+
+        next if $word =~ /_/;
+        next if $word =~ /xYYY+/;
+        next if $word =~ /fe\d+/;
+        next if $word =~ /ebe\d+/;
+        next if $word =~ /Werror/;
+        next if $word =~ /^[A-Za-z][a-z]+([A-Z][a-z]+)+$/; # fooBar FooBar
+
+        $wordsToCheck{$word} = $file;
+    }
+}
+
+RunAspell(\%wordsToCheck);
+
+exit 1 if ($warnings > 0 or $errors > 0);

--- a/meta/checkstructs.sh
+++ b/meta/checkstructs.sh
@@ -111,8 +111,7 @@ function check_structs_history()
 
 # BEGIN_COMMIT is the commit from we want structs to be backward compatible
 
-# currently set to v1.12.0
-BEGIN_COMMIT=fdaf928
+BEGIN_COMMIT=97a1e02 # v1.11.0
 END_COMMIT=HEAD
 
 clean_temp_dir

--- a/meta/checkstructs.sh
+++ b/meta/checkstructs.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+# @file    checkstructs.sh
+#
+# @brief   This module defines check structs script
+#
+
+
+# To list git ancestry all comitts (even if there is a tree not single line)
+# this can be usefull to build histroy of structs from root (struct lock) to the
+# current origin/master and current commit - and it will be possible to fix
+# mistakes.
+
+# examples below are to show how to get correct git history tree
+# git log --graph --oneline --ancestry-path c388490^..0b90765 | cat
+# git rev-list --ancestry-path  c388490^..0b90765
+
+# If we will have our base commit, we will assume that each previous commit
+# followed metadata check, and then we can use naive approach for parsing struct
+# values instead of doing gcc compile whch can take long time. With this
+# approach we should be able to build entire history from base commit throug
+# all commits up to the current PR. This will sure that there will be no
+# abnormalities if some structs will be removed and then added again with
+# different value. This will also help to track the issue if two PRs will pass
+# validation but after they will be merged they could potentially cause struct
+# value issue and this approach will catch that.
+#
+# Working throug 25 commits takes about 0.4 seconds + parsing so it seems like
+# not a hudge time to make sure all commits are safe and even if we get at some
+# point that this will be "too slow", having all history, we can sometimes
+# produce "known" history with structs values and keep that file as a reference
+# and load it at begin, and start checking commits from one of the future
+# commits, basicially reducing processing time to zero.
+
+# Just for sanity we can also keep headers check to 1 commit back and also
+# maybe we can add one gcc check current to history,
+
+set -e
+
+# 1. get all necessary data to temp directory for future processing
+# 2. pass all interesting commits to processor to build history
+
+function clean_temp_dir()
+{
+    rm -rf temp
+}
+
+function create_temp_dir()
+{
+    mkdir temp
+}
+
+function checkout_inc_directories()
+{
+    echo "git checkout work tree commits:" $LIST
+
+    for commit in $LIST
+    do
+        #echo working on commit $commit
+
+        mkdir temp/commit-$commit
+        mkdir temp/commit-$commit/inc
+
+        git --work-tree=temp/commit-$commit checkout $commit inc 2>/dev/null
+
+    done
+}
+
+function create_commit_list()
+{
+    local begin=$1
+    local end=$2
+
+    echo "ancestry graph"
+
+    # NOTE: origin/master should be changed if this file is on different branch
+
+    git --no-pager log --graph --oneline --ancestry-path  origin/master^..HEAD
+
+    echo "git rev list from $begin to $end"
+
+    LIST=$(git rev-list --ancestry-path ${begin}^..${end} | xargs -n 1 git rev-parse --short | tac)
+}
+
+function check_structs_history()
+{
+    perl structs.pl $LIST
+}
+
+#
+# MAIN
+#
+
+# BEGIN_COMMIT is the commit from we want structs to be backward compatible
+
+BEGIN_COMMIT=aed34c8
+END_COMMIT=HEAD
+
+clean_temp_dir
+create_temp_dir
+create_commit_list $BEGIN_COMMIT $END_COMMIT
+checkout_inc_directories
+check_structs_history

--- a/meta/checkstructs.sh
+++ b/meta/checkstructs.sh
@@ -112,7 +112,7 @@ function check_structs_history()
 # BEGIN_COMMIT is the commit from we want structs to be backward compatible
 
 # currently set to v1.12.0
-BEGIN_COMMIT=aed34c8
+BEGIN_COMMIT=fdaf928
 END_COMMIT=HEAD
 
 clean_temp_dir

--- a/meta/checkstructs.sh
+++ b/meta/checkstructs.sh
@@ -111,6 +111,7 @@ function check_structs_history()
 
 # BEGIN_COMMIT is the commit from we want structs to be backward compatible
 
+# currently set to v1.12.0
 BEGIN_COMMIT=aed34c8
 END_COMMIT=HEAD
 

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -5484,7 +5484,7 @@ void check_struct_and_union_size()
     CHECK_STRUCT_SIZE(sai_acl_action_parameter_t, 24);
     CHECK_STRUCT_SIZE(sai_acl_field_data_data_t, 16);
     CHECK_STRUCT_SIZE(sai_acl_field_data_mask_t, 16);
-    CHECK_STRUCT_SIZE(sai_attribute_value_t, 48);
+    CHECK_STRUCT_SIZE(sai_attribute_value_t, 40);
     CHECK_STRUCT_SIZE(sai_ip_addr_t, 16);
     CHECK_STRUCT_SIZE(sai_object_key_entry_t, 64);
     CHECK_STRUCT_SIZE(sai_tlv_entry_t, 36);
@@ -5499,7 +5499,7 @@ void check_struct_and_union_size()
     CHECK_STRUCT_SIZE(sai_acl_resource_list_t, 16);
     CHECK_STRUCT_SIZE(sai_acl_resource_t, 12);
     CHECK_STRUCT_SIZE(sai_attr_capability_t, 3);
-    CHECK_STRUCT_SIZE(sai_attribute_t, 56);
+    CHECK_STRUCT_SIZE(sai_attribute_t, 48);
     CHECK_STRUCT_SIZE(sai_bfd_session_state_notification_t, 16);
     CHECK_STRUCT_SIZE(sai_fabric_port_reachability_t, 8);
     CHECK_STRUCT_SIZE(sai_fdb_entry_t, 24);

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -5492,7 +5492,7 @@ void check_struct_and_union_size()
     /* structs */
 
     CHECK_STRUCT_SIZE(sai_acl_action_data_t, 32);
-    CHECK_STRUCT_SIZE(sai_acl_capability_t, 48);
+    CHECK_STRUCT_SIZE(sai_acl_capability_t, 32);
     CHECK_STRUCT_SIZE(sai_acl_chain_list_t, 16);
     CHECK_STRUCT_SIZE(sai_acl_chain_t, 8);
     CHECK_STRUCT_SIZE(sai_acl_field_data_t, 40);

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -5492,7 +5492,9 @@ void check_struct_and_union_size()
     /* structs */
 
     CHECK_STRUCT_SIZE(sai_acl_action_data_t, 32);
-    CHECK_STRUCT_SIZE(sai_acl_capability_t, 32);
+    CHECK_STRUCT_SIZE(sai_acl_capability_t, 36);
+    CHECK_STRUCT_SIZE(sai_acl_chain_list_t, 32);
+    CHECK_STRUCT_SIZE(sai_acl_chain_t, 8);
     CHECK_STRUCT_SIZE(sai_acl_field_data_t, 40);
     CHECK_STRUCT_SIZE(sai_acl_resource_list_t, 16);
     CHECK_STRUCT_SIZE(sai_acl_resource_t, 12);

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -5484,7 +5484,7 @@ void check_struct_and_union_size()
     CHECK_STRUCT_SIZE(sai_acl_action_parameter_t, 24);
     CHECK_STRUCT_SIZE(sai_acl_field_data_data_t, 16);
     CHECK_STRUCT_SIZE(sai_acl_field_data_mask_t, 16);
-    CHECK_STRUCT_SIZE(sai_attribute_value_t, 40);
+    CHECK_STRUCT_SIZE(sai_attribute_value_t, 48);
     CHECK_STRUCT_SIZE(sai_ip_addr_t, 16);
     CHECK_STRUCT_SIZE(sai_object_key_entry_t, 64);
     CHECK_STRUCT_SIZE(sai_tlv_entry_t, 36);
@@ -5492,14 +5492,14 @@ void check_struct_and_union_size()
     /* structs */
 
     CHECK_STRUCT_SIZE(sai_acl_action_data_t, 32);
-    CHECK_STRUCT_SIZE(sai_acl_capability_t, 36);
-    CHECK_STRUCT_SIZE(sai_acl_chain_list_t, 32);
+    CHECK_STRUCT_SIZE(sai_acl_capability_t, 48);
+    CHECK_STRUCT_SIZE(sai_acl_chain_list_t, 16);
     CHECK_STRUCT_SIZE(sai_acl_chain_t, 8);
     CHECK_STRUCT_SIZE(sai_acl_field_data_t, 40);
     CHECK_STRUCT_SIZE(sai_acl_resource_list_t, 16);
     CHECK_STRUCT_SIZE(sai_acl_resource_t, 12);
     CHECK_STRUCT_SIZE(sai_attr_capability_t, 3);
-    CHECK_STRUCT_SIZE(sai_attribute_t, 48);
+    CHECK_STRUCT_SIZE(sai_attribute_t, 56);
     CHECK_STRUCT_SIZE(sai_bfd_session_state_notification_t, 16);
     CHECK_STRUCT_SIZE(sai_fabric_port_reachability_t, 8);
     CHECK_STRUCT_SIZE(sai_fdb_entry_t, 24);

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -5439,6 +5439,127 @@ void check_global_apis()
     META_ASSERT_TRUE(sizeof(type) >= sizeof(int32_t), "apis type should be at least int32");
 }
 
+/* will check single struct size, as well as array alignment and packing */
+
+#define CHECK_STRUCT_SIZE(name,size) \
+    META_ASSERT_TRUE(sizeof(name) == (size), "wrong size of " #name ", expected %d, got %zu", (size), sizeof(name)); \
+    META_ASSERT_TRUE(sizeof(name[3]) == (3*(size)), "wrong size of " #name "[3], expected %d, got %zu", (3*size), sizeof(name[3]));
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=noreturn"
+void check_struct_and_union_size()
+{
+    META_LOG_ENTER();
+
+    /*
+     * At this point we want to be binary backward compatible, which means that
+     * each union and struct must have the same size (since structs and unions
+     * are used in arrays for example sai_attibute_t* when creating object).
+     *
+     * Also in structs we must check if order of members did not changed. This
+     * is done via external automated script.
+     *
+     * WARNING: !!! DO NOT CHANGE NUMERICAL VALUES !!!
+     *
+     * Since this is manual size check, then this list may need to be updated
+     * in the future when new unions or structures are added. Experimental
+     * headers are and should not be checked here since they can disappear.
+     * Also *_api_t structures should not be changed since they are subject to
+     * be expanded.
+     *
+     * Those struct sizes may change on non x86_64 architecture, for example
+     * armhf, which is 32 bit. Then please add ifdef statement here and provide
+     * corresponding values.
+     *
+     * NOTE: at some point, it may be required to modify some structures for
+     * some objects, and this should be permitted after consulting with SAI
+     * community, to allow binary compatibility break. When this happens, a
+     * specific comment should be added here why that struct change happened.
+     *
+     * TODO: We need to figure out to do this automatically.
+     */
+
+    /* unions */
+
+    CHECK_STRUCT_SIZE(sai_acl_action_parameter_t, 24);
+    CHECK_STRUCT_SIZE(sai_acl_field_data_data_t, 16);
+    CHECK_STRUCT_SIZE(sai_acl_field_data_mask_t, 16);
+    CHECK_STRUCT_SIZE(sai_attribute_value_t, 40);
+    CHECK_STRUCT_SIZE(sai_ip_addr_t, 16);
+    CHECK_STRUCT_SIZE(sai_object_key_entry_t, 64);
+    CHECK_STRUCT_SIZE(sai_tlv_entry_t, 36);
+
+    /* structs */
+
+    CHECK_STRUCT_SIZE(sai_acl_action_data_t, 32);
+    CHECK_STRUCT_SIZE(sai_acl_capability_t, 32);
+    CHECK_STRUCT_SIZE(sai_acl_field_data_t, 40);
+    CHECK_STRUCT_SIZE(sai_acl_resource_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_acl_resource_t, 12);
+    CHECK_STRUCT_SIZE(sai_attr_capability_t, 3);
+    CHECK_STRUCT_SIZE(sai_attribute_t, 48);
+    CHECK_STRUCT_SIZE(sai_bfd_session_state_notification_t, 16);
+    CHECK_STRUCT_SIZE(sai_fabric_port_reachability_t, 8);
+    CHECK_STRUCT_SIZE(sai_fdb_entry_t, 24);
+    CHECK_STRUCT_SIZE(sai_fdb_event_notification_data_t, 48);
+    CHECK_STRUCT_SIZE(sai_hmac_t, 36);
+    CHECK_STRUCT_SIZE(sai_inseg_entry_t, 16);
+    CHECK_STRUCT_SIZE(sai_ip_address_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_ip_address_t, 20);
+    CHECK_STRUCT_SIZE(sai_ipmc_entry_t, 64);
+    CHECK_STRUCT_SIZE(sai_ip_prefix_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_ip_prefix_t, 36);
+    CHECK_STRUCT_SIZE(sai_ipsec_sa_status_notification_t, 16);
+    CHECK_STRUCT_SIZE(sai_json_t, 16);
+    CHECK_STRUCT_SIZE(sai_l2mc_entry_t, 64);
+    CHECK_STRUCT_SIZE(sai_latch_status_t, 2);
+    CHECK_STRUCT_SIZE(sai_map_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_map_t, 8);
+    CHECK_STRUCT_SIZE(sai_mcast_fdb_entry_t, 24);
+    CHECK_STRUCT_SIZE(sai_my_sid_entry_t, 40);
+    CHECK_STRUCT_SIZE(sai_nat_entry_data_t, 32);
+    CHECK_STRUCT_SIZE(sai_nat_entry_key_t, 16);
+    CHECK_STRUCT_SIZE(sai_nat_entry_mask_t, 16);
+    CHECK_STRUCT_SIZE(sai_nat_entry_t, 56);
+    CHECK_STRUCT_SIZE(sai_nat_event_notification_data_t, 64);
+    CHECK_STRUCT_SIZE(sai_neighbor_entry_t, 40);
+    CHECK_STRUCT_SIZE(sai_object_key_t, 64);
+    CHECK_STRUCT_SIZE(sai_object_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_port_err_status_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_port_eye_values_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_port_lane_eye_values_t, 20);
+    CHECK_STRUCT_SIZE(sai_port_lane_latch_status_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_port_lane_latch_status_t, 8);
+    CHECK_STRUCT_SIZE(sai_port_oper_status_notification_t, 16);
+    CHECK_STRUCT_SIZE(sai_prbs_rx_state_t, 8);
+    CHECK_STRUCT_SIZE(sai_qos_map_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_qos_map_params_t, 16);
+    CHECK_STRUCT_SIZE(sai_qos_map_t, 32);
+    CHECK_STRUCT_SIZE(sai_queue_deadlock_notification_data_t, 16);
+    CHECK_STRUCT_SIZE(sai_route_entry_t, 56);
+    CHECK_STRUCT_SIZE(sai_s16_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_s32_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_s32_range_t, 8);
+    CHECK_STRUCT_SIZE(sai_s8_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_segment_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_service_method_table_t, 16);
+    CHECK_STRUCT_SIZE(sai_stat_capability_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_stat_capability_t, 8);
+    CHECK_STRUCT_SIZE(sai_system_port_config_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_system_port_config_t, 24);
+    CHECK_STRUCT_SIZE(sai_timespec_t, 16);
+    CHECK_STRUCT_SIZE(sai_tlv_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_tlv_t, 40);
+    CHECK_STRUCT_SIZE(sai_u16_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_u16_range_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_u16_range_t, 4);
+    CHECK_STRUCT_SIZE(sai_u32_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_u32_range_t, 8);
+    CHECK_STRUCT_SIZE(sai_u8_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_vlan_list_t, 16);
+}
+#pragma GCC diagnostic pop
+
 int main(int argc, char **argv)
 {
     debug = (argc > 1);
@@ -5483,6 +5604,7 @@ int main(int argc, char **argv)
     check_max_conditions_len();
     check_object_type_extension_max_value();
     check_global_apis();
+    check_struct_and_union_size();
 
     SAI_META_LOG_DEBUG("log test");
 

--- a/meta/structs.pl
+++ b/meta/structs.pl
@@ -1,0 +1,218 @@
+#!/usr/bin/perl
+#
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+#
+# @file    structs.pl
+#
+# @brief   This module defines structs backward compatibility check for SAI headers
+#
+
+BEGIN { push @INC,'.'; }
+
+use strict;
+use warnings;
+use diagnostics;
+use sort 'stable'; # for sort
+
+use Getopt::Std;
+use Data::Dumper;
+use utils;
+
+my %options = ();
+
+getopts("dsASl", \%options);
+
+our $optionPrintDebug        = 1 if defined $options{d};
+our $optionDisableAspell     = 1 if defined $options{A};
+our $optionUseXmlSimple      = 1 if defined $options{s};
+our $optionDisableStyleCheck = 1 if defined $options{S};
+our $optionShowLogCaller     = 1 if defined $options{l};
+
+$SIG{__DIE__} = sub
+{
+    LogError "FATAL ERROR === MUST FIX === : @_";
+    exit 1;
+};
+
+our $INCLUDE_DIR = "temp";
+our %SAI_STRUCTS = ();
+our %HISTORY = ();
+
+# TODO: union should be treated as hash map, since order don't matter
+
+sub ProcessSingleHeader
+{
+    my $header = shift;
+
+    my $data = ReadHeaderFile $header;
+
+    my @lines = split/\n/,$data;
+
+    my $currentStruct = "undefined";
+
+    for my $line (@lines)
+    {
+        if ($line =~ /^\s*typedef\s+(struct|union)\s+_((sai_\w+_)t)/)
+        {
+            $currentStruct = $2;
+
+            my @fields = ();
+
+            $SAI_STRUCTS{$currentStruct}->{fields} = \@fields;
+            $SAI_STRUCTS{$currentStruct}->{type} = $1;
+
+            LogDebug "found $1 $currentStruct";
+            next;
+        }
+
+        $currentStruct = "undefined" if $line =~ /}\s*$currentStruct/;
+
+        next if $currentStruct eq "undefined";
+
+        next if $line =~ /^{?$/;        # skip struct open bracket and empty lines
+        next if $line =~ m!^\s*/?\*!;   # skip comment
+
+        if ($line =~ /^\s*((\w+)\s+\*?(\w+)(\[\d+\])?);/)
+        {
+            my $field = $1;
+
+            $field =~ s/\s+/ /g;
+
+            # NOTE: field type is as string here, is of actual type is complex,
+            # like for example function pointer and parameters of that function
+            # will change, then this check will not catch that, we will need
+            # then a much more complex type checking, it could be added
+
+            push @{ $SAI_STRUCTS{$currentStruct}->{fields} }, $field;
+        }
+        else
+        {
+            LogError "unknown struct/union line '$line', FIXME";
+        }
+    }
+}
+
+sub ProcessHeaders
+{
+    my $commit = shift;
+
+    my @headers = GetHeaderFiles("temp/commit-$commit/inc");
+
+    for my $header (@headers)
+    {
+        LogDebug "Processing $header";
+
+        ProcessSingleHeader "temp/commit-$commit/inc/$header";
+    }
+}
+
+sub BuildCommitHistory
+{
+    my $commit = shift;
+
+    for my $structTypeName (sort keys %SAI_STRUCTS)
+    {
+        LogDebug $structTypeName;
+
+        my $arr_ref = $SAI_STRUCTS{$structTypeName}->{fields};
+        my $type = $SAI_STRUCTS{$structTypeName}->{type};
+
+        if (not defined $HISTORY{$structTypeName})
+        {
+            $HISTORY{$structTypeName}{values} = $arr_ref;
+            next;
+        }
+
+        LogDebug "compare $structTypeName on $commit";
+
+        my $hist_arr_ref = $HISTORY{$structTypeName}{values};
+
+        my $currCount = scalar @$arr_ref;
+        my $histCount = scalar @$hist_arr_ref;
+
+        LogDebug "histCount $histCount vs currCount $currCount on $structTypeName";
+
+        # NOTE: we allow api structs to change member count since we can add new api
+        # at the end of the struct.
+        #
+        # NOTE: we also allow to change number of members in union, since size
+        # of union may not increase by adding members, and actual union size
+        # check is performed by sai sanity check
+
+        if ($currCount != $histCount and not $structTypeName =~ /^sai_\w+_api_t$/)
+        {
+            LogError "FATAL: struct $structTypeName member count differs, was $histCount but is $currCount on commit $commit" if $type eq "struct";
+        }
+
+        if ($histCount > $currCount)
+        {
+            LogError "FATAL: $structTypeName members were removed on commit $commit, NOT ALLOWED!";
+            exit 1;
+        }
+
+        my $minCount = ($histCount > $currCount) ? $currCount : $histCount;
+
+        for (my $idx = 0; $idx < $minCount; $idx++)
+        {
+            my $hist_field = $hist_arr_ref->[$idx];
+            my $field = $arr_ref->[$idx];
+
+            next if $hist_field eq $field;
+
+            LogError "FATAL: field on index $idx do not match, was '$hist_field' and now is '$field' on $commit";
+        }
+
+        if ($histCount != $currCount)
+        {
+            LogInfo "updating $structTypeName since member count changed from $histCount to $currCount";
+
+            $HISTORY{$structTypeName}{values} = $arr_ref;
+        }
+
+        # NOTE: we could allow some other structs than *_api_t to also be
+        # extended in th future (added fields at the end), for example simple
+        # structures that are used as attribute value, and not lists
+    }
+}
+
+sub CleanData
+{
+    %SAI_STRUCTS = ();
+}
+
+#
+# MAIN
+#
+
+for my $commit (@ARGV)
+{
+    # reset
+
+    LogInfo "processing commit $commit";
+
+    CleanData();
+
+    ProcessHeaders $commit;
+
+    #print Dumper \%SAI_STRUCTS;
+
+    BuildCommitHistory $commit;
+}
+
+ExitOnErrorsOrWarnings();

--- a/meta/style.pm
+++ b/meta/style.pm
@@ -503,6 +503,55 @@ sub CheckQuadApi
 
     my @fns = $apis =~ /sai_(\w+)_fn/g;
 
+    # this function forces order of existing and new added apis in api struct
+
+    my $order = "";
+
+    for my $function (@fns)
+    {
+        my $f = $function;
+
+        $f =~ s/remove_all_neighbor_entries/X/;
+        $f =~ s/clear_port_all_stats/X/;
+
+        $f =~ s/^create_\w+/c/;
+        $f =~ s/^remove_\w+/r/;
+        $f =~ s/^set_\w+_attribute/s/;
+        $f =~ s/^get_\w+_attribute/g/;
+
+        $f =~ s/^get_\w+_stats$/0/;
+        $f =~ s/^get_\w+_stats_ext/1/;
+        $f =~ s/^clear_\w+_stats/2/;
+
+        $f =~ s/^bulk_object_create/C/;
+        $f =~ s/^bulk_object_remove/R/;
+        $f =~ s/^bulk_object_set_attribute/S/;
+        $f =~ s/^bulk_object_get_attribute/G/;
+
+        $f =~ s/^bulk_create_\w+/C/;
+        $f =~ s/^bulk_remove_\w+/R/;
+        $f =~ s/^bulk_set_\w+_attribute/S/;
+        $f =~ s/^bulk_get_\w+_attribute/G/;
+
+        $f = "X" if length $f != 1;
+
+        $order .= $f;
+    }
+
+    $order =~ s/crsg012/t/g;    # order should be: create,remove,set,get,get_stats,get_stats_ext,clear_stats
+    $order =~ s/crsg/q/g;       # order should be: create,remove,set,get
+    $order =~ s/CRSG/Q/g;       # order should be: bulk_create,bulk_remove,bulk_set,bulk_get
+    $order =~ s/012/s/g;        # order should be: get_stats,get_stats_ext,clear_stats
+    $order =~ s/CR/E/g;         # order should be: bulk_create,bulk_remove
+    $order =~ s/SG/T/g;         # order should be: bulk_set,bulk_get
+    $order =~ s/X+/X/g;         # order should be: any non quad and non stats api
+
+    if (not $order =~ /^[tqQsETX]*$/)
+    {
+        LogWarning "Wrong api order: $order";
+        LogWarning "$apis";
+    }
+
     my $fn = join" ",@fns;
 
     my @quad = split/\bcreate_/,$fn;
@@ -1220,7 +1269,7 @@ BEGIN
 {
     our @ISA    = qw(Exporter);
     our @EXPORT = qw/
-    CheckHeadersStyle
+    CheckHeadersStyle GetAcronyms
     /;
 }
 


### PR DESCRIPTION
This change will force future PRs to be binary backward compatible with structs and unions. This was added to keep all code binary backward compatible if for example, existing code will be using struct array for some sai type, and then only binary sai library will be updated. This change will make sure that no binary break will be possible.

Added restrictions:
* type of each field and name in union and struct is checked on each index and must match
* new members can be added only at the end of union (size of union must stay fixed)
* no existing members can be removed from structs or unions
* new members can be added at the end of any _api_t struct
* non _api_t struct cannot be modified
* alignment of the existing non _api_t structures and union is validated
* api pattern in api struct must follow rules: create/remove/set/get

Extension headers are ignored in this check.

There maybe some exceptions added in the future for some non essential structures, which would break backward compatibility. 