### PR TITLE
Add word of ENI into aspell.

### DIFF
--- a/meta/aspell.en.pws
+++ b/meta/aspell.en.pws
@@ -44,6 +44,9 @@ eg
 egressing
 encap
 Encaps
+eni
+Eni
+ENI
 enum
 Enum
 enums


### PR DESCRIPTION
The word ENI is a term which means elastic network interface. It is used in DASH project and its API design, hence adding this word into the aspell checker. 

This issue didn't show up before very likely because aspell ignores the code, however, once we use it in comments, it starts to fail.