### PR TITLE
Next hop group attribute to specify if weights are achieved by repeating members or via the weighting support in the hardware..

### DIFF
--- a/inc/sainexthopgroup.h
+++ b/inc/sainexthopgroup.h
@@ -300,6 +300,17 @@ typedef enum _sai_next_hop_group_attr_t
     SAI_NEXT_HOP_GROUP_ATTR_LABEL,
 
     /**
+     * @brief Weighted multi path configuration mode.
+     * false: Nexthop group is programmed with repeated member entries proportional to their weight
+     * true: Nexthop group is programmed with switch native configuration
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_NEXT_HOP_GROUP_ATTR_NATIVE_WCMP,
+
+    /**
      * @brief End of attributes
      */
     SAI_NEXT_HOP_GROUP_ATTR_END,


### PR DESCRIPTION
Add new next hop group attribute to specify if a next hop group is programmed by repeating the next hop members in proportion to their weight or by using the intrinsic next hop group weight support in the hardware.