### PR TITLE
Add sai-thrift support to enable/disable CREDIT WATCHDOG  for Voq switch (cherry-pick PR #2010)

### DIFF
--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -1596,6 +1596,29 @@ public:
       }
       attr_list.push_back(thrift_port_list_attribute);
       free(port_list_object_attribute.value.objlist.list);
+
+      sai_attribute_t switch_attr;
+      switch_attr.id = SAI_SWITCH_ATTR_TYPE;
+      status = switch_api->get_switch_attribute(gSwitchId, 1, &switch_attr);
+      if (status != SAI_STATUS_SUCCESS) {
+          SAI_THRIFT_LOG_ERR("get_switch_attribute failed!!!");
+          return;
+      }
+      if (switch_attr.value.u32 != SAI_SWITCH_TYPE_VOQ) {
+          return;
+      }
+      switch_attr.id = SAI_SWITCH_ATTR_CREDIT_WD;
+      status = switch_api->get_switch_attribute(gSwitchId, 1, &switch_attr);
+      if (status != SAI_STATUS_SUCCESS) {
+          SAI_THRIFT_LOG_ERR("get_switch_attribute failed!!!");
+          return;
+      }
+
+      sai_thrift_attribute_t credit_wd_attribute;
+      thrift_attr_list.attr_count = 2;
+      credit_wd_attribute.id = SAI_SWITCH_ATTR_CREDIT_WD;
+      credit_wd_attribute.value.booldata =  switch_attr.value.booldata;
+      attr_list.push_back(credit_wd_attribute);
   }
 
   sai_thrift_status_t sai_thrift_set_switch_attribute(const sai_thrift_attribute_t& thrift_attr) {
@@ -1609,6 +1632,19 @@ public:
           return status;
       }
 
+      if (thrift_attr.id == SAI_SWITCH_ATTR_CREDIT_WD)
+      {
+          attr.id = SAI_SWITCH_ATTR_TYPE;
+          status = switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+          if (status != SAI_STATUS_SUCCESS) {
+              SAI_THRIFT_LOG_ERR("get_switch_attribute failed!!!");
+              return status;
+          }
+          if (attr.value.u32 != SAI_SWITCH_TYPE_VOQ) {
+              SAI_THRIFT_LOG_ERR("Switch is not VOQ switch!!!");
+              return SAI_STATUS_NOT_SUPPORTED;
+          }
+      }
       sai_thrift_parse_switch_attribute(thrift_attr, &attr);
 
       status = switch_api->set_switch_attribute(gSwitchId, &attr);
@@ -1638,6 +1674,10 @@ public:
 
           case SAI_SWITCH_ATTR_LAG_DEFAULT_HASH_SEED:
               attr->value.u32 = thrift_attr.value.u32;
+              break;
+
+          case SAI_SWITCH_ATTR_CREDIT_WD:
+              attr->value.booldata = thrift_attr.value.booldata;
               break;
 
           default:

--- a/test/saithrift/tests/switch.py
+++ b/test/saithrift/tests/switch.py
@@ -101,6 +101,8 @@ def switch_init(client):
                     attr = sai_thrift_attribute_t(id=SAI_PORT_ATTR_ADMIN_STATE, value=attr_value)
                     client.sai_thrift_set_port_attribute(port_id, attr)
                     sai_port_list.append(port_id)
+        elif attribute.id == SAI_SWITCH_ATTR_CREDIT_WD
+            print "Credit Watchdog: " + attribute.value.booldata
         else:
             print "unknown switch attribute"
     attr_value = sai_thrift_attribute_value_t(mac=router_mac)


### PR DESCRIPTION

sonic-mgmt Qos tests disables the TX for the destination ports to induce the shared buffer full, nominal headroom full a, ingress drop and egress drop.

Voq systems like BCM DNX has credit watchdog timer running periodically to check if voq's and flush the data in the voq to prevent the data being stuck forever in the voq. So to avoid the credit watchdog timer flushing the voq during sonic-mgmt Qos tests, we need to disable the credit watchdog timer and enable it back after the test.

The SAI attribute SAI_SWITCH_ATTR_CREDIT_WD was not present in the older SAI versions and got added in SAI 10.X. So this PR adds the sai-thrift support to enable or disable the SAI_SWITCH_ATTR_CREDIT_WD for Voq systems.