### PR TITLE
Extended port operational status with various error and fault status

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -75,6 +75,57 @@ typedef enum _sai_port_oper_status_t
 } sai_port_oper_status_t;
 
 /**
+ * @brief Attribute data for #SAI_PORT_ATTR_ERROR_STATUS
+ * Note enum values must be powers of 2 to be used as Bit mask to query multiple errors
+ *
+ * @flags free
+ */
+typedef enum _sai_port_error_status_t
+{
+    /** No errors */
+    SAI_PORT_ERROR_STATUS_CLEAR = 0,
+
+    /** MAC Local fault asserted */
+    SAI_PORT_ERROR_STATUS_MAC_LOCAL_FAULT = 1 << 0,
+
+    /** MAC Remote fault asserted */
+    SAI_PORT_ERROR_STATUS_MAC_REMOTE_FAULT = 1 << 1,
+
+    /** FEC loss of sync asserted */
+    SAI_PORT_ERROR_STATUS_FEC_SYNC_LOSS = 1 << 2,
+
+    /** FEC loss of alignment marker asserted */
+    SAI_PORT_ERROR_STATUS_FEC_LOSS_ALIGNMENT_MARKER = 1 << 3,
+
+    /** High SER asserted */
+    SAI_PORT_ERROR_STATUS_HIGH_SER = 1 << 4,
+
+    /** High BER asserted */
+    SAI_PORT_ERROR_STATUS_HIGH_BER = 1 << 5,
+
+    /** Rate of data units with CRC errors passed its threshold */
+    SAI_PORT_ERROR_STATUS_CRC_RATE = 1 << 6,
+
+    /** Data Unit CRC Error */
+    SAI_PORT_ERROR_STATUS_DATA_UNIT_CRC_ERROR = 1 << 7,
+
+    /** Data Unit Size Error */
+    SAI_PORT_ERROR_STATUS_DATA_UNIT_SIZE = 1 << 8,
+
+    /** Data Unit Misalignment Error */
+    SAI_PORT_ERROR_STATUS_DATA_UNIT_MISALIGNMENT_ERROR = 1 << 9,
+
+    /** Uncorrectable RS-FEC code word error */
+    SAI_PORT_ERROR_STATUS_CODE_GROUP_ERROR = 1 << 10,
+
+    /** SerDes Signal is out of sync */
+    SAI_PORT_ERROR_STATUS_SIGNAL_LOCAL_ERROR = 1 << 11,
+
+    /** Port is not accepting reachability data units */
+    SAI_PORT_ERROR_STATUS_NO_RX_REACHABILITY = 1 << 12
+} sai_port_error_status_t;
+
+/**
  * @brief Defines the operational status of the port
  */
 typedef struct _sai_port_oper_status_notification_t
@@ -89,6 +140,8 @@ typedef struct _sai_port_oper_status_notification_t
     /** Port operational status */
     sai_port_oper_status_t port_state;
 
+    /** Bitmap of various port error or fault status */
+    sai_port_error_status_t port_error_status;
 } sai_port_oper_status_notification_t;
 
 /**
@@ -1935,6 +1988,7 @@ typedef enum _sai_port_attr_t
      *
      * @type sai_port_err_status_list_t
      * @flags READ_ONLY
+     * @deprecated true
      */
     SAI_PORT_ATTR_ERR_STATUS_LIST,
 
@@ -2536,6 +2590,18 @@ typedef enum _sai_port_attr_t
      * @default false
      */
     SAI_PORT_ATTR_UNRELIABLE_LOS,
+
+    /**
+     * @brief Various port error status
+     *
+     * Attribute to query the capability of the Switch to report
+     * various port error and fault status. The attribute can also
+     * be used to query the current port error and fault status.
+     *
+     * @type sai_port_error_status_t
+     * @flags READ_ONLY
+     */
+    SAI_PORT_ATTR_ERROR_STATUS,
 
     /**
      * @brief End of attributes

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1373,7 +1373,9 @@ typedef struct _sai_fabric_port_reachability_t
 } sai_fabric_port_reachability_t;
 
 /**
- * @brief Port error status
+ * @brief Port error status. This attribute is to be deprecated. Use sai_port_error_status_t instead.
+ *
+ * @deprecated true
  */
 typedef enum _sai_port_err_status_t
 {

--- a/meta/acronyms.txt
+++ b/meta/acronyms.txt
@@ -7,6 +7,7 @@ API - Application Program Interface
 ARP - Address Resolution Protocol
 ARS - Adaptiver Routing and Switching
 ASIC - Application Specific Integrated Circuit
+BER - Bit Error Rate
 BFD - Bidirectional Forwarding Detection
 BFDV6 - Bidirectional Forwarding Detection for IPv6
 BGP - Border Gateway Protocol

--- a/meta/saiserializetest.c
+++ b/meta/saiserializetest.c
@@ -1412,7 +1412,7 @@ void test_serialize_notifications()
     memset(&data1, 0, sizeof(data1));
 
     res = sai_serialize_port_state_change_notification(buf, 1, &data1);
-    ret = "{\"count\":1,\"data\":[{\"port_id\":\"oid:0x0\",\"port_state\":\"SAI_PORT_OPER_STATUS_UNKNOWN\"}]}";
+    ret = "{\"count\":1,\"data\":[{\"port_id\":\"oid:0x0\",\"port_state\":\"SAI_PORT_OPER_STATUS_UNKNOWN\",\"port_error_status\":\"SAI_PORT_ERROR_STATUS_CLEAR\"}]}";
     ASSERT_STR_EQ(buf, ret , res);
 
     sai_queue_deadlock_notification_data_t data2;

--- a/meta/structs.pl
+++ b/meta/structs.pl
@@ -165,7 +165,8 @@ sub BuildCommitHistory
         # check is performed by sai sanity check
 
         if ($currCount != $histCount and not $structTypeName =~ /^sai_\w+_api_t$/
-                and $structTypeName ne "sai_switch_health_data_t")
+                and $structTypeName ne "sai_switch_health_data_t"
+                and $structTypeName ne "sai_port_oper_status_notification_t")
         {
             LogError "FATAL: struct $structTypeName member count differs, was $histCount but is $currCount on commit $commit" if $type eq "struct";
         }


### PR DESCRIPTION
Port status change notification now adds additional field to indicate various port error/fault status that caused the port operational status to go down. A capability attribute is added to query the Switch's capability that can be used to know if the new fault/error status are supported in the port status change notification.


`sai_port_error_status_t` bitmap can indicate more than one port error conditions by setting the corresponding error bit indicating why the port went down. Ideally, when the port operational status goes UP, the bitmap value should be ZERO i.e no errors.

Adding the error status as part of the port link status change notification allows better correlation of port operational status with various port error/fault conditions events that may have caused the port down event.
