### PR TITLE
Allow enum types starting with Ddash to be specified was attribute without DASH prefix.

### DIFF
--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -2429,17 +2429,17 @@ sub CheckEnumNaming
 {
     my ($attr, $type) = @_;
 
-    LogError "can't match sai type on '$type'" if not $type =~ /.*sai_(\w+)_t/;
+    LogError "can't match sai type on '$type'" if not $type =~ /.*sai_(dash_)?(\w+)_t/;
 
-    my $enumTypeName = uc($1);
+    my $enumTypeName = uc($2);
 
-    return if $attr =~ /_${enumTypeName}_LIST$/;
-    return if $attr =~ /_$enumTypeName$/;
+    return if $attr =~ /(_DASH)?_${enumTypeName}_LIST$/;
+    return if $attr =~ /(_DASH)?_$enumTypeName$/;
 
-    $attr =~ /SAI_(\w+?)_ATTR(_\w+?)(_LIST)?$/;
+    $attr =~ /SAI_(DASH_)?(\w+?)_ATTR(_\w+?)(_LIST)?$/;
 
-    my $attrObjectType = $1;
-    my $attrSuffix = $2;
+    my $attrObjectType = $2;
+    my $attrSuffix = $3;
 
     if ($enumTypeName =~ /^${attrObjectType}_(\w+)$/)
     {


### PR DESCRIPTION
In DASH, majority of the enums are defined with dash_ prefix, such as sai_dash_direction_t, sai_dash_encapsulation_t. To make the SAI attribute compatible with SAI naming convention, the attributes with enum types in DASH will have to also have the DASH_ prefix in the attribute name.

For example:

```c++
SAI_ENI_ATTR_DASH_TUNNEL_DSCP_MODE                 // Instead of SAI_ENI_ATTR_TUNNEL_DSCP_MODE  
SAI_OUTBOUND_ROUTING_ENTRY_ATTR_DASH_ENCAPSULATION // Instead of SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ENCAPSULATION
SAI_FLOW_ENTRY_ATTR_DASH_DIRECTION                 // Instead of SAI_FLOW_ENTRY_ATTR_DIRECTION
```

To help with this, I am wondering if we could allow the DASH_ prefix in the enum name, so we don't have to specify the DASH_ prefix anymore in the attribute name.