### PR TITLE
Fill in Doxygen tags on extension headers

### DIFF
--- a/experimental/saiexperimentalbmtor.h
+++ b/experimental/saiexperimentalbmtor.h
@@ -19,7 +19,9 @@
  *
  * @file    saiexperimentalbmtor.h
  *
- * @brief   This module defines SAI P4 extension  interface
+ * @brief   This module defines SAI extensions needed for the BMTOR application
+ *
+ * @warning This module is a SAI experimental module.
  */
 
 #if !defined (__SAIEXPERIMENTALBMTOR_H_)
@@ -28,7 +30,7 @@
 #include <saitypes.h>
 
 /**
- * @defgroup SAIEXPERIMENTALBMTOR SAI - Extension specific API definitions
+ * @defgroup SAIEXPERIMENTALBMTOR SAI - Experimental: BMTOR specific API definitions
  *
  * @{
  */

--- a/experimental/saiexperimentaldashacl.h
+++ b/experimental/saiexperimentaldashacl.h
@@ -19,7 +19,7 @@
  *
  * @file    saiexperimentaldashacl.h
  *
- * @brief   This module defines SAI P4 extension  interface
+ * @brief   This module defines SAI extensions for DASH ACL
  */
 
 #if !defined (__SAIEXPERIMENTALDASHACL_H_)
@@ -28,7 +28,7 @@
 #include <saitypes.h>
 
 /**
- * @defgroup SAIEXPERIMENTALDASH_ACL SAI - Extension specific API definitions
+ * @defgroup SAIEXPERIMENTALDASH_ACL SAI - Experimental: DASH ACL specific API definitions
  *
  * @{
  */

--- a/experimental/saiexperimentaldashdirectionlookup.h
+++ b/experimental/saiexperimentaldashdirectionlookup.h
@@ -19,7 +19,9 @@
  *
  * @file    saiexperimentaldashdirectionlookup.h
  *
- * @brief   This module defines SAI P4 extension  interface
+ * @brief   This module defines SAI extensions for DASH direction lookup
+ *
+ * @warning This module is a SAI experimental module
  */
 
 #if !defined (__SAIEXPERIMENTALDASHDIRECTIONLOOKUP_H_)
@@ -28,7 +30,7 @@
 #include <saitypes.h>
 
 /**
- * @defgroup SAIEXPERIMENTALDASH_DIRECTION_LOOKUP SAI - Extension specific API definitions
+ * @defgroup SAIEXPERIMENTALDASH_DIRECTION_LOOKUP SAI - Experimental: DASH direction lookup specific API definitions
  *
  * @{
  */

--- a/experimental/saiexperimentaldasheni.h
+++ b/experimental/saiexperimentaldasheni.h
@@ -455,14 +455,14 @@ typedef enum _sai_eni_attr_t
 } sai_eni_attr_t;
 
 /**
- * @brief Counter IDs for eni in sai_get_eni_stats() call
+ * @brief Counter IDs for ENI in sai_get_eni_stats() call
  */
 typedef enum _sai_eni_stat_t
 {
-    /** DASH eni LB_FAST_PATH_ICMP_IN_BYTES stat count */
+    /** DASH ENI LB_FAST_PATH_ICMP_IN_BYTES stat count */
     SAI_ENI_STAT_LB_FAST_PATH_ICMP_IN_BYTES,
 
-    /** DASH eni LB_FAST_PATH_ICMP_IN_PACKETS stat count */
+    /** DASH ENI LB_FAST_PATH_ICMP_IN_PACKETS stat count */
     SAI_ENI_STAT_LB_FAST_PATH_ICMP_IN_PACKETS,
 
 } sai_eni_stat_t;
@@ -615,7 +615,7 @@ typedef sai_status_t (*sai_get_eni_attribute_fn)(
         _Inout_ sai_attribute_t *attr_list);
 
 /**
- * @brief Get eni statistics counters. Deprecated for backward compatibility.
+ * @brief Get ENI statistics counters. Deprecated for backward compatibility.
  *
  * @param[in] eni_id Entry id
  * @param[in] number_of_counters Number of counters in the array
@@ -631,7 +631,7 @@ typedef sai_status_t (*sai_get_eni_stats_fn)(
         _Out_ uint64_t *counters);
 
 /**
- * @brief Get eni statistics counters extended.
+ * @brief Get ENI statistics counters extended.
  *
  * @param[in] eni_id Entry id
  * @param[in] number_of_counters Number of counters in the array
@@ -649,7 +649,7 @@ typedef sai_status_t (*sai_get_eni_stats_ext_fn)(
         _Out_ uint64_t *counters);
 
 /**
- * @brief Clear eni statistics counters.
+ * @brief Clear ENI statistics counters.
  *
  * @param[in] eni_id Entry id
  * @param[in] number_of_counters Number of counters in the array

--- a/experimental/saiexperimentaldasheni.h
+++ b/experimental/saiexperimentaldasheni.h
@@ -19,7 +19,9 @@
  *
  * @file    saiexperimentaldasheni.h
  *
- * @brief   This module defines SAI P4 extension  interface
+ * @brief   This module defines SAI extensions for DASH ENI
+ *
+ * @warning This module is a SAI experimental module
  */
 
 #if !defined (__SAIEXPERIMENTALDASHENI_H_)
