### PR TITLE
Fix serialize/deseralize functions in SAI meta

### DIFF
--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -2056,6 +2056,8 @@ sub ProcessIsAclField
 
     return "true" if $attr =~ /^SAI_ACL_ENTRY_ATTR_(USER_DEFINED_)?FIELD_\w+$/;
 
+    return "true" if $attr =~ /^SAI_UDF_MATCH_ATTR_\w+_TYPE$/;
+
     return "false";
 }
 

--- a/meta/saimetadatautils.c
+++ b/meta/saimetadatautils.c
@@ -150,6 +150,75 @@ const sai_attr_metadata_t* sai_metadata_get_attr_metadata_by_attr_id_name(
     return NULL;
 }
 
+static int sai_metadata_attr_id_name_cmp(
+        _In_ const char * str1,
+        _In_ const char * str2)
+{
+    char c1 = 0;
+    char c2 = 0;
+
+    while (true)
+    {
+        c1 = *str1++;
+        c2 = *str2++;
+
+        if (sai_serialize_is_char_allowed(c1) || sai_serialize_is_char_allowed(c2) || c1 != c2)
+        {
+            if (sai_serialize_is_char_allowed(c1))
+            {
+                c1 = 0;
+            }
+
+            if (sai_serialize_is_char_allowed(c2))
+            {
+                c2 = 0;
+            }
+
+            return c1 - c2;
+        }
+    }
+}
+
+const sai_attr_metadata_t* sai_metadata_get_attr_metadata_by_attr_id_name_ext(
+        _In_ const char *attr_id_name)
+{
+    if (attr_id_name == NULL)
+    {
+        return NULL;
+    }
+
+    /* use binary search */
+
+    ssize_t first = 0;
+    ssize_t last = (ssize_t)(sai_metadata_attr_sorted_by_id_name_count - 1);
+
+    while (first <= last)
+    {
+        ssize_t middle = (first + last) / 2;
+
+        int res = sai_metadata_attr_id_name_cmp(attr_id_name, sai_metadata_attr_sorted_by_id_name[middle]->attridname);
+
+        if (res > 0)
+        {
+            first = middle + 1;
+        }
+        else if (res < 0)
+        {
+            last = middle - 1;
+        }
+        else
+        {
+            /* found */
+
+            return sai_metadata_attr_sorted_by_id_name[middle];
+        }
+    }
+
+    /* not found */
+
+    return NULL;
+}
+
 const sai_attr_metadata_t* sai_metadata_get_ignored_attr_metadata_by_attr_id_name(
         _In_ const char *attr_id_name)
 {

--- a/meta/saimetadatautils.h
+++ b/meta/saimetadatautils.h
@@ -80,6 +80,18 @@ extern const sai_attr_metadata_t* sai_metadata_get_attr_metadata_by_attr_id_name
         _In_ const char *attr_id_name);
 
 /**
+ * @brief Gets attribute metadata based on attribute id name, supporting case of
+ * attribute id name is in deserialized buffer and terminated by characters listed
+ * in function sai_serialize_is_char_allowed.
+ *
+ * @param[in] attr_id_name Attribute id name
+ *
+ * @return Pointer to object metadata or NULL in case of failure
+ */
+extern const sai_attr_metadata_t* sai_metadata_get_attr_metadata_by_attr_id_name_ext(
+        _In_ const char *attr_id_name);
+
+/**
  * @brief Gets ignored attribute metadata based on attribute id name
  *
  * @param[in] attr_id_name Attribute id name

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -449,6 +449,19 @@ bool sai_metadata_is_acl_field_or_action(
         }
     }
 
+    if (metadata->objecttype == SAI_OBJECT_TYPE_UDF_MATCH)
+    {
+        if (metadata->attrid <= SAI_UDF_MATCH_ATTR_GRE_TYPE)
+        {
+            return true;
+        }
+
+        if (metadata->attrid == SAI_UDF_MATCH_ATTR_L4_DST_PORT_TYPE)
+        {
+            return true;
+        }
+    }
+
     return false;
 }
 
@@ -2324,7 +2337,7 @@ void check_attr_acl_field_or_action(
         META_ASSERT_FALSE(md->defaultvalue->aclaction.enable, "enable should be false");
     }
 
-    if (md->objecttype != SAI_OBJECT_TYPE_ACL_ENTRY)
+    if (md->objecttype != SAI_OBJECT_TYPE_ACL_ENTRY && md->objecttype != SAI_OBJECT_TYPE_UDF_MATCH)
     {
         META_ASSERT_FALSE(md->isaclfield, "field should be not marked as acl field");
         META_ASSERT_FALSE(md->isaclaction, "field should be not marked as acl action");
@@ -2332,18 +2345,36 @@ void check_attr_acl_field_or_action(
         return;
     }
 
-    if (md->attrid >= SAI_ACL_ENTRY_ATTR_FIELD_START &&
-            md->attrid <= SAI_ACL_ENTRY_ATTR_FIELD_END)
+    if (md->objecttype == SAI_OBJECT_TYPE_ACL_ENTRY)
     {
-        META_ASSERT_TRUE(md->isaclfield, "field should be marked as acl field");
-        META_ASSERT_FALSE(md->isaclaction, "field should be not marked as acl action");
+        if (md->attrid >= SAI_ACL_ENTRY_ATTR_FIELD_START &&
+                md->attrid <= SAI_ACL_ENTRY_ATTR_FIELD_END)
+        {
+            META_ASSERT_TRUE(md->isaclfield, "field should be marked as acl field");
+            META_ASSERT_FALSE(md->isaclaction, "field should be not marked as acl action");
+        }
+
+        if (md->attrid >= SAI_ACL_ENTRY_ATTR_ACTION_START &&
+                md->attrid <= SAI_ACL_ENTRY_ATTR_ACTION_END)
+        {
+            META_ASSERT_FALSE(md->isaclfield, "field should not be marked as acl field");
+            META_ASSERT_TRUE(md->isaclaction, "field should be marked as acl action");
+        }
     }
 
-    if (md->attrid >= SAI_ACL_ENTRY_ATTR_ACTION_START &&
-            md->attrid <= SAI_ACL_ENTRY_ATTR_ACTION_END)
+    if (md->objecttype == SAI_OBJECT_TYPE_UDF_MATCH)
     {
-        META_ASSERT_FALSE(md->isaclfield, "field should not be marked as acl field");
-        META_ASSERT_TRUE(md->isaclaction, "field should be marked as acl action");
+        if (md->attrid <= SAI_UDF_MATCH_ATTR_GRE_TYPE)
+        {
+            META_ASSERT_TRUE(md->isaclfield, "field should be marked as acl field");
+            META_ASSERT_FALSE(md->isaclaction, "field should be not marked as acl action");
+        }
+
+        if (md->attrid == SAI_UDF_MATCH_ATTR_L4_DST_PORT_TYPE)
+        {
+            META_ASSERT_TRUE(md->isaclfield, "field should be marked as acl field");
+            META_ASSERT_FALSE(md->isaclaction, "field should be not marked as acl action");
+        }
     }
 }
 
@@ -3755,6 +3786,13 @@ void check_attr_sorted_by_id_name()
         META_ASSERT_NOT_NULL(found);
 
         META_ASSERT_TRUE(strcmp(found->attridname, am->attridname) == 0, "search attr by id name failed to find");
+
+        const sai_attr_metadata_t *found_ext = sai_metadata_get_attr_metadata_by_attr_id_name_ext(am->attridname);
+
+        META_ASSERT_NOT_NULL(found_ext);
+
+        META_ASSERT_TRUE(strcmp(found_ext->attridname, am->attridname) == 0, "search attr by id name ext failed to find");
+
     }
 
     META_ASSERT_NULL(sai_metadata_get_attr_metadata_by_attr_id_name(NULL));     /* null pointer */
