### PR TITLE
Unreliable LOS

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -2529,6 +2529,15 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_JSON_FORMATTED_DEBUG_DATA_SIZE,
 
     /**
+     * @brief Unreliable Loss of Signal
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_PORT_ATTR_UNRELIABLE_LOS,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_ATTR_END,


### PR DESCRIPTION
Enable/Disable Control for Unreliable Loss of Signal

Closed the old PR because of enum shift.
https://github.com/opencomputeproject/SAI/pull/2059
