### PR TITLE
Flush all FDB entries if no attributes specified

### DIFF
--- a/inc/saifdb.h
+++ b/inc/saifdb.h
@@ -272,7 +272,7 @@ typedef enum _sai_fdb_flush_attr_t
      *
      * @type sai_fdb_flush_entry_type_t
      * @flags CREATE_ONLY
-     * @default SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC
+     * @default SAI_FDB_FLUSH_ENTRY_TYPE_ALL
      */
     SAI_FDB_FLUSH_ATTR_ENTRY_TYPE,
 

--- a/inc/saifdb.h
+++ b/inc/saifdb.h
@@ -229,11 +229,11 @@ typedef enum _sai_fdb_flush_entry_type_t
  *
  * For example:
  *
- * 1) Flush all entries in FDB table - Do not specify any attribute
- * 2) Flush all entries by bridge port - Set #SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID
- * 3) Flush all entries by VLAN - Set #SAI_FDB_FLUSH_ATTR_BV_ID with object id as vlan object
- * 3) Flush all entries by bridge - Set #SAI_FDB_FLUSH_ATTR_BV_ID with object id as bridge object
- * 4) Flush all entries by bridge port and VLAN - Set #SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID
+ * 1) Flush all dynamic entries in FDB table - Do not specify any attribute
+ * 2) Flush dynamic entries by bridge port - Set #SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID
+ * 3) Flush dynamic entries by VLAN - Set #SAI_FDB_FLUSH_ATTR_BV_ID with object id as vlan object
+ * 3) Flush dynamic entries by bridge - Set #SAI_FDB_FLUSH_ATTR_BV_ID with object id as bridge object
+ * 4) Flush dynamic entries by bridge port and VLAN - Set #SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID
  *    and #SAI_FDB_FLUSH_ATTR_BV_ID
  * 5) Flush all static entries by bridge port and VLAN - Set #SAI_FDB_FLUSH_ATTR_ENTRY_TYPE,
  *    #SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID, and #SAI_FDB_FLUSH_ATTR_BV_ID
@@ -272,7 +272,7 @@ typedef enum _sai_fdb_flush_attr_t
      *
      * @type sai_fdb_flush_entry_type_t
      * @flags CREATE_ONLY
-     * @default SAI_FDB_FLUSH_ENTRY_TYPE_ALL
+     * @default SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC
      */
     SAI_FDB_FLUSH_ATTR_ENTRY_TYPE,
 


### PR DESCRIPTION
As per enum `sai_fdb_flush_attr_t` description:
```
 * For example:
 *
 * 1) Flush all entries in FDB table - Do not specify any attribute
   . . . . .
```
Also, it's logically to flush all types of FDB entries in case either no attributes specified or just BV_ID or BRIDGE_PORT_ID.