### PR TITLE
[meta] Ignore SAI_PORT_BREAKOUT_MODE_TYPE_MAX when checking enum

### DIFF
--- a/meta/checkheaders.pl
+++ b/meta/checkheaders.pl
@@ -194,6 +194,7 @@ sub CheckHash
             next if $key eq "SAI_OBJECT_TYPE_MAX";
             next if $key eq "SAI_API_MAX";
             next if $key eq "SAI_PORT_INTERFACE_TYPE_MAX";
+            next if $key eq "SAI_PORT_BREAKOUT_MODE_TYPE_MAX";
 
             # NOTE: some other attributes/enum with END range could be added
         }


### PR DESCRIPTION
Will fix build issue