### PR TITLE
Support for reading RX_FREQUENCY_OFFSET_PPM, RX_SNR and FEC_CORRECTED_BITS with SAI

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -2355,6 +2355,22 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_PATH_TRACING_TIMESTAMP_TYPE,
 
     /**
+     * @brief List of per lane RX Frequency PPM for a port
+     *
+     * @type sai_port_frequency_offset_ppm_list_t
+     * @flags READ_ONLY
+     */
+    SAI_PORT_ATTR_RX_FREQUENCY_OFFSET_PPM,
+
+    /**
+     * @brief List of per lane RX SNR for a port
+     *
+     * @type sai_port_snr_list_t
+     * @flags READ_ONLY
+     */
+    SAI_PORT_ATTR_RX_SNR,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_ATTR_END,
@@ -3022,6 +3038,9 @@ typedef enum _sai_port_stat_t
 
     /** Count of FEC codewords with 16 symbol errors. */
     SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S16,
+
+    /** Count of total bits corrected by FEC. Counter will increment monotonically. */
+    SAI_PORT_STAT_IF_IN_FEC_CORRECTED_BITS,
 
     /** Port stat in drop reasons range start */
     SAI_PORT_STAT_IN_DROP_REASON_RANGE_BASE = 0x00001000,

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1148,6 +1148,45 @@ typedef struct _sai_port_eye_values_list_t
 } sai_port_eye_values_list_t;
 
 /**
+ * @brief Defines a lane with its frequency offset ppm
+ */
+typedef struct _sai_port_frequency_offset_ppm_values_t
+{
+    uint32_t lane;
+    sai_int16_t ppm;
+} sai_port_frequency_offset_ppm_values_t;
+
+/**
+ * @brief Defines a port's lanes frequency offset ppm list
+ */
+typedef struct _sai_port_frequency_offset_ppm_list_t
+{
+    uint32_t count;
+    sai_port_frequency_offset_ppm_values_t *list;
+} sai_port_frequency_offset_ppm_list_t;
+
+/**
+ * @brief Defines a lane with its SNR
+ *
+ * Each SNR value is encoded as U16 in units of 1/256 dB.
+ * For example, a value of 5248 represents a SNR of 20.5 dB
+ */
+typedef struct _sai_port_snr_values_t
+{
+    uint32_t lane;
+    sai_uint16_t snr;
+} sai_port_snr_values_t;
+
+/**
+ * @brief Defines a port's lanes SNR list
+ */
+typedef struct _sai_port_snr_list_t
+{
+    uint32_t count;
+    sai_port_snr_values_t *list;
+} sai_port_snr_list_t;
+
+/**
  * @brief Enum defining MPLS out segment type
  */
 typedef enum _sai_outseg_type_t
@@ -1473,6 +1512,12 @@ typedef union _sai_attribute_value_t
 
     /** @validonly meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_ACL_CHAIN_LIST */
     sai_acl_chain_list_t aclchainlist;
+
+    /** @validonly meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_PORT_FREQUENCY_OFFSET_PPM_LIST */
+    sai_port_frequency_offset_ppm_list_t portfrequencyoffsetppmlist;
+
+    /** @validonly meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST */
+    sai_port_snr_list_t portsnrlist;
 } sai_attribute_value_t;
 
 /**

--- a/meta/saimetadatatypes.h
+++ b/meta/saimetadatatypes.h
@@ -475,6 +475,16 @@ typedef enum _sai_attr_value_type_t
      * @brief Attribute value is IP prefix list.
      */
     SAI_ATTR_VALUE_TYPE_ACL_CHAIN_LIST,
+
+    /**
+     * @brief Attribute value is frequency offset ppm list.
+     */
+    SAI_ATTR_VALUE_TYPE_PORT_FREQUENCY_OFFSET_PPM_LIST,
+
+    /**
+     * @brief Attribute value is SNR list.
+     */
+    SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST,
 } sai_attr_value_type_t;
 
 /**

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -679,6 +679,8 @@ void check_attr_object_type_provided(
         case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
         case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_FREQUENCY_OFFSET_PPM_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
         case SAI_ATTR_VALUE_TYPE_LATCH_STATUS:
         case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
         case SAI_ATTR_VALUE_TYPE_TIMESPEC:
@@ -982,6 +984,8 @@ void check_attr_default_required(
         case SAI_ATTR_VALUE_TYPE_MAP_LIST:
         case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_FREQUENCY_OFFSET_PPM_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
         case SAI_ATTR_VALUE_TYPE_SYSTEM_PORT_CONFIG_LIST:
         case SAI_ATTR_VALUE_TYPE_IP_PREFIX_LIST:
@@ -1192,6 +1196,8 @@ void check_attr_default_value_type(
                 case SAI_ATTR_VALUE_TYPE_MAP_LIST:
                 case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST:
                 case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
+                case SAI_ATTR_VALUE_TYPE_PORT_FREQUENCY_OFFSET_PPM_LIST:
+                case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
                 case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
                 case SAI_ATTR_VALUE_TYPE_SYSTEM_PORT_CONFIG_LIST:
                 case SAI_ATTR_VALUE_TYPE_IP_PREFIX_LIST:
@@ -1795,6 +1801,8 @@ void check_attr_allow_flags(
             case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
             case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST:
             case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
+            case SAI_ATTR_VALUE_TYPE_PORT_FREQUENCY_OFFSET_PPM_LIST:
+            case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
             case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
             case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
             case SAI_ATTR_VALUE_TYPE_SYSTEM_PORT_CONFIG_LIST:
@@ -2662,6 +2670,8 @@ void check_attr_is_primitive(
         case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
         case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_FREQUENCY_OFFSET_PPM_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
         case SAI_ATTR_VALUE_TYPE_SYSTEM_PORT_CONFIG_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_ERR_STATUS_LIST:
         case SAI_ATTR_VALUE_TYPE_UINT16_RANGE_LIST:
@@ -5582,6 +5592,10 @@ void check_struct_and_union_size()
     CHECK_STRUCT_SIZE(sai_port_lane_eye_values_t, 20);
     CHECK_STRUCT_SIZE(sai_port_lane_latch_status_list_t, 16);
     CHECK_STRUCT_SIZE(sai_port_lane_latch_status_t, 8);
+    CHECK_STRUCT_SIZE(sai_port_frequency_offset_ppm_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_port_frequency_offset_ppm_values_t, 8);
+    CHECK_STRUCT_SIZE(sai_port_snr_list_t, 16);
+    CHECK_STRUCT_SIZE(sai_port_snr_values_t, 8);
     CHECK_STRUCT_SIZE(sai_port_oper_status_notification_t, 16);
     CHECK_STRUCT_SIZE(sai_prbs_rx_state_t, 8);
     CHECK_STRUCT_SIZE(sai_qos_map_list_t, 16);


### PR DESCRIPTION
This change includes support for reading the following PHY layer diagnostics in SAI -

1. RX_FREQUENCY_OFFSET_PPM - Per lane frequency offset observed at the receiver serdes

2. RX_SNR - Per lane Signal to Noise ratio observed at the receiver serdes Note that the units chosen (value reported as a U16 in units of 1/256dB) to represent this value in SAI is similar to how transceiver management standards like SFF-8636 and CMIS represent them.

3. TOTAL FEC CORRECTED BITS - Represents the total bits corrected by the FEC (Forward Error Correction) as a monotonically incrementing counter. Note that SAI today has support for reading FEC Corrected codewords and symbols, but not the total corrected bits. The corrected bits counter will help in providing an accurate representation of the bit error rate on a link.

These are some useful diagnostics for debugging a link down or a link flap issue.

