### PR TITLE
Add label attribute for Policer, RIF, Scheduler and UDF

### DIFF
--- a/inc/saipolicer.h
+++ b/inc/saipolicer.h
@@ -232,6 +232,15 @@ typedef enum _sai_policer_attr_t
     SAI_POLICER_ATTR_SELECTIVE_COUNTER_LIST,
 
     /**
+     * @brief Label attribute used to uniquely identify identical policers.
+     *
+     * @type char
+     * @flags CREATE_AND_SET
+     * @default ""
+     */
+    SAI_POLICER_ATTR_LABEL,
+
+    /**
      * @brief End of attributes
      */
     SAI_POLICER_ATTR_END,

--- a/inc/sairouterinterface.h
+++ b/inc/sairouterinterface.h
@@ -317,6 +317,15 @@ typedef enum _sai_router_interface_attr_t
     SAI_ROUTER_INTERFACE_ATTR_SELECTIVE_COUNTER_LIST,
 
     /**
+     * @brief Label attribute used to uniquely identify router interface.
+     *
+     * @type char
+     * @flags CREATE_AND_SET
+     * @default ""
+     */
+    SAI_ROUTER_INTERFACE_ATTR_LABEL,
+
+    /**
      * @brief End of attributes
      */
     SAI_ROUTER_INTERFACE_ATTR_END,

--- a/inc/saischeduler.h
+++ b/inc/saischeduler.h
@@ -130,6 +130,15 @@ typedef enum _sai_scheduler_attr_t
     SAI_SCHEDULER_ATTR_MAX_BANDWIDTH_BURST_RATE = 0x00000006,
 
     /**
+     * @brief Label attribute used to uniquely identify scheduler.
+     *
+     * @type char
+     * @flags CREATE_AND_SET
+     * @default ""
+     */
+    SAI_SCHEDULER_ATTR_LABEL,
+
+    /**
      * @brief End of attributes
      */
     SAI_SCHEDULER_ATTR_END,

--- a/inc/saiudf.h
+++ b/inc/saiudf.h
@@ -259,6 +259,15 @@ typedef enum _sai_udf_group_attr_t
     SAI_UDF_GROUP_ATTR_LENGTH,
 
     /**
+     * @brief Label attribute used to uniquely identify UDF group.
+     *
+     * @type char
+     * @flags CREATE_AND_SET
+     * @default ""
+     */
+    SAI_UDF_GROUP_ATTR_LABEL,
+
+    /**
      * @brief End of attributes
      */
     SAI_UDF_GROUP_ATTR_END,

--- a/meta/aspell.en.pws
+++ b/meta/aspell.en.pws
@@ -144,6 +144,7 @@ PGs
 PHY
 pkts
 policer
+policers
 Policer
 postcursor
 pre


### PR DESCRIPTION
Add label attribute to a few SAI objects that will help during warmboot object matching.