### PR TITLE
Add TX/RX precoding to SERDES attribute list

### DIFF
--- a/doc/SAI-Proposal-CMIS-Module-Management.md
+++ b/doc/SAI-Proposal-CMIS-Module-Management.md
@@ -100,6 +100,32 @@ Port SERDES attributes are used with SAI\_OBJECT\_TYPE\_PORT\_SERDES SAI object 
      * @default internal
      */
     SAI_PORT_SERDES_ATTR_TX_NMOS_VLTG_REG,
+
+    /**
+     * @brief Port serdes control TX pre-coding value
+     *
+     * TX pre-coding value (used for PAM4 links)
+     * The values are of type sai_s32_list_t where the count is number lanes in
+     * a port and the list specifies list of values to be applied to each lane.
+     *
+     * @type sai_s32_list_t
+     * @flags CREATE_ONLY
+     * @default internal
+     */
+    SAI_PORT_SERDES_ATTR_TX_PRECODING,
+
+    /**
+     * @brief Port serdes control RX pre-coding value
+     *
+     * RX pre-coding value (used for PAM4 links)
+     * The values are of type sai_s32_list_t where the count is number lanes in
+     * a port and the list specifies list of values to be applied to each lane.
+     *
+     * @type sai_s32_list_t
+     * @flags CREATE_ONLY
+     * @default internal
+     */
+    SAI_PORT_SERDES_ATTR_RX_PRECODING,
 ```
 
 # 3. Enhancement of synchronization between ASIC and module configuration

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -3748,6 +3748,32 @@ typedef enum _sai_port_serdes_attr_t
     SAI_PORT_SERDES_ATTR_TX_NMOS_VLTG_REG,
 
     /**
+     * @brief Port serdes control TX pre-coding value
+     *
+     * TX pre-coding value (used for PAM4 links)
+     * The values are of type sai_s32_list_t where the count is number lanes in
+     * a port and the list specifies list of values to be applied to each lane.
+     *
+     * @type sai_s32_list_t
+     * @flags CREATE_ONLY
+     * @default internal
+     */
+    SAI_PORT_SERDES_ATTR_TX_PRECODING,
+
+    /**
+     * @brief Port serdes control RX pre-coding value
+     *
+     * RX pre-coding value (used for PAM4 links)
+     * The values are of type sai_s32_list_t where the count is number lanes in
+     * a port and the list specifies list of values to be applied to each lane.
+     *
+     * @type sai_s32_list_t
+     * @flags CREATE_ONLY
+     * @default internal
+     */
+    SAI_PORT_SERDES_ATTR_RX_PRECODING,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_SERDES_ATTR_END,


### PR DESCRIPTION
- Precoding allows to improve the performance (decreasing errors) on
  PAM4 SERDES implementing DFE (Decision Feedback Equalizer)
- When AN is disabled the precoding values should be configured via SAI API.
  When AN is enabled the precoding values are negotiated as a part of Link Training
- For now the precoding configuration is applicable for DAC (copper).
  In the future (CMIS 5.3) it might be applicable also for active optics