### PR TITLE
update test/saithriftv2/Makefile

### DIFF
--- a/test/saithriftv2/Makefile
+++ b/test/saithriftv2/Makefile
@@ -104,7 +104,8 @@ clientlib: $(PY_SOURCES) $(SAI_PY_HEADERS)
 
 saiserver: $(ODIR)/saiserver.o $(ODIR)/librpcserver.a
 	$(CXX) $(LDFLAGS) $(ODIR)/sai_rpc_server.o $(ODIR)/saiserver.o -o $@ \
-		   $(ODIR)/librpcserver.a $(LIBS) $(SAIRPC_EXTRA_LIBS)
+		   $(ODIR)/librpcserver.a ../../meta/saimetadata.o \
+		   ../../meta/saimetadatautils.o $(LIBS) $(SAIRPC_EXTRA_LIBS)
 
 install-lib: $(ODIR)/librpcserver.a
 	$(INSTALL) -D $(ODIR)/librpcserver.a $(DESTDIR)/usr/lib/librpcserver.a


### PR DESCRIPTION
closes #1788

SAI RPC Thrift server (sathriftv2) builds successfully with the following commands:

export SAITHRIFTV2=y
make saithrift-build
make saithrift-install