### PR TITLE
Upgrade the PR checker's slave container to Bullseye

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ stages:
   - job:
 
     container:
-      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:latest
+      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bullseye:latest
 
     displayName: "build"
     timeoutInMinutes: 60

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ stages:
   - job:
 
     container:
-      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-buster:latest
+      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:latest
 
     displayName: "build"
     timeoutInMinutes: 60
@@ -34,7 +34,7 @@ stages:
     - script: |
         set -ex
         sudo apt-get update
-        sudo apt-get install -y thrift-compiler libthrift-0.11.0 libthrift-dev
+        sudo apt-get install -y thrift-compiler libthrift-dev
       displayName: "Install thrift compiler"
     - script: |
         set -ex


### PR DESCRIPTION
Currently, the PR checkers are using the Buster slave container, but Debian Buster is two versions behind stable and is EOL. Since there are no artifacts built here that might get reused elsewhere, switch to using Debian Bullseye.

Debian Bookworm is the current stable version, but it looks like there is some generated code that is causing GCC errors.