### PR TITLE
Modified the test script to match ACL match fields which should be configured to match l4 src and dst port

### DIFF
--- a/ptf/saiacl.py
+++ b/ptf/saiacl.py
@@ -1414,7 +1414,7 @@ class L3L4PortTest(SaiHelperSimplified):
             self.client,
             acl_stage=table_stage_ingress,
             acl_bind_point_type_list=table_bind_point_type_list,
-            field_src_ip=True)
+            field_l4_src_port=True, field_l4_dst_port=True)
 
         self.assertNotEqual(acl_ingress_table_id, 0)
 


### PR DESCRIPTION
Test case goal is to verify matching on l4_dst_port and l4_src_port fields configuration
but test case is enabling only src ip match field while creating route table
Modifed the test script to enable l4 src port and l4 dst port match fields