### PR TITLE
Add ACL actions for setting inner MACs

### DIFF
--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -291,6 +291,12 @@ typedef enum _sai_acl_action_type_t
 
     /** Disable packet trim */
     SAI_ACL_ACTION_TYPE_PACKET_TRIM_DISABLE = 0x00000039,
+
+    /** Set Packet inner Src MAC Address */
+    SAI_ACL_ACTION_TYPE_SET_INNER_SRC_MAC = 0x0000003a,
+
+    /** Set Packet inner Dst MAC Address */
+    SAI_ACL_ACTION_TYPE_SET_INNER_DST_MAC = 0x0000003b,
 } sai_acl_action_type_t;
 
 /**
@@ -3304,9 +3310,27 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_ACTION_PACKET_TRIM_DISABLE = SAI_ACL_ENTRY_ATTR_ACTION_START + 0x39,
 
     /**
+     * @brief Set Packet Inner Src MAC Address
+     *
+     * @type sai_acl_action_data_t sai_mac_t
+     * @flags CREATE_AND_SET
+     * @default disabled
+     */
+    SAI_ACL_ENTRY_ATTR_ACTION_SET_INNER_SRC_MAC = SAI_ACL_ENTRY_ATTR_ACTION_START + 0x3a,
+
+    /**
+     * @brief Set Packet Inner Dst MAC Address
+     *
+     * @type sai_acl_action_data_t sai_mac_t
+     * @flags CREATE_AND_SET
+     * @default disabled
+     */
+    SAI_ACL_ENTRY_ATTR_ACTION_SET_INNER_DST_MAC = SAI_ACL_ENTRY_ATTR_ACTION_START + 0x3b,
+
+    /**
      * @brief End of Rule Actions
      */
-    SAI_ACL_ENTRY_ATTR_ACTION_END = SAI_ACL_ENTRY_ATTR_ACTION_PACKET_TRIM_DISABLE,
+    SAI_ACL_ENTRY_ATTR_ACTION_END = SAI_ACL_ENTRY_ATTR_ACTION_SET_INNER_DST_MAC,
 
     /**
      * @brief End of ACL Entry attributes


### PR DESCRIPTION
Add actions SET_INNER_SRC_MAC and SET_INNER_DST_MAC for tunneled packets to be able to override inner
values independently from router based on ACL policy.