### PR TITLE
Revert "Tunnel Term Types - fixed the description for types and validity checks for mask attributes"

### DIFF
--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -914,13 +914,13 @@ typedef enum _sai_tunnel_term_table_entry_type_t
     /** Tunnel termination table point to point entry match on dst & src IP & tunnel type */
     SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2P,
 
-    /** Tunnel termination table point to multi point entry match on src IP & dst IP+mask & tunnel type */
+    /** Tunnel termination table destination point to multi point source entry match on dst IP & src IP+mask & tunnel type */
     SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2MP,
 
-    /** Tunnel termination table multi point to point entry match on src IP+mask & dst IP & tunnel type */
+    /** Tunnel termination table multi point destination to point source entry match on dst IP+mask & src IP & tunnel type */
     SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_MP2P,
 
-    /** Tunnel termination table multi point to multi point entry match on src IP+mask & dst IP+mask & tunnel type */
+    /** Tunnel termination table multi point to multi point entry match on dst IP+mask & src IP+mask & tunnel type */
     SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_MP2MP,
 
 } sai_tunnel_term_table_entry_type_t;
@@ -968,7 +968,7 @@ typedef enum _sai_tunnel_term_table_entry_attr_t
      * @type sai_ip_address_t
      * @flags CREATE_ONLY
      * @default 0.0.0.0
-     * @validonly SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2MP or SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_MP2MP
+     * @validonly SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_MP2P or SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_MP2MP
      */
     SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_DST_IP_MASK,
 
@@ -988,7 +988,7 @@ typedef enum _sai_tunnel_term_table_entry_attr_t
      * @type sai_ip_address_t
      * @flags CREATE_ONLY
      * @default 0.0.0.0
-     * @validonly SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_MP2P or SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_MP2MP
+     * @validonly SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2MP or SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE == SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_MP2MP
      */
     SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_SRC_IP_MASK,
 


### PR DESCRIPTION
Reverts opencomputeproject/SAI#1848

The Tunnel Term Type checks/changes are breaking backward compatibility, so pulling it back. The interpretation of the types are "switched", they are from the perspective of the peer.

For instance P2P = peer to peer
                      P2MP = (one destination from multiple sources)
                      MP2P = (multiple destinations from one source)
                      MP2MP = (multiple destinations from multiple destinations)