### PR TITLE
Add ingress_acl and egress_acl attributes to tunnel object

### DIFF
--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -775,6 +775,38 @@ typedef enum _sai_tunnel_attr_t
     SAI_TUNNEL_ATTR_VXLAN_UDP_SPORT_SECURITY,
 
     /**
+     * @brief Tunnel bind point for ingress ACL object
+     *
+     * Bind (or unbind) an ingress ACL table or ACL group on a tunnel.
+     * Enable/Update ingress ACL table or ACL group filtering by assigning
+     * a valid object id. Disable ingress filtering by assigning
+     * SAI_NULL_OBJECT_ID in the attribute value.
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_ACL_TABLE, SAI_OBJECT_TYPE_ACL_TABLE_GROUP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_TUNNEL_ATTR_INGRESS_ACL,
+
+    /**
+     * @brief Tunnel bind point for egress ACL object
+     *
+     * Bind (or unbind) an egress ACL table or ACL group on a tunnel.
+     * Enable/Update egress ACL table or ACL group filtering by assigning
+     * a valid object id. Disable egress filtering by assigning
+     * SAI_NULL_OBJECT_ID in the attribute value.
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_ACL_TABLE, SAI_OBJECT_TYPE_ACL_TABLE_GROUP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_TUNNEL_ATTR_EGRESS_ACL,
+
+    /**
      * @brief End of attributes
      */
     SAI_TUNNEL_ATTR_END,

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -926,7 +926,10 @@ typedef enum _sai_acl_bind_point_type_t
     SAI_ACL_BIND_POINT_TYPE_ROUTER_INTF = SAI_ACL_BIND_POINT_TYPE_ROUTER_INTERFACE,
 
     /** Bind Point Type Switch */
-    SAI_ACL_BIND_POINT_TYPE_SWITCH
+    SAI_ACL_BIND_POINT_TYPE_SWITCH,
+
+    /** Bind Point Type Tunnel */
+    SAI_ACL_BIND_POINT_TYPE_TUNNEL
 
 } sai_acl_bind_point_type_t;
 


### PR DESCRIPTION
Add SAI_TUNNEL_ATTR_INGRESS_ACL and SAI_TUNNEL_ATTR_EGRESS_ACL attributes to tunnel object.
Add new ACL bind point type SAI_ACL_BIND_POINT_TYPE_TUNNEL

SAI_TUNNEL_ATTR_INGRESS_ACL - ACL table/group lookup after tunnel termination.
SAI_TUNNEL_ATTR_EGRESS_ACL - ACL table/group lookup after encapsulation.

Packet flow scenarios:
https://github.com/r12f/SONiC/blob/user/r12f/ha/doc/smart-switch/high-availability/smart-switch-ha-hld.md
