### PR TITLE
Make TAM report optional

### DIFF
--- a/inc/saitam.h
+++ b/inc/saitam.h
@@ -791,8 +791,10 @@ typedef enum _sai_tam_int_attr_t
      * @brief Tam report type
      *
      * @type sai_object_id_t
-     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @flags CREATE_ONLY
      * @objects SAI_OBJECT_TYPE_TAM_REPORT
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
      */
     SAI_TAM_INT_ATTR_REPORT_ID,
 


### PR DESCRIPTION
TAM report is mandatory only in the case of termination and not for initiation and transit. This PR is updating the saitam.h to make the TAM report optional.