### PR TITLE
Unify SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_CUSTOM_RANGE_BASE value

### DIFF
--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -712,13 +712,13 @@ typedef enum _sai_hostif_user_defined_trap_type_t
     /** Traps to be associated with TAM collector */
     SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_TAM,
 
-    /** Custom range base */
-    SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_CUSTOM_RANGE_BASE = 0x00001000,
-
     /**
      * @brief End of user defined trap types
      */
     SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_END,
+
+    /** Custom range base */
+    SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_CUSTOM_RANGE_BASE = 0x10000000,
 
 } sai_hostif_user_defined_trap_type_t;
 

--- a/meta/checkheaders.pl
+++ b/meta/checkheaders.pl
@@ -196,6 +196,8 @@ sub CheckHash
             next if $key eq "SAI_API_MAX";
             next if $key eq "SAI_PORT_INTERFACE_TYPE_MAX";
             next if $key eq "SAI_PORT_BREAKOUT_MODE_TYPE_MAX";
+            next if $key eq "SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_CUSTOM_RANGE_BASE";
+            next if $key eq "SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_END";
 
             # NOTE: some other attributes/enum with END range could be added
         }

--- a/meta/test.pm
+++ b/meta/test.pm
@@ -190,8 +190,6 @@ sub CreateCustomRangeBaseTest
 
         for my $range (@ranges)
         {
-            next if $range eq "SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_CUSTOM_RANGE_BASE"; # TODO exception, to be remove
-
             my $prefix = uc $1 if $key =~ /(sai_\w+)_t$/;
 
             if ($range eq "${prefix}_CUSTOM_RANGE_BASE")


### PR DESCRIPTION
To match all other custom range bases starting from 0x1000000.

All other _CUSTOM_RANGE_BASE enums are indexed at 0x1000000, lets's move this one to the same base to have all vendor custom enums at the same base across entire SAI