### PR TITLE
Add sai-thrift support to enable/disable CREDIT WATCHDOG  for Voq switch

### DIFF
--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -1619,7 +1619,6 @@ public:
       credit_wd_attribute.id = SAI_SWITCH_ATTR_CREDIT_WD;
       credit_wd_attribute.value.booldata =  switch_attr.value.booldata;
       attr_list.push_back(credit_wd_attribute);
-      printf("sai_thrift_get_switch_attribute credit_wd:%d\n", switch_attr.value.booldata);
   }
 
   sai_thrift_status_t sai_thrift_set_switch_attribute(const sai_thrift_attribute_t& thrift_attr) {
@@ -1645,7 +1644,6 @@ public:
               SAI_THRIFT_LOG_ERR("Switch is not VOQ switch!!!");
               return SAI_STATUS_NOT_SUPPORTED;
           }
-          printf("sai_thrift_set_switch_attribute credit_wd value:%d\n", thrift_attr.value.booldata);
       }
       sai_thrift_parse_switch_attribute(thrift_attr, &attr);
 

--- a/test/saithrift/tests/switch.py
+++ b/test/saithrift/tests/switch.py
@@ -101,6 +101,8 @@ def switch_init(client):
                     attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_ADMIN_STATE, value=attr_value)
                     client.sai_thrift_set_port_attribute(port_id, attr)
                     sai_port_list.append(port_id)
+        elif attribute.id == SAI_SWITCH_ATTR_CREDIT_WD
+            print "Credit Watchdog: " + attribute.value.booldata
         else:
             print "unknown switch attribute"
     attr_value = sai_thrift_attribute_value_t(mac=router_mac)


### PR DESCRIPTION
sonic-mgmt Qos tests disables the TX for the destination ports to induce the shared buffer full, nominal headroom full a, ingress drop and egress drop.

Voq systems like BCM DNX has credit watchdog timer running periodically to check if voq's and flush the data in the voq to prevent the data being stuck forever in the voq. So to avoid the credit watchdog timer flushing the voq during sonic-mgmt Qos tests, we need to disable the credit watchdog timer and enable it back after the test.

The SAI attribute SAI_SWITCH_ATTR_CREDIT_WD was not present in the older SAI versions and got added in SAI 10.X. So this PR adds the sai-thrift support to enable or disable the SAI_SWITCH_ATTR_CREDIT_WD for Voq systems.