### PR TITLE
Add custom serdes attributes for saiport.h

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -4116,6 +4116,45 @@ typedef enum _sai_port_serdes_attr_t
     SAI_PORT_SERDES_ATTR_RX_PRECODING,
 
     /**
+     * @brief A collection of custom serdes attributes
+     *
+     * The value is of type sai_json_t, which can include multiple custom serdes
+     * attributes. This allows vendor-specific serdes attributes to be forwarded
+     * in a JSON string without the sender needing to know the details. The
+     * sender simply passes along the data, vendor-defined rules determine which
+     * attributes and values to include in different situations, and the vendor
+     * SDK interprets the JSON accordingly.
+     *
+     * Example of the JSON object:
+     * {
+     * "attributes": [
+     * {
+     *    "attr_xyz": {
+     *        "sai_metadata": {
+     *        "sai_attr_value_type": "SAI_ATTR_VALUE_TYPE_INT32_LIST"
+     *        },
+     *        "value": [10, 10, 10, 10]
+     *    }
+     * },
+     * {
+     *    "attr_abc": {
+     *        "sai_metadata": {
+     *        "sai_attr_value_type": "SAI_ATTR_VALUE_TYPE_INT32_LIST"
+     *        },
+     *        "value": [20, 20, 20, 20]
+     *    }
+     * },
+     * ...
+     * ]
+     * }
+     *
+     * @type sai_json_t
+     * @flags CREATE_AND_SET
+     * @default internal
+     */
+    SAI_PORT_SERDES_ATTR_CUSTOM_COLLECTION,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_SERDES_ATTR_END,


### PR DESCRIPTION
**Problem description:**

Today, [saiport.h](https://github.com/opencomputeproject/SAI/blob/ee6f49bde8100e3797f3540ebf362d27f13d96a2/inc/saiport.h#L3842-L4116) and [SONiC](https://github.com/sonic-net/sonic-swss/blob/7a965caf4c7211afca5303191cf731858c791bcd/orchagent/portsorch.cpp#L366-L455) only supports 10+ NPU SI serdes attributes, but there are below situations for certain vendors/platforms:
1. The total number of attributes can be way more than 10+ for certain platforms/vendors (e.g. 40+ attrs), and the number can keep growing even more for future platforms and new ASIC board versions for existing platforms.
2. Attributes can be vendor/platform specific. Different platforms may have totally different sets of attributes (or only very few attributes are common). And SONiC’s orchagent (which is platform agnostic and independently built) should not include a platform-specific extension header file containing those attributes enums.
3. Attributes can be proprietary, which means original names for those attributes cannot be exposed to public, they cannot be upstreamed as it is, unless as dummy/alias attributes.


**Proposal:**
(credit to @kcudnik for his idea https://github.com/opencomputeproject/SAI/pull/2156#issuecomment-2758536612)

Add one single attribute, whose value is a string that includes a JSON object with key-value pairs. Each pair's key represents the serdes attribute name, and each pair's value is a list of values for every serdes lane. This allows vendor-specific serdes attributes to be forwarded in a JSON string without the sender needing to know the details. The sender simply passes along the data, vendor-defined rules (e.g. for SONiC, it's [media_settings.json](https://github.com/sonic-net/sonic-platform-daemons/blob/master/sonic-xcvrd/tests/media_settings.json) on [platform side](https://github.com/sonic-net/sonic-platform-daemons/blob/0b0ea3b2a3ed60ef00f25305631a30314f59a6fe/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py#L35)) determine which key-value pairs to include, and the vendor SDK interprets the JSON accordingly. 