### PR TITLE
Add port attribute to get the max debug data size.

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -2521,6 +2521,14 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_POE_PORT_ID,
 
     /**
+     * @brief The maximum size of SAI_PORT_ATTR_JSON_FORMATTED_DEBUG_DATA in bytes.
+     *
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_PORT_ATTR_JSON_FORMATTED_DEBUG_DATA_SIZE,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_ATTR_END,


### PR DESCRIPTION
Create a new port attribute to get the max size of the port debug data. This can be read by the NOS to determine the size of the buffer to allocate before reading the port debug data.