@@ -3763,6 +3801,13 @@ void check_attr_sorted_by_id_name()
     META_ASSERT_NULL(sai_metadata_get_attr_metadata_by_attr_id_name("SAI_P"));  /* in the middle of attr names */
     META_ASSERT_NULL(sai_metadata_get_attr_metadata_by_attr_id_name("SAI_W"));  /* in the middle of attr names */
     META_ASSERT_NULL(sai_metadata_get_attr_metadata_by_attr_id_name("ZZZ"));    /* after all attr names */
+
+    META_ASSERT_NULL(sai_metadata_get_attr_metadata_by_attr_id_name_ext(NULL));     /* null pointer */
+    META_ASSERT_NULL(sai_metadata_get_attr_metadata_by_attr_id_name_ext("AAA"));    /* before all attr names */
+    META_ASSERT_NULL(sai_metadata_get_attr_metadata_by_attr_id_name_ext("SAI_B"));  /* in the middle of attr names */
+    META_ASSERT_NULL(sai_metadata_get_attr_metadata_by_attr_id_name_ext("SAI_P"));  /* in the middle of attr names */
+    META_ASSERT_NULL(sai_metadata_get_attr_metadata_by_attr_id_name_ext("SAI_W"));  /* in the middle of attr names */
+    META_ASSERT_NULL(sai_metadata_get_attr_metadata_by_attr_id_name_ext("ZZZ"));    /* after all attr names */
 }
 
 void list_loop(

--- a/meta/serialize.pm
+++ b/meta/serialize.pm
@@ -488,6 +488,7 @@ sub EmitSerializeFooter
         WriteSource "{";
         WriteSource "SAI_META_LOG_WARN(\"nothing was serialized for '$name', bad condition?\");";
         # WriteSource "return SAI_SERIALIZE_ERROR;";
+        WriteSource "return SAI_SERIALIZE_ERROR;" if $name eq "sai_attribute_value_t";
         WriteSource "}\n";
     }
 
@@ -1093,6 +1094,7 @@ sub EmitDeserializeFooter
         WriteSource "{";
         WriteSource "SAI_META_LOG_WARN(\"nothing was deserialized for '$name', bad condition?\");";
         # WriteSource "return SAI_SERIALIZE_ERROR;";
+        WriteSource "return SAI_SERIALIZE_ERROR;" if $name eq "sai_attribute_value_t";
         WriteSource "}\n";
     }
 


### PR DESCRIPTION
This PR is fixing several issues we saw in serialize/deserialize:

1 Fix several not implemented deserialize functions.
    sai_deserialize_enum_list()
    sai_deserialize_attr_id()
    sai_deserialize_attribute()
By doing this, the serialize/deserialize functions are complete.

2 Mark several attributes as aclfiled for SAI_OBJECT_TYPE_UDF_MATCH. The corresponding attribute values are in type of sai_acl_field_data_t.
    SAI_UDF_MATCH_ATTR_L2_TYPE ~ SAI_UDF_MATCH_ATTR_GRE_TYPE
    SAI_UDF_MATCH_ATTR_L4_DST_PORT_TYPE
By doing this, serialize/deserialize for the above attributes works as expected. 

3 Add sai_metadata_get_attr_metadata_by_attr_id_name_ext which can support the case of attribute id name is in deserialized buffer and terminated by characters listed in function sai_serialize_is_char_allowed().
By doing this, sai_deserialize_attr_id() and sai_deserialize_attribute() can get the attribute metadata by the deserialized buffer.

4 Return SAI_SERIALIZE_ERROR in case of the data type is not find for the attribute value.
By doing this, the user can know that serialize/deserialize is failed and do proper response.

Thanks!
  