### PR TITLE
SAI attributes for path tracing for midpoint node .

### DIFF
--- a/doc/SAI-Proposal-SRv6-Path-Tracing.md
+++ b/doc/SAI-Proposal-SRv6-Path-Tracing.md
@@ -1,0 +1,17 @@
+# Overview #
+
+    Path tracing provides a record of the packet path as a sequence of interface ids. In addition, it provides a record of end-to-end delay, per-hop delay, and load on each egress interface along the packet delivery path.
+
+# Standards references #
+
+    [Path Tracing in SRv6 networks](https://datatracker.ietf.org/doc/draft-filsfils-spring-path-tracing/)
+
+# SAI attributes for configuring path tracing on midpoint node #
+
+    When midpoint node that is path tracing enabled receives an IPv6 packet that contains an IPv6 HbH-PT option, records it's path tracing information into the HbH-PT header. This information is known as Midpoint Compressed Data (MCD).
+
+    MCD.OIF (Outgoing Interface ID): An 8-bit or 12-bit interface ID associated with the egress physical interface of the router SAI_PORT_ATTR_PATH_TRACING_INTF is proposed to represent the output interface id.
+
+    MCD.TTS (Truncated Timestamp): An 8-bit timestamp encoding the time at which the packet egress the router. Each egress interface in the device is configured with a TTS template. The TTS template defines the position of 8-bits to be selected from the egress timestamp. SAI_PORT_ATTR_PATH_TRACING_TIMESTAMP_TEMPLATE is proposed to represent the timestamp template. sai_port_pt_timestamp_template_type is proposed to define the possible template values.
+
+

--- a/doc/SAI-Proposal-SRv6-Path-Tracing.md
+++ b/doc/SAI-Proposal-SRv6-Path-Tracing.md
@@ -7,8 +7,9 @@
     [Path Tracing in SRv6 networks](https://datatracker.ietf.org/doc/draft-filsfils-spring-path-tracing/)
 
 # SAI attributes for configuring path tracing on midpoint node #
+    To enable path tracing on a node, a TAM object with type SAI_TAM_INT_TYPE_PATH_TRACING is created and is associated on every port on which path tracing is enabled using SAI_PORT_ATTR_TAM_OBJECT.
 
-    When midpoint node that is path tracing enabled receives an IPv6 packet that contains an IPv6 HbH-PT option, records it's path tracing information into the HbH-PT header. This information is known as Midpoint Compressed Data (MCD).
+    When midpoint node on which path tracing enabled, receives an IPv6 packet that contains an IPv6 HbH-PT option, it records it's path tracing information into the HbH-PT header. This information is known as Midpoint Compressed Data (MCD).
 
     MCD.OIF (Outgoing Interface ID): An 8-bit or 12-bit interface ID associated with the egress physical interface of the router SAI_PORT_ATTR_PATH_TRACING_INTF is proposed to represent the output interface id.
 

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -2336,10 +2336,7 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_HOST_TX_READY_STATUS,
 
     /**
-     * @brief Configure 12b path tracing interface id
-     *
-     * Set interface id = 0 to disable path tracing on port.
-     * Valid values for interface id are 0 - 4095.
+     * @brief Configure path tracing interface id
      *
      * @type sai_uint16_t
      * @flags CREATE_AND_SET
@@ -2353,7 +2350,7 @@ typedef enum _sai_port_attr_t
      *
      * @type sai_port_path_tracing_timestamp_type_t
      * @flags CREATE_AND_SET
-     * @default SAI_PORT_PATH_TRACING_TIMESTAMP_TYPE_8_15
+     * @default SAI_PORT_PATH_TRACING_TIMESTAMP_TYPE_16_23
      */
     SAI_PORT_ATTR_PATH_TRACING_TIMESTAMP_TYPE,
 

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -502,6 +502,25 @@ typedef enum _sai_port_host_tx_ready_status_t
 } sai_port_host_tx_ready_status_t;
 
 /**
+ * @brief Attribute data for #SAI_PORT_ATTR_PATH_TRACING_TIMESTAMP_TYPE
+ */
+typedef enum _sai_port_path_tracing_timestamp_type_t
+{
+    /** Timestamp nanosecond bits [8:15] */
+    SAI_PORT_PATH_TRACING_TIMESTAMP_TYPE_8_15,
+
+    /** Timestamp nanosecond bits [12:19] */
+    SAI_PORT_PATH_TRACING_TIMESTAMP_TYPE_12_19,
+
+    /** Timestamp nanosecond bits [16:23] */
+    SAI_PORT_PATH_TRACING_TIMESTAMP_TYPE_16_23,
+
+    /** Timestamp nanosecond bits [20:27] */
+    SAI_PORT_PATH_TRACING_TIMESTAMP_TYPE_20_27,
+
+} sai_port_path_tracing_timestamp_type_t;
+
+/**
  * @brief Attribute Id in sai_set_port_attribute() and
  * sai_get_port_attribute() calls
  */
@@ -2315,6 +2334,28 @@ typedef enum _sai_port_attr_t
      * @flags READ_ONLY
      */
     SAI_PORT_ATTR_HOST_TX_READY_STATUS,
+
+    /**
+     * @brief Configure 12b path tracing interface id
+     *
+     * Set interface id = 0 to disable path tracing on port.
+     * Valid values for interface id are 0 - 4095.
+     *
+     * @type sai_uint16_t
+     * @flags CREATE_AND_SET
+     * @isvlan false
+     * @default 0
+     */
+    SAI_PORT_ATTR_PATH_TRACING_INTF,
+
+    /**
+     * @brief Configure path tracing timestamp template
+     *
+     * @type sai_port_path_tracing_timestamp_type_t
+     * @flags CREATE_AND_SET
+     * @default SAI_PORT_PATH_TRACING_TIMESTAMP_TYPE_8_15
+     */
+    SAI_PORT_ATTR_PATH_TRACING_TIMESTAMP_TYPE,
 
     /**
      * @brief End of attributes

--- a/inc/saitam.h
+++ b/inc/saitam.h
@@ -480,7 +480,7 @@ typedef enum _sai_tam_int_type_t
      * @brief INT type Path Tracing
      */
     SAI_TAM_INT_TYPE_PATH_TRACING,
-    
+
 } sai_tam_int_type_t;
 
 /**

--- a/inc/saitam.h
+++ b/inc/saitam.h
@@ -476,6 +476,11 @@ typedef enum _sai_tam_int_type_t
      */
     SAI_TAM_INT_TYPE_IFA1_TAILSTAMP,
 
+    /**
+     * @brief INT type Path Tracing
+     */
+    SAI_TAM_INT_TYPE_PATH_TRACING,
+    
 } sai_tam_int_type_t;
 
 /**


### PR DESCRIPTION
Path tracing provides a record of the packet path as a sequence of interface ids. In addition, it provides a record of end-to-end delay, per-hop delay, and load on each egress interface along the packet delivery path.

Following draft describes path tracing in detail.
https://datatracker.ietf.org/doc/draft-filsfils-spring-path-tracing

This change adds SAI attributes to configure path tracing on mid point node.
