### PR TITLE
Adding DASH SAI APIs for load balancer fast path scenario.

### DIFF
--- a/experimental/saiexperimentaldasheni.h
+++ b/experimental/saiexperimentaldasheni.h
@@ -431,6 +431,15 @@ typedef enum _sai_eni_attr_t
     SAI_ENI_ATTR_OUTBOUND_V6_STAGE5_DASH_ACL_GROUP_ID,
 
     /**
+     * @brief Action set_eni_attrs parameter DISABLE_FAST_PATH_ICMP_FLOW_REDIRECTION
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_ENI_ATTR_DISABLE_FAST_PATH_ICMP_FLOW_REDIRECTION,
+
+    /**
      * @brief End of attributes
      */
     SAI_ENI_ATTR_END,
@@ -442,6 +451,19 @@ typedef enum _sai_eni_attr_t
     SAI_ENI_ATTR_CUSTOM_RANGE_END,
 
 } sai_eni_attr_t;
+
+/**
+ * @brief Counter IDs for eni in sai_get_eni_stats() call
+ */
+typedef enum _sai_eni_stat_t
+{
+    /** DASH eni LB_FAST_PATH_ICMP_IN_BYTES stat count */
+    SAI_ENI_STAT_LB_FAST_PATH_ICMP_IN_BYTES,
+
+    /** DASH eni LB_FAST_PATH_ICMP_IN_PACKETS stat count */
+    SAI_ENI_STAT_LB_FAST_PATH_ICMP_IN_PACKETS,
+
+} sai_eni_stat_t;
 
 /**
  * @brief Create dash_eni_eni_ether_address_map_entry
@@ -590,6 +612,54 @@ typedef sai_status_t (*sai_get_eni_attribute_fn)(
         _In_ uint32_t attr_count,
         _Inout_ sai_attribute_t *attr_list);
 
+/**
+ * @brief Get eni statistics counters. Deprecated for backward compatibility.
+ *
+ * @param[in] eni_id Entry id
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Specifies the array of counter ids
+ * @param[out] counters Array of resulting counter values.
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_eni_stats_fn)(
+        _In_ sai_object_id_t eni_id,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _Out_ uint64_t *counters);
+
+/**
+ * @brief Get eni statistics counters extended.
+ *
+ * @param[in] eni_id Entry id
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Specifies the array of counter ids
+ * @param[in] mode Statistics mode
+ * @param[out] counters Array of resulting counter values.
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_eni_stats_ext_fn)(
+        _In_ sai_object_id_t eni_id,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _In_ sai_stats_mode_t mode,
+        _Out_ uint64_t *counters);
+
+/**
+ * @brief Clear eni statistics counters.
+ *
+ * @param[in] eni_id Entry id
+ * @param[in] number_of_counters Number of counters in the array
+ * @param[in] counter_ids Specifies the array of counter ids
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_clear_eni_stats_fn)(
+        _In_ sai_object_id_t eni_id,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids);
+
 typedef struct _sai_dash_eni_api_t
 {
     sai_create_eni_ether_address_map_entry_fn           create_eni_ether_address_map_entry;
@@ -603,6 +673,9 @@ typedef struct _sai_dash_eni_api_t
     sai_remove_eni_fn                                   remove_eni;
     sai_set_eni_attribute_fn                            set_eni_attribute;
     sai_get_eni_attribute_fn                            get_eni_attribute;
+    sai_get_eni_stats_fn                                get_eni_stats;
+    sai_get_eni_stats_ext_fn                            get_eni_stats_ext;
+    sai_clear_eni_stats_fn                              clear_eni_stats;
     sai_bulk_object_create_fn                           create_enis;
     sai_bulk_object_remove_fn                           remove_enis;
 

--- a/experimental/saiportextensions.h
+++ b/experimental/saiportextensions.h
@@ -52,6 +52,18 @@ typedef enum _sai_port_stat_extensions_t
 {
     SAI_PORT_STAT_EXTENSIONS_RANGE_START = SAI_PORT_STAT_END,
 
+    /** DASH port LB_FAST_PATH_ICMP_IN_BYTES stat count */
+    SAI_PORT_STAT_LB_FAST_PATH_ICMP_IN_BYTES = SAI_PORT_STAT_EXTENSIONS_RANGE_START,
+
+    /** DASH port LB_FAST_PATH_ICMP_IN_PACKETS stat count */
+    SAI_PORT_STAT_LB_FAST_PATH_ICMP_IN_PACKETS,
+
+    /** DASH port LB_FAST_PATH_ENI_MISS_BYTES stat count */
+    SAI_PORT_STAT_LB_FAST_PATH_ENI_MISS_BYTES,
+
+    /** DASH port LB_FAST_PATH_ENI_MISS_PACKETS stat count */
+    SAI_PORT_STAT_LB_FAST_PATH_ENI_MISS_PACKETS,
+
     /* Add new experimental port stats above this line */
 
     SAI_PORT_STAT_EXTENSIONS_RANGE_END


### PR DESCRIPTION
This change adds the SAI API changes for enabling the load balancer fast path scenario.

- DASH load balancer fast path HLD: https://github.com/sonic-net/DASH/blob/main/documentation/load-bal-service/fast-path-icmp-flow-redirection.md
- Change that used to generate the headers: https://github.com/sonic-net/DASH/pull/517