### PR TITLE
[cherry-pick][1.15]Fix for RPC build failure (#2097)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ GEN_SAIRPC_OPTS?=
 # Passed to meta/Makefile via "make saithrift-build, can specify add'l libraries along with libsai
 SAIRPC_EXTRA_LIBS?=
 
+SAI_HEADER_DIR=../../inc
+
 .PHONY: test doc clean
 
 doc: meta/xml
@@ -46,7 +48,7 @@ test:
 	make -C test
 
 saithrift-build:
-	SAIRPC_EXTRA_LIBS="$(SAIRPC_EXTRA_LIBS)" GEN_SAIRPC_OPTS="$(GEN_SAIRPC_OPTS)" make -C $(SAITHRIFT_PATH)
+	SAIRPC_EXTRA_LIBS="$(SAIRPC_EXTRA_LIBS)" GEN_SAIRPC_OPTS="$(GEN_SAIRPC_OPTS)" SAI_HEADER_DIR="$(SAI_HEADER_DIR)" make -C $(SAITHRIFT_PATH)
 
 saithrift-install: saithrift-build
 	make -C $(SAITHRIFT_PATH) install


### PR DESCRIPTION
Fixed the RPC build failure in sonic-net/sonic-buildimage#20322. The PR #2028 introduced some SAI header file changes and Since Vendor (ex BCM) SAI header files do not have these changes and also the sai-thrift includes the sai header files installed from Vendor SAI debian package, the saithrift build fails. This PR modifies the sai-thrift make to include the SAI header files from sai-redis SAI/inc folder instead of the SAI headers installed from Vendor SAI debian package.