### PR TITLE
Modified the script to pass decap tunnel map object instead of encap tunnel object while creating tunnel decap entry

### DIFF
--- a/ptf/saitunnel.py
+++ b/ptf/saitunnel.py
@@ -108,7 +108,7 @@ class VxLanBaseSetup(SaiHelper):
 
         self.decap_tunnel_map_entry = sai_thrift_create_tunnel_map_entry(
             self.client,
-            tunnel_map=self.encap_tunnel_map,
+            tunnel_map=self.decap_tunnel_map,
             tunnel_map_type=SAI_TUNNEL_MAP_TYPE_VNI_TO_VIRTUAL_ROUTER_ID,
             virtual_router_id_value=self.ovrf,
             vni_id_key=self.vni)


### PR DESCRIPTION
Modified the script to pass decap tunnel map object instead of encap tunnel object while creating tunnel decap entry

tunnel script is passing tunnel_map=encap_tunnel_map oject while creating tunnel decap map entry. Modifed the script to fix this issue

 ```
self.decap_tunnel_map_entry = sai_thrift_create_tunnel_map_entry(
             self.client,
-            tunnel_map=self.encap_tunnel_map,
+            tunnel_map=self.decap_tunnel_map,
             tunnel_map_type=SAI_TUNNEL_MAP_TYPE_VNI_TO_VIRTUAL_ROUTER_ID,
             virtual_router_id_value=self.ovrf,
             vni_id_key=self.vni)
```