### PR TITLE
[meta] Add exception for sai_switch_health_data_t

### DIFF
--- a/meta/structs.pl
+++ b/meta/structs.pl
@@ -162,7 +162,8 @@ sub BuildCommitHistory
         # of union may not increase by adding members, and actual union size
         # check is performed by sai sanity check
 
-        if ($currCount != $histCount and not $structTypeName =~ /^sai_\w+_api_t$/)
+        if ($currCount != $histCount and not $structTypeName =~ /^sai_\w+_api_t$/
+                and $structTypeName ne "sai_switch_health_data_t")
         {
             LogError "FATAL: struct $structTypeName member count differs, was $histCount but is $currCount on commit $commit" if $type eq "struct";
         }

--- a/meta/test.pm
+++ b/meta/test.pm
@@ -619,6 +619,7 @@ sub CreateStructUnionSizeCheckTest
             $STRUCTS{$name} = $name;
 
             next if $name =~ /^sai_\w+_api_t$/; # skip api structs
+            next if $name eq "sai_switch_health_data_t";
 
             my $upname = uc($name);
 


### PR DESCRIPTION
This will add exception for breaking change SER Data #1982. Since new field is added to existing structure and it changes it size, but it is only used in notification, we allow this breaking change.

It still can cause issues, since that struct will have different size on the stack, and potentially it can read garbage memory or cause crash when using old headers and new SAI library