### PR TITLE
[meta] Add relaxed condition type

### DIFF
--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -958,6 +958,7 @@ typedef enum _sai_tunnel_term_table_entry_attr_t
      * @type sai_ip_address_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
      * @condition SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2P or SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2MP
+     * @relaxed true
      */
     SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_DST_IP,
 
@@ -977,6 +978,7 @@ typedef enum _sai_tunnel_term_table_entry_attr_t
      * @type sai_ip_address_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
      * @condition SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2P or SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_MP2P
+     * @relaxed true
      */
     SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_SRC_IP,
 

--- a/meta/Doxyfile
+++ b/meta/Doxyfile
@@ -234,6 +234,7 @@ ALIASES                += "passparam      =@par Pass paramater:^^         @xmlon
 ALIASES                += "extraparam     =@par Extra paramater:^^        @xmlonly @@extraparam     @endxmlonly"
 ALIASES                += "suffix         =@par Serialize suffix:^^       @xmlonly @@suffix         @endxmlonly"
 ALIASES                += "isresourcetype =@par IsResourceType:^^         @xmlonly @@isresourcetype @endxmlonly"
+ALIASES                += "relaxed        =@par Condition Relaxed:^^      @xmlonly @@relaxed        @endxmlonly"
 ALIASES                += "deprecated     =@par Deprecated:^^             @xmlonly @@deprecated     @endxmlonly"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).

--- a/meta/Doxyfile.compat
+++ b/meta/Doxyfile.compat
@@ -234,6 +234,7 @@ ALIASES                += "passparam      =@par Pass paramater:\n         @xmlon
 ALIASES                += "extraparam     =@par Extra paramater:\n        @xmlonly @@extraparam     @endxmlonly"
 ALIASES                += "suffix         =@par Serialize suffix:\n       @xmlonly @@suffix         @endxmlonly"
 ALIASES                += "isresourcetype =@par IsResourceType:\n         @xmlonly @@isresourcetype @endxmlonly"
+ALIASES                += "relaxed        =@par Condition Relaxed:\n      @xmlonly @@relaxed        @endxmlonly"
 ALIASES                += "deprecated     =@par Deprecated:\n             @xmlonly @@deprecated     @endxmlonly"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).

--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -87,6 +87,7 @@ my %ATTR_TAGS = (
         "isvlan"         , \&ProcessTagIsVlan,
         "getsave"        , \&ProcessTagGetSave,
         "range"          , \&ProcessTagRange,
+        "relaxed"        , \&ProcessTagRelaxed,
         "isresourcetype" , \&ProcessTagIsRecourceType,
         "deprecated"     , \&ProcessTagDeprecated,
         );
@@ -385,6 +386,16 @@ sub ProcessTagIsVlan
     return undef;
 }
 
+sub ProcessTagRelaxed
+{
+    my ($type, $value, $val) = @_;
+
+    return $val if $val =~ /^(true|false)$/i;
+
+    LogError "relaxed tag value '$val', expected true/false";
+    return undef;
+}
+
 sub ProcessTagIsRecourceType
 {
     my ($type, $value, $val) = @_;
@@ -497,7 +508,7 @@ sub ProcessDescription
 
     return if scalar@order == 0;
 
-    my $rightOrder = 'type:flags(:objects)?(:allownull)?(:allowempty)?(:isvlan)?(:default)?(:range)?(:condition|:validonly)?(:isresourcetype)?(:deprecated)?';
+    my $rightOrder = 'type:flags(:objects)?(:allownull)?(:allowempty)?(:isvlan)?(:default)?(:range)?(:condition|:validonly)?(:relaxed)?(:isresourcetype)?(:deprecated)?';
 
     my $order = join(":",@order);
 
@@ -1556,6 +1567,15 @@ sub ProcessIsDeprecatedType
     return "false";
 }
 
+sub ProcessRelaxedType
+{
+    my ($value, $relaxed) = @_;
+
+    return $relaxed if defined $relaxed;
+
+    return "false";
+}
+
 sub ProcessObjects
 {
     my ($attr, $objects) = @_;
@@ -2325,6 +2345,7 @@ sub ProcessSingleObjectType
         my $isextensionattr = ProcessIsExtensionAttr($attr, $meta{type});
         my $isresourcetype  = ProcessIsResourceType($attr, $meta{isresourcetype});
         my $isdeprecated    = ProcessIsDeprecatedType($attr, $meta{deprecated});
+        my $isrelaxed       = ProcessRelaxedType($attr, $meta{relaxed});
 
         my $ismandatoryoncreate = ($flags =~ /MANDATORY/)       ? "true" : "false";
         my $iscreateonly        = ($flags =~ /CREATE_ONLY/)     ? "true" : "false";
@@ -2381,6 +2402,7 @@ sub ProcessSingleObjectType
         WriteSource ".isextensionattr               = $isextensionattr,";
         WriteSource ".isresourcetype                = $isresourcetype,";
         WriteSource ".isdeprecated                  = $isdeprecated,";
+        WriteSource ".isconditionrelaxed            = $isrelaxed,";
 
         WriteSource "};";
 

--- a/meta/saimetadatatypes.h
+++ b/meta/saimetadatatypes.h
@@ -1270,6 +1270,16 @@ typedef struct _sai_attr_metadata_t
      */
     bool                                        isdeprecated;
 
+    /**
+     * @brief Indicates whether condition is relaxed.
+     *
+     * If attribute is MANDATORY_ON_CREATE and relaxed flag is set to true then
+     * given attribute can be passed to create function even if the condition
+     * is not met. If relaxed flag is set to false, then attribute is forbidden
+     * to be passed to create function is condition is not met.
+     */
+    bool                                        isconditionrelaxed;
+
 } sai_attr_metadata_t;
 
 /*

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -3348,6 +3348,22 @@ void check_attr_extension_flag(
     }
 }
 
+void check_attr_condition_relaxed(
+        _In_ const sai_attr_metadata_t* md)
+{
+    META_LOG_ENTER();
+
+    if (md->isconditionrelaxed && !md->isconditional)
+    {
+        META_MD_ASSERT_FAIL(md, "relaxed flag applied to non conditional attribute");
+    }
+
+    if (md->isconditionrelaxed)
+    {
+        META_LOG_WARN("condition relaxed on: %s", md->attridname);
+    }
+}
+
 void check_single_attribute(
         _In_ const sai_attr_metadata_t* md)
 {
@@ -3393,6 +3409,7 @@ void check_single_attribute(
     check_attr_extension_flag(md);
     check_attr_mixed_condition(md);
     check_attr_mixed_validonly(md);
+    check_attr_condition_relaxed(md);
 
     define_attr(md);
 }


### PR DESCRIPTION
If attribute is MANDATORY_ON_CREATE and relaxed flag is set to true then given attribute can be passed to create function even if the condition is not met. If relaxed flag is set to false, then attribute is forbidden to be passed to create function is condition is not met.

Mark SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_DST_IP and
SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_SRC_IP as relaxed