### PR TITLE
[saithrift] Allow overriding variable SAI_HEADER_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ GEN_SAIRPC_OPTS?=
 # Passed to meta/Makefile via "make saithrift-build, can specify add'l libraries along with libsai
 SAIRPC_EXTRA_LIBS?=
 
-SAI_HEADER_DIR=../../inc
+SAI_HEADER_DIR?=../../inc
 
 .PHONY: test doc clean
 


### PR DESCRIPTION
PR #2097 breaks the [DASH saithrift](https://github.com/sonic-net/DASH/blob/main/dash-pipeline/SAI/saithrift/Makefile), which uses /usr/include/sai/ as SAI header directory.

Use  conditional assignment `?=` to assign `SAI_HEADER_DIR` with default value, then it can be overridden via make command-line argument or environment variable.