### PR TITLE
[meta] Ignore rpc auto generated files in aspell

### DIFF
--- a/meta/aspellcheck.pl
+++ b/meta/aspellcheck.pl
@@ -170,6 +170,8 @@ for my $file (@files)
     next if $file =~ m!temp!;
     next if $file =~ m!xml!;
     next if $file =~ m!saimetadata.[ch]!;
+    next if $file =~ m!generated!;
+    next if $file =~ m!sai_rpc_server.cpp!;
 
     my $data = ReadFile $file;
 


### PR DESCRIPTION
When rpc server is build, some files are auto generated and aspell check is attempting to scan them, and fails when you make build again