### PR TITLE
ARS Enhancements 

### DIFF
--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -3185,11 +3185,10 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_ACTION_SET_ARS_OBJECT = SAI_ACL_ENTRY_ATTR_ACTION_START + 0x36,
 
     /**
-     * @brief Disable ARS forwarding for a destination that can be a LAG or nexthopgroup
+     * @brief Enable ARS forwarding for a given match condition. This rule takes effect only when global ARS profile object is created and has binding to the switch
      *
-     * @type sai_acl_action_data_t sai_object_id_t
+     * @type sai_acl_action_data_t bool
      * @flags CREATE_AND_SET
-     * @objects SAI_OBJECT_TYPE_LAG, SAI_OBJECT_TYPE_NEXT_HOP_GROUP
      * @default disabled
      */
     SAI_ACL_ENTRY_ATTR_ACTION_DISABLE_ARS_FORWARDING = SAI_ACL_ENTRY_ATTR_ACTION_START + 0x37,

--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -3185,7 +3185,7 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_ACTION_SET_ARS_OBJECT = SAI_ACL_ENTRY_ATTR_ACTION_START + 0x36,
 
     /**
-     * @brief Enable ARS forwarding for a given match condition. This rule takes effect only when global ARS profile object is created and has binding to the switch
+     * @brief Disable ARS forwarding for a given match condition. This rule takes effect only when global ARS profile object is created and has binding to the switch
      *
      * @type sai_acl_action_data_t bool
      * @flags CREATE_AND_SET

--- a/inc/saiarsprofile.h
+++ b/inc/saiarsprofile.h
@@ -327,6 +327,24 @@ typedef enum _sai_ars_profile_attr_t
     SAI_ARS_PROFILE_ATTR_QUANT_BAND_7_MAX_THRESHOLD,
 
     /**
+     * @brief Enable IPv4 traffic (ether type) for ARS processing.
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_ARS_PROFILE_ATTR_ENABLE_IPV4,
+
+    /**
+     * @brief Enable IPv6 traffic (ether type) for ARS processing.
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_ARS_PROFILE_ATTR_ENABLE_IPV6,
+
+    /**
      * @brief End of attributes
      */
     SAI_ARS_PROFILE_ATTR_END,


### PR DESCRIPTION
New global attributes added to
1. Enable/DIsable IPv4 traffic
2. Enable/Disable IPv6 traffic

SAI_ACL_ENTRY_ATTR_ACTION_DISABLE_ARS_FORWARDING attribute modified as a data type bool.
Default value is ARS forwarding is enabled. Setting bool to true means that ARS forwarding is disabled.
1.  ACL ARS forwarding Enable and NHG with ARS binding: ARS forwarding takes effect
2. ACL ARS forwarding Enable and NHG without ARS binding: ACL entry is a noop and NHG forwarding takes effect.
3. ACL ARS forwarding Disable and NHG with ARS binding: NHG forwarding takes effect
4. ACL ARS forwarding Disable and NHG without ARS binding: ACL entry is a noop and NHG forwarding takes effect.
