### PR TITLE
Tunnel Term Table support for P2MP type and backward compatible change

### DIFF
--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -911,7 +911,7 @@ typedef sai_status_t (*sai_clear_tunnel_stats_fn)(
  */
 typedef enum _sai_tunnel_term_table_entry_type_t
 {
-    /** Tunnel termination table point to point entry match on dst & src IP & tunnel type */
+    /** Tunnel termination table point to point entry match on src & dst IP & tunnel type */
     SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2P,
 
     /** Tunnel termination table point to multi point entry match on src IP & dst IP+mask & tunnel type */
@@ -956,8 +956,8 @@ typedef enum _sai_tunnel_term_table_entry_attr_t
      * @brief Tunnel termination IP address
      *
      * @type sai_ip_address_t
-     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
-     * @condition SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2P or SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2MP or SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_MP2P or SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_MP2MP
+     * @flags CREATE_ONLY
+     * @default 0.0.0.0
      */
     SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_DST_IP,
 
@@ -975,8 +975,8 @@ typedef enum _sai_tunnel_term_table_entry_attr_t
      * @brief Tunnel source IP address
      *
      * @type sai_ip_address_t
-     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
-     * @condition SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2P or SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_MP2P or SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2MP or SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_MP2MP
+     * @flags CREATE_ONLY
+     * @default 0.0.0.0
      */
     SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_SRC_IP,
 


### PR DESCRIPTION
For Tunnel Termination Tables - P2MP type, we want to be able to provide the dst IP+ mask & src IP. This change is backward compatible, while relaxing the validations.