### PR TITLE
Adding a new macsec port id attribute to macsec flow attributes

### DIFF
--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -459,7 +459,7 @@ typedef enum _sai_macsec_flow_attr_t
     SAI_MACSEC_FLOW_ATTR_SC_LIST,
 
     /**
-     * @brief MACsec Port object id to associate a macsec flow with MACsec Port id
+     * @brief MACsec Port object id to associate a MACsec flow with MACsec Port id
      *
      * @type sai_object_id_t
      * @flags CREATE_AND_SET

--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -463,6 +463,7 @@ typedef enum _sai_macsec_flow_attr_t
      *
      * @type sai_object_id_t
      * @flags CREATE_AND_SET
+     * @default 0
      * @objects SAI_OBJECT_TYPE_MACSEC_PORT
      */
     SAI_MACSEC_FLOW_ATTR_MACSEC_PORT_ID,

--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -459,6 +459,15 @@ typedef enum _sai_macsec_flow_attr_t
     SAI_MACSEC_FLOW_ATTR_SC_LIST,
 
     /**
+     * @brief MACsec Port object id to associate a macsec flow with MACsec Port id
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_MACSEC_PORT
+     */
+    SAI_MACSEC_FLOW_ATTR_MACSEC_PORT_ID,
+
+    /**
      * @brief End of MACsec Flow attributes
      */
     SAI_MACSEC_FLOW_ATTR_END,

--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -463,8 +463,8 @@ typedef enum _sai_macsec_flow_attr_t
      *
      * @type sai_object_id_t
      * @flags CREATE_AND_SET
-     * @default 0
      * @objects SAI_OBJECT_TYPE_MACSEC_PORT
+     * @default 0
      */
     SAI_MACSEC_FLOW_ATTR_MACSEC_PORT_ID,
 


### PR DESCRIPTION
For multi-octal devices with same MDIO address requires a relation between macsec flow and macsec port id.