@@ -28,7 +30,7 @@
 #include <saitypes.h>
 
 /**
- * @defgroup SAIEXPERIMENTALDASH_ENI SAI - Extension specific API definitions
+ * @defgroup SAIEXPERIMENTALDASH_ENI SAI - Experimental: DASH ENI specific API definitions
  *
  * @{
  */

--- a/experimental/saiexperimentaldashinboundrouting.h
+++ b/experimental/saiexperimentaldashinboundrouting.h
@@ -19,7 +19,9 @@
  *
  * @file    saiexperimentaldashinboundrouting.h
  *
- * @brief   This module defines SAI P4 extension  interface
+ * @brief   This module defines SAI extensions for DASH inbound routing
+ *
+ * @warning This module is a SAI experimental module
  */
 
 #if !defined (__SAIEXPERIMENTALDASHINBOUNDROUTING_H_)
@@ -28,7 +30,7 @@
 #include <saitypes.h>
 
 /**
- * @defgroup SAIEXPERIMENTALDASH_INBOUND_ROUTING SAI - Extension specific API definitions
+ * @defgroup SAIEXPERIMENTALDASH_INBOUND_ROUTING SAI - Experimental: DASH inbound routing specific API definitions
  *
  * @{
  */

--- a/experimental/saiexperimentaldashmeter.h
+++ b/experimental/saiexperimentaldashmeter.h
@@ -19,7 +19,9 @@
  *
  * @file    saiexperimentaldashmeter.h
  *
- * @brief   This module defines SAI P4 extension  interface
+ * @brief   This module defines SAI extensions for DASH meter
+ *
+ * @warning This module is a SAI experimental module
  */
 
 #if !defined (__SAIEXPERIMENTALDASHMETER_H_)
@@ -28,7 +30,7 @@
 #include <saitypes.h>
 
 /**
- * @defgroup SAIEXPERIMENTALDASH_METER SAI - Extension specific API definitions
+ * @defgroup SAIEXPERIMENTALDASH_METER SAI - Experimental: DASH meter specific API definitions
  *
  * @{
  */

--- a/experimental/saiexperimentaldashoutboundcatopa.h
+++ b/experimental/saiexperimentaldashoutboundcatopa.h
@@ -19,7 +19,9 @@
  *
  * @file    saiexperimentaldashoutboundcatopa.h
  *
- * @brief   This module defines SAI P4 extension  interface
+ * @brief   This module defines SAI extensions for DASH outbound CA to PA
+ *
+ * @warning This module is a SAI experimental module
  */
 
 #if !defined (__SAIEXPERIMENTALDASHOUTBOUNDCATOPA_H_)
@@ -28,7 +30,7 @@
 #include <saitypes.h>
 
 /**
- * @defgroup SAIEXPERIMENTALDASH_OUTBOUND_CA_TO_PA SAI - Extension specific API definitions
+ * @defgroup SAIEXPERIMENTALDASH_OUTBOUND_CA_TO_PA SAI - Experimental: DASH outbound CA to PA specific API definitions
  *
  * @{
  */

--- a/experimental/saiexperimentaldashoutboundrouting.h
+++ b/experimental/saiexperimentaldashoutboundrouting.h
@@ -19,7 +19,9 @@
  *
  * @file    saiexperimentaldashoutboundrouting.h
  *
- * @brief   This module defines SAI P4 extension  interface
+ * @brief   This module defines SAI extensions for DASH outbound routing
+ *
+ * @warning This module is a SAI experimental module
  */
 
 #if !defined (__SAIEXPERIMENTALDASHOUTBOUNDROUTING_H_)
@@ -28,7 +30,7 @@
 #include <saitypes.h>
 
 /**
- * @defgroup SAIEXPERIMENTALDASH_OUTBOUND_ROUTING SAI - Extension specific API definitions
+ * @defgroup SAIEXPERIMENTALDASH_OUTBOUND_ROUTING SAI - Experimental: DASH outbound routing specific API definitions
  *
  * @{
  */

