### PR TITLE
add word of TWAMP for aspell

### DIFF
--- a/meta/aspell.en.pws
+++ b/meta/aspell.en.pws
@@ -212,3 +212,4 @@ wildcard
 Wildcard
 www
 xconnect
+TWAMP


### PR DESCRIPTION
Fix sonic-sairedis compile when merge to twamp light in syncd 