### PR TITLE
Modified the saiacl test suite to fix Invalid IP prefix format error while Creating route entry

### DIFF
--- a/ptf/saiacl.py
+++ b/ptf/saiacl.py
@@ -558,7 +558,7 @@ class SrcIpAclTest(SaiHelperSimplified):
         rif_id1 = self.port0_rif
         self.rif_id2 = self.port1_rif
 
-        ip_addr_subnet = '172.16.10.0'
+        ip_addr_subnet = '172.16.10.0/24'
         ip_addr = '172.16.10.1'
         dmac = '00:11:22:33:44:55'
         mac_src = '00:22:22:22:22:22'
@@ -815,7 +815,7 @@ class DstIpAclTest(SaiHelperSimplified):
         rif_id1 = self.port0_rif
         self.rif_id2 = self.port1_rif
 
-        ip_addr_subnet = '172.16.10.0'
+        ip_addr_subnet = '172.16.10.0/24'
         ip_addr = '172.16.10.1'
         dmac = '00:11:22:33:44:55'
         mac_src = '00:22:22:22:22:22'
@@ -1071,7 +1071,7 @@ class MACSrcAclTest(SaiHelperSimplified):
         rif_id1 = self.port0_rif
         self.rif_id2 = self.port1_rif
 
-        ip_addr_subnet = '172.16.10.0'
+        ip_addr_subnet = '172.16.10.0/24'
         ip_addr = '172.16.10.1'
         dmac = '00:11:22:33:44:55'
         self.mac_src = '00:22:22:22:22:22'
@@ -1331,7 +1331,7 @@ class L3L4PortTest(SaiHelperSimplified):
         rif_id1 = self.port0_rif
         self.rif_id2 = self.port1_rif
 
-        ip_addr_subnet = '172.16.10.0'
+        ip_addr_subnet = '172.16.10.0/24'
         ip_addr = '172.16.10.1'
         dmac = '00:11:22:33:44:55'
         mac_src = '00:22:22:22:22:22'
@@ -1611,7 +1611,7 @@ class L3AclRangeTest(SaiHelperSimplified):
         rif_id1 = self.port0_rif
         self.rif_id2 = self.port1_rif
 
-        ip_addr_subnet = '172.16.10.0'
+        ip_addr_subnet = '172.16.10.0/24'
         ip_addr = '172.16.10.1'
         dmac = '00:11:22:33:44:55'
         mac_src = '00:22:22:22:22:22'
@@ -2547,7 +2547,7 @@ class MultAclTableGroupBindTest(SaiHelper):
         super(MultAclTableGroupBindTest, self).setUp()
         rif_id = self.port13_rif
 
-        ip_addr_subnet = '172.16.10.0'
+        ip_addr_subnet = '172.16.10.0/24'
         self.ip_addr = '172.16.10.1'
         self.dmac = '00:11:22:33:44:55'
 


### PR DESCRIPTION
Modified the test file to fix Invalid IP prefix format error while Creating route entry. Please find error details given below

Finish SaiHelperBase setup
Create default v4&v6 route entry...
Create neighbor with 172.16.10.1 ip address, 1688849860263944 router interface id and 00:11:22:33:44:55 destination mac
Create nhop with 172.16.10.1 ip address and 1688849860263944 router interface id
Create route with 172.16.10.0 ip prefix and 1688849860263944 router interface id
**Invalid IP prefix format**

Added prefix with sbunet to fix this issue


