### PR TITLE
[meta] Remove error message on unsupported notification

### DIFF
--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -4962,7 +4962,6 @@ sub CreateSwitchNotificationsUpdateMethods
     }
 
     WriteSource "default:";
-    WriteSource "    SAI_META_LOG_ERROR(\"unsupported notification attribute id: %d\", attrs[idx].id);";
     WriteSource "    break;";
 
     WriteSource "}";


### PR DESCRIPTION
All notifications are supported in generated methods so any other attribute is actually a non pointer