### PR TITLE
Include the metadata headers in the generated SWIG bindings

### DIFF
--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -5498,13 +5498,22 @@ sub CreateSaiSwigApiStructs
     }
 
     my @headers = GetHeaderFiles();
+    my @metaheaders = GetMetaHeaderFiles();
     my @exheaders = GetExperimentalHeaderFiles();
 
-    my @merged = (@headers, @exheaders);
+    push(@metaheaders, "saimetadata.h");
+
+    my @merged = (@headers, @metaheaders, @exheaders);
+
+    WriteSwig "%ignore sai_metadata_log;";
+    WriteSwig "%ignore sai_metadata_log_level;";
+    WriteSwig "%ignore sai_free_attribute;";
 
     for my $header (sort @merged)
     {
+        WriteSwig "%nodefaultctor;" if $header =~ /saimetadatatypes\.h/;
         WriteSwig "%include \"$header\"";
+        WriteSwig "%clearnodefaultctor;" if $header =~ /saimetadatatypes\.h/;
     }
 }
 


### PR DESCRIPTION
In the generated SWIG bindings, include access to the metadata functions from other scripting languages (such as Python). This allows access to functions that indicate what object type an OID represents (`sai_metadata_get_object_type_name`) as well as metadata of an attribute (`sai_metadata_get_attr_metadata`).

As part of this, some workarounds are needed to either ignore certain types/functions or to not try to generate constructors. This is because of const qualifier issues:

```
pysairedis_wrap.cpp: In function 'PyObject* Swig_var_sai_metadata_log_get()':
pysairedis_wrap.cpp:3318:49: error: invalid 'static_cast' from type 'void (* volatile*)(sai_log_level_t, const char*, int, const char*, const char*, ...)' {aka 'void (* volatile*)(_sai_log_level_t, const char*, int, const char*, const char*, ...)'} to type 'const void*'
 3318 | #define SWIG_as_voidptr(a) const_cast< void * >(static_cast< const void * >(a))
      |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pysairedis_wrap.cpp:1092:89: note: in definition of macro 'SWIG_NewPointerObj'
 1092 | #define SWIG_NewPointerObj(ptr, type, flags)            SWIG_Python_NewPointerObj(NULL, ptr, type, flags)
      |                                                                                         ^~~
pysairedis_wrap.cpp:108691:30: note: in expansion of macro 'SWIG_as_voidptr'
108691 |   pyobj = SWIG_NewPointerObj(SWIG_as_voidptr(&sai_metadata_log), SWIGTYPE_p_p_f_enum__sai_log_level_t_p_q_const__char_int_p_q_const__char_p_q_const__char_v_______void,  0 );
       |                              ^~~~~~~~~~~~~~~
pysairedis_wrap.cpp: In function 'int Swig_var_sai_metadata_log_level_set(PyObject*)':
pysairedis_wrap.cpp:108700:39: error: 'reinterpret_cast' from type 'volatile sai_log_level_t*' {aka 'volatile _sai_log_level_t*'} to type 'int*' casts away qualifiers
108700 |     int ecode = SWIG_AsVal_int (_val, reinterpret_cast< int* >(&sai_metadata_log_level));
       |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
pysairedis_wrap.cpp: In function 'PyObject* _wrap_new_sai_attr_condition_t(PyObject*, PyObject*)':
pysairedis_wrap.cpp:108999:63: error: use of deleted function '_sai_attr_condition_t::_sai_attr_condition_t()'
108999 |   result = (_sai_attr_condition_t *)new _sai_attr_condition_t();
       |                                                               ^
In file included from pysairedis_wrap.cpp:3401:
../../SAI/meta/saimetadatatypes.h:730:16: note: '_sai_attr_condition_t::_sai_attr_condition_t()' is implicitly deleted because the default definition would be ill-formed:
  730 | typedef struct _sai_attr_condition_t
      |                ^~~~~~~~~~~~~~~~~~~~~
../../SAI/meta/saimetadatatypes.h:730:16: error: uninitialized const member in 'struct _sai_attr_condition_t'
../../SAI/meta/saimetadatatypes.h:742:41: note: 'const sai_attribute_value_t _sai_attr_condition_t::condition' should be initialized
  742 |     const sai_attribute_value_t         condition;
      |                                         ^~~~~~~~~
pysairedis_wrap.cpp: In function 'PyObject* _wrap_new_sai_enum_metadata_t(PyObject*, PyObject*)':
pysairedis_wrap.cpp:109362:61: error: use of deleted function '_sai_enum_metadata_t::_sai_enum_metadata_t()'
109362 |   result = (_sai_enum_metadata_t *)new _sai_enum_metadata_t();
       |                                                             ^
In file included from pysairedis_wrap.cpp:3401:
../../SAI/meta/saimetadatatypes.h:814:16: note: '_sai_enum_metadata_t::_sai_enum_metadata_t()' is implicitly deleted because the default definition would be ill-formed:
  814 | typedef struct _sai_enum_metadata_t
      |                ^~~~~~~~~~~~~~~~~~~~
../../SAI/meta/saimetadatatypes.h:814:16: error: uninitialized const member in 'struct _sai_enum_metadata_t'
../../SAI/meta/saimetadatatypes.h:819:37: note: 'const char* const _sai_enum_metadata_t::name' should be initialized
  819 |     const char* const               name;
      |                                     ^~~~
../../SAI/meta/saimetadatatypes.h:814:16: error: uninitialized const member in 'struct _sai_enum_metadata_t'
  814 | typedef struct _sai_enum_metadata_t
      |                ^~~~~~~~~~~~~~~~~~~~
../../SAI/meta/saimetadatatypes.h:824:37: note: 'const size_t _sai_enum_metadata_t::valuescount' should be initialized
  824 |     const size_t                    valuescount;
      |                                     ^~~~~~~~~~~
../../SAI/meta/saimetadatatypes.h:814:16: error: uninitialized const member in 'struct _sai_enum_metadata_t'
  814 | typedef struct _sai_enum_metadata_t
      |                ^~~~~~~~~~~~~~~~~~~~
```