### PR TITLE
Add port extensions for DASH project

### DIFF
--- a/experimental/saiextensions.h
+++ b/experimental/saiextensions.h
@@ -31,6 +31,7 @@
 /* existing enum extensions */
 #include "saitypesextensions.h"
 #include "saiswitchextensions.h"
+#include "saiportextensions.h"
 
 /* new experimental object type includes */
 #include "saiexperimentaldashvip.h"

--- a/experimental/saiportextensions.h
+++ b/experimental/saiportextensions.h
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2018 Microsoft Open Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ *    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ *    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ *
+ *    See the Apache Version 2.0 License for specific language governing
+ *    permissions and limitations under the License.
+ *
+ *    Microsoft would like to thank the following companies for their review and
+ *    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+ *    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+ *
+ * @file    saiportextensions.h
+ *
+ * @brief   This module defines port extensions of the Switch Abstraction Interface (SAI)
+ */
+
+#ifndef __SAIPORTEXTENSIONS_H_
+#define __SAIPORTEXTENSIONS_H_
+
+#include <saiport.h>
+#include <saitypes.h>
+
+/**
+ * @brief SAI port attribute extensions.
+ *
+ * @flags free
+ */
+typedef enum _sai_port_attr_extensions_t
+{
+    SAI_PORT_ATTR_EXTENSIONS_RANGE_START = SAI_PORT_ATTR_END,
+
+    /* Add new experimental port attributes above this line */
+
+    SAI_PORT_ATTR_EXTENSIONS_RANGE_END
+
+} sai_port_attr_extensions_t;
+
+#endif /* __SAIPORTEXTENSIONS_H_ */


### PR DESCRIPTION
This port extension is described in the SAI extension design doc (PR #835): https://github.com/opencomputeproject/SAI/blob/master/doc/SAI-Extensions.md, but currently missing in the experiment folder. This change is trying to add it in.

With port extensions, we will be able to add port level counters or other attributes for DASH project for tracking global stats.