### PR TITLE
[meta] Skip git repo based checks if dir is not git repo

### DIFF
--- a/meta/checkancestry.sh
+++ b/meta/checkancestry.sh
@@ -55,6 +55,12 @@
 
 set -e
 
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+
+    echo "WARNING: this is not git repository, will skip ancestry check"
+    exit
+fi
+
 # 1. get all necessary data to temp directory for future processing
 # 2. pass all interesting commits to processor to build history
 

--- a/meta/checkenumlock.sh
+++ b/meta/checkenumlock.sh
@@ -25,6 +25,12 @@
 
 set -e
 
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+
+    echo "WARNING: this is not git repository, will skip check enum lock"
+    exit
+fi
+
 rm -rf temp
 
 sairepo=`git remote get-url origin`

--- a/meta/checkstructs.sh
+++ b/meta/checkstructs.sh
@@ -55,6 +55,12 @@
 
 set -e
 
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+
+    echo "WARNING: this is not git repository, will skip structs check"
+    exit
+fi
+
 # 1. get all necessary data to temp directory for future processing
 # 2. pass all interesting commits to processor to build history
 

--- a/meta/size.sh
+++ b/meta/size.sh
@@ -25,6 +25,13 @@
 
 set -e
 
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+
+    echo "WARNING: this is not git repository, will skip generating saimetadatasize.h and skip struct size check"
+    touch saimetadatasize.h
+    exit
+fi
+
 TEMP_DIR="tmp"
 
 COMMIT=origin/master # should be corresponding branch HEAD


### PR DESCRIPTION
This will be handy for DASH repo, since SAI is submodule in DASH repo and when building headers is mounted in docker and it's not a proper git repo, just a directory