### PR TITLE
Fix saithrift build issue for Bookworm SONiC

### DIFF
--- a/debian/copy_installer.sh
+++ b/debian/copy_installer.sh
@@ -1,11 +1,21 @@
 if [[ x"$1" =~ x"v2" ]]
 then
-   echo "Copy python3-saithrift.install as python-saithrift.install"
-   cp ./debian/installerFiles/python3-saithrift.install ./debian/python-saithrift.install
-else
-   if [ $(lsb_release -sr) -ge 11 ]
+   if [ $(lsb_release -sr) -ge 12 ]
    then
-      echo "Copy python3-saithrift.install as python-saithrift.install after Ver.11 releases"
+      echo "Copy python3-saithrift-bookworm.install as python-saithrift.install after Ver.12 releases"
+      cp ./debian/installerFiles/python3-saithrift-bookworm.install ./debian/python-saithrift.install
+   else
+      echo "Copy python3-saithrift.install as python-saithrift.install"
+      cp ./debian/installerFiles/python3-saithrift.install ./debian/python-saithrift.install
+   fi
+else
+   if [ $(lsb_release -sr) -ge 12 ]
+   then
+      echo "Copy python3-saithrift-bookworm.install as python-saithrift.install after Ver.12 releases"
+      cp ./debian/installerFiles/python3-saithrift-bookworm.install ./debian/python-saithrift.install
+   elif [ $(lsb_release -sr) -eq 11 ]
+   then
+      echo "Copy python3-saithrift.install as python-saithrift.install for Ver.11 releases"
       cp ./debian/installerFiles/python3-saithrift.install ./debian/python-saithrift.install
    else
       echo "Copy python2.7-saithrift.install as python-saithrift.install"

--- a/debian/installerFiles/python3-saithrift-bookworm.install
+++ b/debian/installerFiles/python3-saithrift-bookworm.install
@@ -1,0 +1,2 @@
+#compatiable with bookworm python 3.11 environment and build with python3
+debian/usr/local/local/lib/python3*/dist-packages/* /usr/lib/python3/dist-packages/


### PR DESCRIPTION
saithrift package is getting installed at different location for bookworm. Taking care it using copy_installer.sh script.
This change fixes build issue for both saithriftv1 and saithriftv2.