### PR TITLE
Add a new attribute SAI_BFD_SESSION_ATTR_NEXT_HOP_ID to saibfd.h

### DIFF
--- a/inc/saibfd.h
+++ b/inc/saibfd.h
@@ -164,7 +164,7 @@ typedef enum _sai_bfd_session_attr_t
      * @type sai_object_id_t
      * @flags MANDATORY_ON_CREATE | CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_VIRTUAL_ROUTER
-     * @condition SAI_BFD_SESSION_ATTR_HW_LOOKUP_VALID == true
+     * @condition SAI_BFD_SESSION_ATTR_HW_LOOKUP_VALID == true and SAI_BFD_SESSION_ATTR_USE_NEXT_HOP == false
      */
     SAI_BFD_SESSION_ATTR_VIRTUAL_ROUTER,
 
@@ -522,6 +522,26 @@ typedef enum _sai_bfd_session_attr_t
      * @default empty
      */
     SAI_BFD_SESSION_ATTR_SELECTIVE_COUNTER_LIST,
+
+    /**
+     * @brief Use next hop
+     *
+     * @type bool
+     * @flags CREATE_ONLY
+     * @default false
+     */
+    SAI_BFD_SESSION_ATTR_USE_NEXT_HOP,
+
+    /**
+     * @brief Next Hop ID for single hop BFD session
+     *
+     * @type sai_object_id_t
+     * @flags MANDATORY_ON_CREATE | CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_NEXT_HOP
+     * @allownull true
+     * @condition SAI_BFD_SESSION_ATTR_USE_NEXT_HOP == true
+     */
+    SAI_BFD_SESSION_ATTR_NEXT_HOP_ID,
 
     /**
      * @brief End of attributes


### PR DESCRIPTION
<re-created the PR, because the original one https://github.com/opencomputeproject/SAI/pull/2117 was using master branch in forked repo cause the commits were lost when do fork sync. 
Please see comments in https://github.com/opencomputeproject/SAI/pull/2117 for review history>

Adding a new attribute SAI_BFD_SESSION_ATTR_NEXT_HOP_ID to saibfd.h to support forwarding single hop bfd packet to specific nexthop.

The proposed usage is:
1, this attribute can be provided both in create_bfd_session and set_bfd_session_attribute.
2, if SAI_BFD_SESSION_ATTR_USE_NEXT_HOP (optional, default is false) is set to true, BFD session will get next hop from SAI_BFD_SESSION_ATTR_NEXT_HOP_ID value and forward the bfd packet to the next hop. If SAI_BFD_SESSION_ATTR_USE_NEXT_HOP is false, attribute SAI_BFD_SESSION_ATTR_NEXT_HOP_ID will be ignored.
3, when using both SAI_BFD_SESSION_ATTR_HW_LOOKUP_VALID and SAI_BFD_SESSION_ATTR_USE_NEXT_HOP, the implementation is vender dependent.

A document to explain the use case for the proposed attributes:
https://github.com/sonic-net/SONiC/pull/1932
