### PR TITLE
Add occupancy and watermark counters in cells

### DIFF
--- a/inc/saibuffer.h
+++ b/inc/saibuffer.h
@@ -150,6 +150,24 @@ typedef enum _sai_ingress_priority_group_stat_t
     /** Get dropped packets count [uint64_t] */
     SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS = 0x00000008,
 
+    /** Get current pg occupancy in cells [uint64_t] */
+    SAI_INGRESS_PRIORITY_GROUP_STAT_CURR_OCCUPANCY_CELLS = 0x00000009,
+
+    /** Get watermark pg occupancy in cells [uint64_t] */
+    SAI_INGRESS_PRIORITY_GROUP_STAT_WATERMARK_CELLS = 0x0000000a,
+
+    /** Get current pg shared occupancy in cells [uint64_t] */
+    SAI_INGRESS_PRIORITY_GROUP_STAT_SHARED_CURR_OCCUPANCY_CELLS = 0x0000000b,
+
+    /** Get watermark pg shared occupancy in cells [uint64_t] */
+    SAI_INGRESS_PRIORITY_GROUP_STAT_SHARED_WATERMARK_CELLS = 0x0000000c,
+
+    /** Get current pg XOFF room occupancy in cells [uint64_t] */
+    SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_CURR_OCCUPANCY_CELLS = 0x0000000d,
+
+    /** Get watermark pg XOFF room occupancy in cells [uint64_t] */
+    SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_CELLS = 0x0000000e,
+
     /** Custom range base value */
     SAI_INGRESS_PRIORITY_GROUP_STAT_CUSTOM_RANGE_BASE = 0x10000000
 
@@ -471,6 +489,18 @@ typedef enum _sai_buffer_pool_stat_t
 
     /** Get headroom pool occupancy in bytes [uint64_t] */
     SAI_BUFFER_POOL_STAT_XOFF_ROOM_WATERMARK_BYTES = 0x00000014,
+
+    /** Get current headroom pool occupancy in cells [uint64_t] */
+    SAI_BUFFER_POOL_STAT_XOFF_ROOM_CURR_OCCUPANCY_CELLS = 0x00000015,
+
+    /** Get headroom pool occupancy in cells [uint64_t] */
+    SAI_BUFFER_POOL_STAT_XOFF_ROOM_WATERMARK_CELLS = 0x00000016,
+
+    /** Get current pool occupancy in cells [uint64_t] */
+    SAI_BUFFER_POOL_STAT_CURR_OCCUPANCY_CELLS = 0x00000017,
+
+    /** Get watermark pool occupancy in cells [uint64_t] */
+    SAI_BUFFER_POOL_STAT_WATERMARK_CELLS = 0x00000018,
 
     /** Custom range base value */
     SAI_BUFFER_POOL_STAT_CUSTOM_RANGE_BASE = 0x10000000

--- a/inc/saiqueue.h
+++ b/inc/saiqueue.h
@@ -421,6 +421,18 @@ typedef enum _sai_queue_stat_t
     /** Packets trimmed due to failed admission [uint64_t] */
     SAI_QUEUE_STAT_TRIM_PACKETS = 0x00000028,
 
+    /** Get current queue occupancy in cells [uint64_t] */
+    SAI_QUEUE_STAT_CURR_OCCUPANCY_CELLS = 0x00000029,
+
+    /** Get watermark queue occupancy in cells [uint64_t] */
+    SAI_QUEUE_STAT_WATERMARK_CELLS = 0x0000002a,
+
+    /** Get current queue shared occupancy in cells [uint64_t] */
+    SAI_QUEUE_STAT_SHARED_CURR_OCCUPANCY_CELLS = 0x0000002b,
+
+    /** Get watermark queue shared occupancy in cells [uint64_t] */
+    SAI_QUEUE_STAT_SHARED_WATERMARK_CELLS = 0x0000002c,
+
     /** Custom range base value */
     SAI_QUEUE_STAT_CUSTOM_RANGE_BASE = 0x10000000
 

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -3186,6 +3186,18 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_INDEX,
 
     /**
+     * @brief Size of a shared buffer cell
+     *
+     * Some counters related to shared buffer may be
+     * reported in cells instead of bytes for an
+     * improved performance.
+     *
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_SWITCH_ATTR_SHARED_BUFFER_CELL_SIZE,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,


### PR DESCRIPTION
Add occcupancy and watermark counters for
priority group and queue objects in shared buffer cells to report them as they are in counted in the ASIC. Also add a companion read-only attribute to
get the cell size of a shared buffer in a switch.