### PR TITLE
[meta] Add custom range start end values check

### DIFF
--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -68,6 +68,7 @@ our %FUNCTION_DEF = ();
 our @ALL_ENUMS = ();
 our %GLOBAL_APIS = ();
 our %OBJECT_TYPE_BULK_MAP = ();
+our %SAI_ENUMS_CUSTOM_RANGES = ();
 
 my $FLAGS = "MANDATORY_ON_CREATE|CREATE_ONLY|CREATE_AND_SET|READ_ONLY|KEY";
 my $ENUM_FLAGS_TYPES = "(none|strict|mixed|ranges|free)";
@@ -655,6 +656,10 @@ sub ProcessEnumSection
         my @ranges = grep(/^SAI_\w+(RANGE_BASE)$/, @values);
 
         $SAI_ENUMS{$enumtypename}{ranges} = \@ranges;
+
+        my @custom = grep(/^SAI_\w+_CUSTOM_RANGE_(START|END)$/, @values);
+
+        $SAI_ENUMS_CUSTOM_RANGES{$enumtypename}{customranges} = \@custom;
 
         @values = grep(!/^SAI_\w+_(START|END)$/, @values);
         @values = grep(!/^SAI_\w+(RANGE_BASE)$/, @values);

--- a/meta/test.pm
+++ b/meta/test.pm
@@ -149,6 +149,42 @@ sub CreateCustomRangeTest
     WriteTest "}";
 }
 
+sub CreateCustomRangeAll
+{
+    WriteTest "#pragma GCC diagnostic push";
+    WriteTest "#pragma GCC diagnostic ignored \"-Wsuggest-attribute=noreturn\"";
+
+    DefineTestName "custom_range_all_test";
+
+    # purpose of this test is to make sure
+    # all enums define custom range start and end markers
+
+    WriteTest "{";
+
+    my @keys = sort keys %main::SAI_ENUMS_CUSTOM_RANGES;
+
+    for my $key (@keys)
+    {
+        my @all = @{ $main::SAI_ENUMS_CUSTOM_RANGES{$key}{customranges} };
+
+        for my $enum (@all)
+        {
+            # extepions and will be removed
+            next if $enum eq "SAI_API_CUSTOM_RANGE_START";
+            next if $enum eq "SAI_API_CUSTOM_RANGE_END";
+            next if $enum eq "SAI_OBJECT_TYPE_CUSTOM_RANGE_START";
+            next if $enum eq "SAI_OBJECT_TYPE_CUSTOM_RANGE_END";
+
+            WriteTest "    TEST_ASSERT_TRUE($enum == 0x10000000, \"invalid custom range start for $enum\");" if $enum =~ /_START$/;
+            WriteTest "    TEST_ASSERT_TRUE($enum > 0x10000000, \"invalid custom range end for $enum\");" if $enum =~ /_END$/;
+        }
+    }
+
+    WriteTest "}";
+
+    WriteTest "#pragma GCC diagnostic pop";
+}
+
 sub CreateEnumSizeCheckTest
 {
     DefineTestName "enum_size_check_test";
@@ -694,6 +730,8 @@ sub CreateTests
     CreateStructUnionSizeCheckTest();
 
     CreatePragmaPop();
+
+    CreateCustomRangeAll();
 
     WriteTestMain();
 }


### PR DESCRIPTION
To make sure all custom ranges are beginning from the same value. This will be handy to easy distinguish custom enums.