### PR TITLE
Support to get list of all reachable switch-id's from a fabric port

### DIFF
--- a/doc/VoQ/SAI-Proposal-VoQ-Switch.md
+++ b/doc/VoQ/SAI-Proposal-VoQ-Switch.md
@@ -764,6 +764,22 @@ typedef enum _sai_port_stat_t
 } sai_port_stat_t;
 ```
 
+### 2.3.9 Fabric Port Reachability Vector
+
+The port reachability vector attribute returns a vector that has all the remote switch ID reachable through this fabric port. The reachability vector attribute
+can be queried on each fabric port retrieved from the fabric port list switch attribute.
+
+```c
+
+/**
+* @brief Fabric port reachability for all remote reachable switches
+*
+* @type sai_u16_list_t
+* @flags READ_ONLY
+*/
+    SAI_PORT_ATTR_FABRIC_REACHABILITY_VECTOR,
+```
+
 ## 2.4 Queue Attributes, Types, and APIs
 
 ## 2.4.1 New Queue Types

--- a/doc/VoQ/SAI-Proposal-VoQ-Switch.md
+++ b/doc/VoQ/SAI-Proposal-VoQ-Switch.md
@@ -764,9 +764,9 @@ typedef enum _sai_port_stat_t
 } sai_port_stat_t;
 ```
 
-### 2.3.9 Fabric Port Reachability Vector
+### 2.3.9 Fabric Port Reachability List
 
-The port reachability vector attribute returns a vector that has all the remote switch ID reachable through this fabric port. The reachability vector attribute
+The port reachability list attribute returns a list, that has all the remote switch ID reachable through this fabric port. The reachability list attribute
 can be queried on each fabric port retrieved from the fabric port list switch attribute.
 
 ```c
@@ -777,7 +777,7 @@ can be queried on each fabric port retrieved from the fabric port list switch at
 * @type sai_u16_list_t
 * @flags READ_ONLY
 */
-    SAI_PORT_ATTR_FABRIC_REACHABILITY_VECTOR,
+    SAI_PORT_ATTR_FABRIC_REACHABILITY_LIST,
 ```
 
 ## 2.4 Queue Attributes, Types, and APIs

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -2521,6 +2521,14 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_POE_PORT_ID,
 
     /**
+     * @brief Fabric port reachability for all remote reachable switches
+     *
+     * @type sai_u16_list_t
+     * @flags READ_ONLY
+     */
+    SAI_PORT_ATTR_FABRIC_REACHABILITY_VECTOR,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_ATTR_END,

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -2526,7 +2526,7 @@ typedef enum _sai_port_attr_t
      * @type sai_u16_list_t
      * @flags READ_ONLY
      */
-    SAI_PORT_ATTR_FABRIC_REACHABILITY_VECTOR,
+    SAI_PORT_ATTR_FABRIC_REACHABILITY_LIST,
 
     /**
      * @brief End of attributes


### PR DESCRIPTION
Adding support to get a list of all reachable switch-id's from a fabric port, currently we can only check from switch-id if its reachable or not .

SAI_PORT_ATTR_FABRIC_REACHABILITY_LIST