### PR TITLE
Add ENI mac selection attributes and tunnel learning attributes in DASH.

### DIFF
--- a/experimental/saiexperimentaldashdirectionlookup.h
+++ b/experimental/saiexperimentaldashdirectionlookup.h
@@ -83,6 +83,15 @@ typedef enum _sai_direction_lookup_entry_attr_t
     SAI_DIRECTION_LOOKUP_ENTRY_ATTR_ACTION = SAI_DIRECTION_LOOKUP_ENTRY_ATTR_START,
 
     /**
+     * @brief Action parameter DASH ENI MAC override type
+     *
+     * @type sai_dash_eni_mac_override_type_t
+     * @flags CREATE_AND_SET
+     * @default SAI_DASH_ENI_MAC_OVERRIDE_TYPE_NONE
+     */
+    SAI_DIRECTION_LOOKUP_ENTRY_ATTR_DASH_ENI_MAC_OVERRIDE_TYPE,
+
+    /**
      * @brief End of attributes
      */
     SAI_DIRECTION_LOOKUP_ENTRY_ATTR_END,

--- a/experimental/saiexperimentaldasheni.h
+++ b/experimental/saiexperimentaldasheni.h
@@ -528,6 +528,24 @@ typedef enum _sai_eni_attr_t
     SAI_ENI_ATTR_IS_HA_FLOW_OWNER,
 
     /**
+     * @brief Action parameter enable reverse tunnel learning
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_ENI_ATTR_ENABLE_REVERSE_TUNNEL_LEARNING,
+
+    /**
+     * @brief Action parameter reverse tunnel sip
+     *
+     * @type sai_ip_address_t
+     * @flags CREATE_AND_SET
+     * @default 0.0.0.0
+     */
+    SAI_ENI_ATTR_REVERSE_TUNNEL_SIP,
+
+    /**
      * @brief End of attributes
      */
     SAI_ENI_ATTR_END,

--- a/experimental/saitypesextensions.h
+++ b/experimental/saitypesextensions.h
@@ -279,5 +279,18 @@ typedef enum _sai_dash_flow_entry_bulk_get_session_filter_key_t
 
 } sai_dash_flow_entry_bulk_get_session_filter_key_t;
 
+/**
+ * @brief Defines a list of enums for dash_eni_mac_override_type
+ */
+typedef enum _sai_dash_eni_mac_override_type_t
+{
+    SAI_DASH_ENI_MAC_OVERRIDE_TYPE_NONE,
+
+    SAI_DASH_ENI_MAC_OVERRIDE_TYPE_SRC_MAC,
+
+    SAI_DASH_ENI_MAC_OVERRIDE_TYPE_DST_MAC,
+
+} sai_dash_eni_mac_override_type_t;
+
 #endif /* __SAITYPESEXTENSIONS_H_ */
 


### PR DESCRIPTION
This change adds the ENI mac selection APIs and reverse tunnel learning attributes in DASH.

The API follows the ExpressRoute gateway bypass HLD in DASH: <https://github.com/sonic-net/DASH/blob/main/documentation/express-route-service/express-route-gateway-bypass.md>.