### PR TITLE
[meta] Enforce same include pattern style for SAI headers

### DIFF
--- a/inc/saiwred.h
+++ b/inc/saiwred.h
@@ -25,7 +25,7 @@
 #if !defined (__SAIWRED_H_)
 #define __SAIWRED_H_
 
-#include "saitypes.h"
+#include <saitypes.h>
 
 /**
  * @defgroup SAIWRED SAI - QOS WRED specific API definitions

--- a/meta/style.pm
+++ b/meta/style.pm
@@ -1216,6 +1216,13 @@ sub CheckHeadersStyle
                 }
             }
 
+            if ($line =~ /#include\s*\"sai/ and not $header =~ /^sai(|extensions|metadatautils).h$/)
+            {
+                # TODO we should dedice later whether use <> or "" on all includes to make it consistent
+
+                LogWarning "include should use <> brackets on: $header:$n:$line";
+            }
+
             if ($line =~ /typedef\s*(enum|struct|union).*{/)
             {
                 LogWarning "move '{' to new line in typedef $header $n:$line";


### PR DESCRIPTION
Most of the headers with some exceptions use <> and some "", this will enforce to use <> on most of them.