### PR TITLE
DCO Error fixing PR

### DIFF
--- a/inc/saibridge.h
+++ b/inc/saibridge.h
@@ -98,6 +98,9 @@ typedef enum _sai_bridge_port_tagging_mode_t
     /** Tagged mode */
     SAI_BRIDGE_PORT_TAGGING_MODE_TAGGED,
 
+    /** Hybrid mode */
+    SAI_BRIDGE_PORT_TAGGING_MODE_HYBRID,
+
 } sai_bridge_port_tagging_mode_t;
 
 /**


### PR DESCRIPTION
Currently, there are two tagging modes for a bridge port (untagged, tagged). A Hybrid Switchport Mode allows both untagged or tagged traffic which needs this hybrid bridge port tagging attribute.

This is in support of  [Hybrid Switchport Mode](https://github.com/sonic-net/SONiC/issues/1136) SONiC

Signed-off-by: Rida Hanif <ridahanif958@gmail.com>
