### PR TITLE
Support Unreliable Loss Of Signal

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -2529,6 +2529,15 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_JSON_FORMATTED_DEBUG_DATA_SIZE,
 
     /**
+     * @brief Support unreliable loss of signal
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_PORT_ATTR_UNRELIABLE_LOSS_OF_SIGNAL,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_ATTR_END,


### PR DESCRIPTION
Old PR is closed because of stale code conflict.
https://github.com/opencomputeproject/SAI/pull/2059

Add boolean to enable/disable ULOS setting on a port.

ULOS off on a port if it is currently on, and only turns it on if it is currently off.  This will prevent link flaps during warm boot, and will present link flaps on ports that don’t need Unreliable LOS (when set to auto). Managing the auto setting is done by SONiC xcvrd daemon and it does all the validations needed finally translating the action into enable/disable ULOS setting.
