### PR TITLE
[meta] Optimize rpc target to not build every time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 meta/xml
 meta/html
 meta/temp
+meta/generated
 
 meta/*.o
 meta/*.lo
@@ -18,6 +19,9 @@ meta/saisanitycheck
 meta/saiserializetest
 meta/saiswig.i
 meta/saimetadatasize.h
+meta/sai.thrift
+meta/sai_adapter.py
+meta/sai_rpc_server.cpp
 
 # temporary files
 **/*~
@@ -40,4 +44,5 @@ test/saithrift/saiserver
 test/saithrift/src/gen-cpp/
 test/saithrift/src/gen-py/
 test/saithrift/src/obj/
+test/saithriftv2/gen-cpp/
 **/*.pyc

--- a/meta/Makefile
+++ b/meta/Makefile
@@ -125,8 +125,10 @@ saimetadatasize.h: $(DEPS)
 saimetadatatest.c saimetadata.c saimetadata.h: xml $(XMLDEPS) parse.pl $(CONSTHEADERS) $(EXTRA)
 	perl -I. parse.pl
 
-rpc sai.thrift sai_rpc_server.cpp sai_adapter.py: xml $(XMLDEPS) gensairpc.pl
+sai.thrift sai_rpc_server.cpp sai_adapter.py: xml $(XMLDEPS) gensairpc.pl
 	perl -Irpc gensairpc.pl $(GEN_SAIRPC_OPTS)
+
+rpc: sai.thrift sai_rpc_server.cpp sai_adapter.py
 
 HEADERS = saimetadata.h saimetadatasize.h $(CONSTHEADERS)
 
@@ -157,11 +159,12 @@ saidepgraph.gv: saidepgraphgen
 saidepgraph.svg: saidepgraph.gv
 	dot -Tsvg saidepgraph.gv > $@
 
-.PHONY: clean
+.PHONY: clean rpc
 
 clean:
 	rm -f *.o *~ .*~ *.tmp .*.swp .*.swo *.bak sai*.gv sai*.svg *.o.symbols doxygen*.db
-	rm -f saimetadata.h saimetadatasize.h saimetadata.c saimetadatatest.c
+	rm -f saimetadata.h saimetadatasize.h saimetadata.c saimetadatatest.c saiswig.i
 	rm -f saisanitycheck saimetadatatest saiserializetest saidepgraphgen
 	rm -f sai.thrift sai_rpc_server.cpp sai_adapter.py
+	rm -f *.gcda *.gcno *.gcov
 	rm -rf xml html dist temp generated


### PR DESCRIPTION
Refactor Makefile target rpc to not regenerate everything over and over again if target files were already generated and are up to date

Also update .gitignore file to not pay attention to generated targets