### PR TITLE
Updating saimacsec.h to add macsec_port_id to flow obj

### DIFF
--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -459,17 +459,6 @@ typedef enum _sai_macsec_flow_attr_t
     SAI_MACSEC_FLOW_ATTR_SC_LIST,
 
     /**
-     * @brief MACsec Port object id to associate a MACsec flow with MACsec Port id
-     *
-     * @type sai_object_id_t
-     * @flags CREATE_ONLY
-     * @objects SAI_OBJECT_TYPE_MACSEC_PORT
-     * @allownull true
-     * @default SAI_NULL_OBJECT_ID
-     */
-    SAI_MACSEC_FLOW_ATTR_MACSEC_PORT_ID,
-
-    /**
      * @brief End of MACsec Flow attributes
      */
     SAI_MACSEC_FLOW_ATTR_END,
@@ -705,6 +694,17 @@ typedef enum _sai_macsec_sc_attr_t
      * @default true
      */
     SAI_MACSEC_SC_ATTR_ENCRYPTION_ENABLE,
+
+    /**
+     * @brief Bind MACsec Port object id with MACsec Secure Channel
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_ONLY
+     * @objects SAI_OBJECT_TYPE_MACSEC_PORT
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_MACSEC_SC_ATTR_MACSEC_PORT_ID,
 
     /**
      * @brief End of MACsec Secure Channel attributes

--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -459,6 +459,17 @@ typedef enum _sai_macsec_flow_attr_t
     SAI_MACSEC_FLOW_ATTR_SC_LIST,
 
     /**
+     * @brief MACsec Port object id to associate a MACsec flow with MACsec Port id
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_ONLY
+     * @objects SAI_OBJECT_TYPE_MACSEC_PORT
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_MACSEC_FLOW_ATTR_MACSEC_PORT_ID,
+
+    /**
      * @brief End of MACsec Flow attributes
      */
     SAI_MACSEC_FLOW_ATTR_END,


### PR DESCRIPTION
In the current implementation (without the proposed changes), there is no relation between secure flow, secure channel and the macsec_port_id/port. MACsec user is not able create a flow or secure channel for a particular core. This is an optional attiribute so this change won't break current macsec applications and the new attribute should only be used when there is a need to have a relation between flow, SC, SA and a port.