--- a/experimental/saiexperimentaldashpavalidation.h
+++ b/experimental/saiexperimentaldashpavalidation.h
@@ -19,7 +19,9 @@
  *
  * @file    saiexperimentaldashpavalidation.h
  *
- * @brief   This module defines SAI P4 extension  interface
+ * @brief   This module defines SAI extensions for DASH PA validation
+ *
+ * @warning This module is a SAI experimental module
  */
 
 #if !defined (__SAIEXPERIMENTALDASHPAVALIDATION_H_)
@@ -28,7 +30,7 @@
 #include <saitypes.h>
 
 /**
- * @defgroup SAIEXPERIMENTALDASH_PA_VALIDATION SAI - Extension specific API definitions
+ * @defgroup SAIEXPERIMENTALDASH_PA_VALIDATION SAI - Experimental: DASH PA validation specific API definitions
  *
  * @{
  */

--- a/experimental/saiexperimentaldashvip.h
+++ b/experimental/saiexperimentaldashvip.h
@@ -19,7 +19,9 @@
  *
  * @file    saiexperimentaldashvip.h
  *
- * @brief   This module defines SAI P4 extension  interface
+ * @brief   This module defines SAI extensions for DASH VIP
+ *
+ * @warning This module is a SAI experimental module
  */
 
 #if !defined (__SAIEXPERIMENTALDASHVIP_H_)
@@ -28,7 +30,7 @@
 #include <saitypes.h>
 
 /**
- * @defgroup SAIEXPERIMENTALDASH_VIP SAI - Extension specific API definitions
+ * @defgroup SAIEXPERIMENTALDASH_VIP SAI - Experimental: DASH VIP specific API definitions
  *
  * @{
  */

--- a/experimental/saiexperimentaldashvnet.h
+++ b/experimental/saiexperimentaldashvnet.h
@@ -19,7 +19,9 @@
  *
  * @file    saiexperimentaldashvnet.h
  *
- * @brief   This module defines SAI P4 extension  interface
+ * @brief   This module defines SAI extensions for DASH VNET
+ *
+ * @warning This module is a SAI experimental module
  */
 
 #if !defined (__SAIEXPERIMENTALDASHVNET_H_)
@@ -28,7 +30,7 @@
 #include <saitypes.h>
 
 /**
- * @defgroup SAIEXPERIMENTALDASH_VNET SAI - Extension specific API definitions
+ * @defgroup SAIEXPERIMENTALDASH_VNET SAI - Experimental: DASH VNET specific API definitions
  *
  * @{
  */

--- a/meta/acronyms.txt
+++ b/meta/acronyms.txt
@@ -10,6 +10,7 @@ ASIC - Application Specific Integrated Circuit
 BFD - Bidirectional Forwarding Detection
 BFDV6 - Bidirectional Forwarding Detection for IPv6
 BGP - Border Gateway Protocol
+BMTOR - Behavioral Model Top-of-Rack
 BOS - Bottom Of Stack
 BW - Bandwidth
 CAM - Content Addressable Memory
@@ -42,6 +43,7 @@ ECN - Explicit Congestion Notification
 ECT - ECN Capable Transport
 EEE - Electrical and Electronics Engineering
 EEPROM - Electrically erasable programmable read-only memory
+ENI - Elastic Network Interface
 ERSPAN - Encapsulated Remote SPAN
 ESN - Extended Sequence Number
 EWMA - Exponentially Weighted Moving Average
@@ -158,6 +160,7 @@ UDP - User Datagram Protocol
 USD - Ultimate Segment Decapsulation
 USP - Ultimate Segment Pop
 USXGMII - Universal Serial 10 Gigabit Media Independent Interface
+VNET - Virtual Network
 VNI - Virtual Network Interface
 VNID - Virtual Network Identifier
 VOQ - Virtual Output Queue


### PR DESCRIPTION
This change makes Doxygen output a viewer that has proper naming instead of a handful of pages named "SAI - Extension specific API definitions".

Before:

![image](https://github.com/opencomputeproject/SAI/assets/149442/32f0eb23-35c2-4fba-8977-30c529a5ea14)

After:

![image](https://github.com/opencomputeproject/SAI/assets/149442/c571f39b-bcd1-436b-9c74-625558c5989d)

Futhermore, as per doc/SAI-Extensions.md all experimental headers should have a `@warning`, so it was added as well.