### PR TITLE
Update the Doxyfile for doxygen in Debian Bookworm

### DIFF
--- a/meta/Doxyfile
+++ b/meta/Doxyfile
@@ -1681,7 +1681,7 @@ LATEX_HIDE_INDICES     = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_SOURCE_CODE      = NO
+#LATEX_SOURCE_CODE      = NO
 
 # The LATEX_BIB_STYLE tag can be used to specify the style to use for the
 # bibliography, e.g. plainnat, or ieeetr. See
@@ -2031,7 +2031,7 @@ EXTERNAL_PAGES         = YES
 # powerful graphs.
 # The default value is: YES.
 
-CLASS_DIAGRAMS         = YES
+#CLASS_DIAGRAMS         = YES
 
 # You can define message sequence charts within doxygen comments using the \msc
 # command. Doxygen will then run the mscgen tool (see:


### PR DESCRIPTION
In Bookworm, the LATEX_SOURCE_CODE and CLASS_DIAGRAMS options are deprecated/removed. Comment these options out in the Doxyfile.