### PR TITLE
[meta] Add -fPIC compiler flag

### DIFF
--- a/meta/Makefile
+++ b/meta/Makefile
@@ -69,7 +69,7 @@ BINS = doxygen perl dot
 
 $(foreach bin,$(BINS),$(if $(shell which $(bin)),,$(error "Missing $(bin) in PATH")))
 
-CFLAGS += -I../inc -I../experimental $(WARNINGS)
+CFLAGS += -I../inc -I../experimental -fPIC $(WARNINGS)
 
 CC = $(CROSS_COMPILE)gcc
 CXX = $(CROSS_COMPILE)g++


### PR DESCRIPTION
Since making metadata already generates object files it may be time beneficial to use those compiled objects in library right away instead of compiling them in other projects