### PR TITLE
Allow sparse mode fdb mac program on vlan member

### DIFF
--- a/inc/saifdb.h
+++ b/inc/saifdb.h
@@ -139,7 +139,7 @@ typedef enum _sai_fdb_entry_attr_t
      *
      * @type sai_object_id_t
      * @flags CREATE_AND_SET
-     * @objects SAI_OBJECT_TYPE_BRIDGE_PORT
+     * @objects SAI_OBJECT_TYPE_BRIDGE_PORT, SAI_OBJECT_TYPE_VLAN_MEMBER
      * @allownull true
      * @default SAI_NULL_OBJECT_ID
      */


### PR DESCRIPTION
There is a single bridge port on the port, and this bridge port, along with a VLAN, is used to create a VLAN member. When a MAC address is learned with a specific VLAN on a bridge port that has multiple VLAN members, it is necessary to specify the VLAN member.