### PR TITLE
[meta] Add custom range start/end to sai_object_type_t and sai_api_t as workaround for internal enum size

### DIFF
--- a/inc/sai.h
+++ b/inc/sai.h
@@ -147,6 +147,12 @@ typedef enum _sai_api_t
     SAI_API_ARS_PROFILE      = 49, /**<sai_ars_api_profile_t */
     SAI_API_TWAMP            = 50, /**< sai_twamp_api_t */
     SAI_API_MAX,                   /**< total number of APIs */
+
+    /** Custom range base value */
+    SAI_API_CUSTOM_RANGE_START = 256,
+
+    /** End of custom range base */
+    SAI_API_CUSTOM_RANGE_END
 } sai_api_t;
 
 /**

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -294,7 +294,15 @@ typedef enum _sai_object_type_t
     SAI_OBJECT_TYPE_ARS                      = 104,
     SAI_OBJECT_TYPE_ACL_TABLE_CHAIN_GROUP    = 105,
     SAI_OBJECT_TYPE_TWAMP_SESSION            = 106,
-    SAI_OBJECT_TYPE_MAX,  /* Must remain in last position */
+
+    /** Must remain in last position */
+    SAI_OBJECT_TYPE_MAX,
+
+    /** Custom range base value */
+    SAI_OBJECT_TYPE_CUSTOM_RANGE_START = 256,
+
+    /** End of custom range base */
+    SAI_OBJECT_TYPE_CUSTOM_RANGE_END
 } sai_object_type_t;
 
 typedef struct _sai_u8_list_t

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -5538,6 +5538,8 @@ void check_object_type_extension_max_value()
      */
 
     META_ASSERT_TRUE(SAI_OBJECT_TYPE_EXTENSIONS_MAX < 256, "max object type can be 255 to be encoded on single byte");
+
+    META_ASSERT_TRUE(SAI_OBJECT_TYPE_MAX < SAI_OBJECT_TYPE_EXTENSIONS_MAX, "max object must be less than max extensions");
 }
 
 void check_global_apis()

--- a/meta/saiserializetest.c
+++ b/meta/saiserializetest.c
@@ -512,9 +512,9 @@ void test_serialize_enum()
 
     ASSERT_STR_EQ(buf, "-1", res);
 
-    res = sai_serialize_enum(buf, &sai_metadata_enum_sai_object_type_t, 128);
+    res = sai_serialize_enum(buf, &sai_metadata_enum_sai_object_type_t, 228);
 
-    ASSERT_STR_EQ(buf, "128", res);
+    ASSERT_STR_EQ(buf, "228", res);
 
     /* test all enums */
 
@@ -1551,10 +1551,10 @@ void test_serialize_enum_list()
 
     ASSERT_STR_EQ(buf, "{\"count\":2,\"list\":[\"SAI_OBJECT_TYPE_PORT\",\"-1\"]}", res);
 
-    ot[1] = 128;
+    ot[1] = 228;
 
     res = sai_serialize_enum_list(buf, &sai_metadata_enum_sai_object_type_t, &list);
-    ASSERT_STR_EQ(buf, "{\"count\":2,\"list\":[\"SAI_OBJECT_TYPE_PORT\",\"128\"]}", res);
+    ASSERT_STR_EQ(buf, "{\"count\":2,\"list\":[\"SAI_OBJECT_TYPE_PORT\",\"228\"]}", res);
 
     ot[1] = SAI_OBJECT_TYPE_LAG;
     res = sai_serialize_enum_list(buf, NULL, &list);
@@ -1592,12 +1592,12 @@ void test_deserialize_enum_list()
     list.list = NULL;
     list.count = 0;
 
-    buf = "{\"count\":2,\"list\":[\"SAI_OBJECT_TYPE_PORT\",\"128\"]}";
+    buf = "{\"count\":2,\"list\":[\"SAI_OBJECT_TYPE_PORT\",\"228\"]}";
     res = sai_deserialize_enum_list(buf, &sai_metadata_enum_sai_object_type_t, &list);
     ASSERT_TRUE(res == (int)strlen(buf), "expected true");
     ASSERT_TRUE(list.count == 2, "expected true");
     ASSERT_TRUE(list.list[0] == SAI_OBJECT_TYPE_PORT, "expected true");
-    ASSERT_TRUE(list.list[1] == 128, "expected true");
+    ASSERT_TRUE(list.list[1] == 228, "expected true");
     free(list.list);
     list.list = NULL;
     list.count = 0;


### PR DESCRIPTION
Workadound for https://github.com/opencomputeproject/SAI/issues/1925

Since SAI_OBJECT_TYPE_EXTENSIONS_MAX is declared as define, compiler warns about:

error: the result of the conversion is unspecified because .129. is outside the range of type .sai_object_type_t. {aka
    ._sai_object_type_t.} [-Werror=conversion]

when next value exceeds 7 bits, since that's enough for encode all values for sai_object_type_t. Unfortunetly #pragma GCC diagnostic ignored "-Wconversion" is not working (probably gcc bug) then workaround needs to be addressed in other way.

Those custom ranges can be removed after actual SAI_OBJECT_TYPE_MAX will reach 128 value