### PR TITLE
[meta] Use strinct flags on sai_port_error_status_t

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -76,9 +76,10 @@ typedef enum _sai_port_oper_status_t
 
 /**
  * @brief Attribute data for #SAI_PORT_ATTR_ERROR_STATUS
+ *
  * Note enum values must be powers of 2 to be used as Bit mask to query multiple errors
  *
- * @flags free
+ * @flags strict
  */
 typedef enum _sai_port_error_status_t
 {

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -5574,6 +5574,13 @@ void check_enum_flags_type_strict(
 
         size_t i = 0;
 
+        if (emd->values[0] == 0)
+        {
+            /* first value in strict flags is zero (no flags, we allow this case) */
+
+            i = 1;
+        }
+
         for (; i < emd->valuescount; ++i)
         {
             int val = emd->values[i];


### PR DESCRIPTION
Mark flags as string on sai_port_error_status_t, also allow metadata to correctly validate first entry with value zero.