### PR TITLE
Hostif trap type for Subnet routes

### DIFF
--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -343,6 +343,13 @@ typedef enum _sai_hostif_trap_type_t
      */
     SAI_HOSTIF_TRAP_TYPE_ISIS = 0x00002014,
 
+    /**
+     * @brief Packets matching subnet routes with NH pointing to router interface
+     * i.e., no neighbor entry route is present
+     * (default packet action is trap)
+     */
+    SAI_HOSTIF_TRAP_TYPE_NEIGHBOR_MISS = 0x00002015,
+
     /** Router traps custom range start */
     SAI_HOSTIF_TRAP_TYPE_ROUTER_CUSTOM_RANGE_BASE = 0x00003000,
 


### PR DESCRIPTION
Fixes #2037 

When an IP address and subnet, say  _**10.1.1.1/24**_ is on a RIF, the following set of routes are created as per SAI:

```
2024-10-07.14:41:31.066482|c|SAI_OBJECT_TYPE_ROUTER_INTERFACE:oid:0x60000000004f2|SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID=oid:0x3000000000276|SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS=00:30:64:68:63:43|SAI_ROUTER_INTERFACE_ATTR_TYPE=SAI_ROUTER_INTERFACE_TYPE_PORT|SAI_ROUTER_INTERFACE_ATTR_PORT_ID=oid:0x1000000000132|SAI_ROUTER_INTERFACE_ATTR_MTU=9100
2024-10-07.14:41:31.071107|c|SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"10.1.1.1/32","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000276"}|SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION=SAI_PACKET_ACTION_FORWARD|SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID=oid:0x1000000000125
2024-10-07.14:41:31.081518|C|SAI_OBJECT_TYPE_ROUTE_ENTRY||{"dest":"10.1.1.0/24","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000276"}|SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID=oid:0x60000000004f2
```

1.  10.1.1.1/32 to CPU (SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID points to CPU port). The CPU queuing is controlled using SAI\_HOSTIF\_TRAP\_TYPE\_IP2ME,
2.  _**10.1.1.X/24 route**_ : **This route points to CPU (In the SAI API model, this is done by setting SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID as the RIF).  However, there is no standard hostif trap defined to control the CPU queuing behavior.**

Note: Both the routes are created with SAI_PACKET_ACTION_FORWARD.