### PR TITLE
Add SAI port attribute to fetch PAM4 eye height values

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -2677,6 +2677,14 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_PORT_STAT_EXTENDED,
 
     /**
+     * @brief List of port's PAM4 lanes eye values
+     *
+     * @type sai_port_pam4_eye_values_list_t
+     * @flags READ_ONLY
+     */
+    SAI_PORT_ATTR_PAM4_EYE_VALUES,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_ATTR_END,

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1194,6 +1194,39 @@ typedef struct _sai_port_eye_values_list_t
 } sai_port_eye_values_list_t;
 
 /**
+ * @brief Defines the eye height and width for PAM4 SerDes lane
+ * height is in mV
+ * width is in psec. -1 means not available
+ */
+typedef struct _sai_port_pam4_lane_eye_values_t
+{
+    uint32_t lane;
+    int32_t upper_ht;
+    int32_t upper_wd;
+    int32_t middle_ht;
+    int32_t middle_wd;
+    int32_t lower_ht;
+    int32_t lower_wd;
+} sai_port_pam4_lane_eye_values_t;
+
+/**
+ * @brief Defines a port's PAM4 eye values for list of all serdes lanes
+ *
+ * The count defines the number of objects which will be returned to the
+ * caller in the list member. The caller must allocate the buffer for the
+ * list member and set the count member to the size of the allocated objects
+ * in the list member. If the size is not large enough, the callee must set
+ * the count member to the actual number of objects filled in the list member
+ * and return #SAI_STATUS_BUFFER_OVERFLOW. Once the caller gets such a return
+ * code, it may use the returned count member to re-allocate the list and retry.
+ */
+typedef struct _sai_port_pam4_eye_values_list_t
+{
+    uint32_t count;
+    sai_port_pam4_lane_eye_values_t *list;
+} sai_port_pam4_eye_values_list_t;
+
+/**
  * @brief Defines a lane with its frequency offset ppm
  */
 typedef struct _sai_port_frequency_offset_ppm_values_t
@@ -1657,6 +1690,8 @@ typedef union _sai_attribute_value_t
     /** @validonly meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_POE_PORT_POWER_CONSUMPTION */
     sai_poe_port_power_consumption_t portpowerconsumption;
 
+    /** @validonly meta->attrvaluetype == SAI_ATTR_VALUE_TYPE_PORT_PAM4_EYE_VALUES_LIST */
+    sai_port_pam4_eye_values_list_t portpam4eyevalues;
 } sai_attribute_value_t;
 
 /**

--- a/meta/aspell.en.pws
+++ b/meta/aspell.en.pws
@@ -130,6 +130,7 @@ nexthop
 nexthopgroup
 nextrelease
 NPUs
+NRZ
 objlist
 offsetof
 oid
@@ -150,6 +151,7 @@ Policer
 postcursor
 pre
 precursor
+psec
 PVID
 qos
 quantization

--- a/meta/saimetadatatypes.h
+++ b/meta/saimetadatatypes.h
@@ -495,6 +495,11 @@ typedef enum _sai_attr_value_type_t
      * @brief Attribute value is the POE port consumption data.
      */
     SAI_ATTR_VALUE_TYPE_POE_PORT_POWER_CONSUMPTION,
+
+    /**
+     * @brief Attribute value is port PAM4 eye values list.
+     */
+    SAI_ATTR_VALUE_TYPE_PORT_PAM4_EYE_VALUES_LIST,
 } sai_attr_value_type_t;
 
 /**

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -799,6 +799,7 @@ void check_attr_object_type_provided(
         case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
         case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_PAM4_EYE_VALUES_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_FREQUENCY_OFFSET_PPM_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
         case SAI_ATTR_VALUE_TYPE_LATCH_STATUS:
@@ -1105,6 +1106,7 @@ void check_attr_default_required(
         case SAI_ATTR_VALUE_TYPE_MAP_LIST:
         case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_PAM4_EYE_VALUES_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_FREQUENCY_OFFSET_PPM_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
@@ -1317,6 +1319,7 @@ void check_attr_default_value_type(
                 case SAI_ATTR_VALUE_TYPE_MAP_LIST:
                 case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST:
                 case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
+                case SAI_ATTR_VALUE_TYPE_PORT_PAM4_EYE_VALUES_LIST:
                 case SAI_ATTR_VALUE_TYPE_PORT_FREQUENCY_OFFSET_PPM_LIST:
                 case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
                 case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
@@ -2071,6 +2074,7 @@ void check_attr_allow_flags(
             case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
             case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST:
             case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
+            case SAI_ATTR_VALUE_TYPE_PORT_PAM4_EYE_VALUES_LIST:
             case SAI_ATTR_VALUE_TYPE_PORT_FREQUENCY_OFFSET_PPM_LIST:
             case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
             case SAI_ATTR_VALUE_TYPE_PORT_LANE_LATCH_STATUS_LIST:
@@ -2964,6 +2968,7 @@ void check_attr_is_primitive(
         case SAI_ATTR_VALUE_TYPE_SEGMENT_LIST:
         case SAI_ATTR_VALUE_TYPE_IP_ADDRESS_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_EYE_VALUES_LIST:
+        case SAI_ATTR_VALUE_TYPE_PORT_PAM4_EYE_VALUES_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_FREQUENCY_OFFSET_PPM_LIST:
         case SAI_ATTR_VALUE_TYPE_PORT_SNR_LIST:
         case SAI_ATTR_VALUE_TYPE_SYSTEM_PORT_CONFIG_LIST:
@@ -6277,6 +6282,8 @@ void check_struct_and_union_size()
     CHECK_STRUCT_SIZE(sai_port_err_status_list_t, 16);
     CHECK_STRUCT_SIZE(sai_port_eye_values_list_t, 16);
     CHECK_STRUCT_SIZE(sai_port_lane_eye_values_t, 20);
+    CHECK_STRUCT_SIZE(sai_port_pam4_lane_eye_values_t, 28);
+    CHECK_STRUCT_SIZE(sai_port_pam4_eye_values_list_t, 16);
     CHECK_STRUCT_SIZE(sai_port_lane_latch_status_list_t, 16);
     CHECK_STRUCT_SIZE(sai_port_lane_latch_status_t, 8);
     CHECK_STRUCT_SIZE(sai_port_frequency_offset_ppm_list_t, 16);


### PR DESCRIPTION
SAI port attribute to fetch PAM4 eye heights and widths of the lower, middle and upper eye of a PAM4 signal.

Eye height in mV
Eye width in psecs. If an implementation does not support then, -1

A narrower eye is more sensitive to jitter and smaller eye has lower SNR.

A good eye height and width threshold is implementation defined based upon the desired SNR, jitter tolerance etc for the application or deployment scenario

SAI_PORT_ATTR_PAM4_EYE_VALUES - Is the attribute introduced for PAM4 SerDes lanes.

SAI_PORT_ATTR_EYE_VALUES - Can be used for NRZ SerDes lanes

![image](https://github.com/user-attachments/assets/9d353066-1051-4331-a102-024c09936f54)
