### PR TITLE
Add back port_error_status to sai_port_oper_status_notification_t

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -141,6 +141,8 @@ typedef struct _sai_port_oper_status_notification_t
     /** Port operational status */
     sai_port_oper_status_t port_state;
 
+    /** Bitmap of various port error or fault status */
+    sai_port_error_status_t port_error_status;
 } sai_port_oper_status_notification_t;
 
 /**

--- a/meta/saiserializetest.c
+++ b/meta/saiserializetest.c
@@ -1412,7 +1412,7 @@ void test_serialize_notifications()
     memset(&data1, 0, sizeof(data1));
 
     res = sai_serialize_port_state_change_notification(buf, 1, &data1);
-    ret = "{\"count\":1,\"data\":[{\"port_id\":\"oid:0x0\",\"port_state\":\"SAI_PORT_OPER_STATUS_UNKNOWN\"}]}";
+    ret = "{\"count\":1,\"data\":[{\"port_id\":\"oid:0x0\",\"port_state\":\"SAI_PORT_OPER_STATUS_UNKNOWN\",\"port_error_status\":\"SAI_PORT_ERROR_STATUS_CLEAR\"}]}";
     ASSERT_STR_EQ(buf, ret , res);
 
     sai_extended_port_oper_status_notification_t data1e;


### PR DESCRIPTION
`sai_port_oper_status_notification_t`  notification in SAI version starting from v1.15.0 onwards had the new field `sai_port_error_status`. 

This field got removed by [PR2087](https://github.com/opencomputeproject/SAI/pull/2087) . 

Added the field back to prevent this incompatibility for vendors using SAI v1.15.0 and above 