### PR TITLE
Add action type to ENI ether address map entry to be consistent with all other DASH tables.

### DIFF
--- a/experimental/saiexperimentaldasheni.h
+++ b/experimental/saiexperimentaldasheni.h
@@ -36,6 +36,15 @@
  */
 
 /**
+ * @brief Attribute data for #SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION
+ */
+typedef enum _sai_eni_ether_address_map_entry_action_t
+{
+    SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI,
+
+} sai_eni_ether_address_map_entry_action_t;
+
+/**
  * @brief Entry for eni_ether_address_map_entry
  */
 typedef struct _sai_eni_ether_address_map_entry_t
@@ -65,6 +74,15 @@ typedef enum _sai_eni_ether_address_map_entry_attr_t
     SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_START,
 
     /**
+     * @brief Action
+     *
+     * @type sai_eni_ether_address_map_entry_action_t
+     * @flags CREATE_AND_SET
+     * @default SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ACTION_SET_ENI
+     */
+    SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ACTION = SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_START,
+
+    /**
      * @brief Action set_eni parameter ENI_ID
      *
      * @type sai_object_id_t
@@ -73,7 +91,7 @@ typedef enum _sai_eni_ether_address_map_entry_attr_t
      * @allownull true
      * @default SAI_NULL_OBJECT_ID
      */
-    SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID = SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_START,
+    SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID,
 
     /**
      * @brief End of attributes


### PR DESCRIPTION
Currently all DASH SAI table entries (not objects) will have an action type defined for it, even for a single action. This is for future proof in case we need to add any new action type in, so we will not break the ABI. 

However, due to an issue in the template, this action type is missing for eni ether address map entry. And we have this recently fixed in DASH, hence updating the API accordingly.