### PR TITLE
new in drop reasons and new port stat counters to map to in drop reasons

### DIFF
--- a/inc/saidebugcounter.h
+++ b/inc/saidebugcounter.h
@@ -124,10 +124,16 @@ typedef enum _sai_in_drop_reason_t
     /** Packet size is larger than the L2 (Port) MTU */
     SAI_IN_DROP_REASON_EXCEEDS_L2_MTU,
 
+    /** Source MAC address is zero */
+    SAI_IN_DROP_REASON_SMAC_ZERO = 0x00000037,
+
+    /** Destination MAC address is zero */
+    SAI_IN_DROP_REASON_DMAC_ZERO,
+
     /* L3 reasons */
 
     /** Any L3 pipeline drop */
-    SAI_IN_DROP_REASON_L3_ANY,
+    SAI_IN_DROP_REASON_L3_ANY = 0x0000000b,
 
     /** Packet size is larger than the L3 (Router Interface) MTU */
     SAI_IN_DROP_REASON_EXCEEDS_L3_MTU,
@@ -321,6 +327,9 @@ typedef enum _sai_in_drop_reason_t
      * Segments Left value is not 0 when received packet is destined to S and S is a local SID of type End.D*
      */
     SAI_IN_DROP_REASON_SRV6_LOCAL_SID_DROP,
+
+    /** IPv4 or IPv6 Routing table (LPM) unicast miss */
+    SAI_IN_DROP_REASON_LPM_MISS = 0x00000039,
 
     /** End of in drop reasons */
     SAI_IN_DROP_REASON_END,

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -3395,6 +3395,30 @@ typedef enum _sai_port_stat_t
     /** Get in port packet drops configured by debug counter API at index 7 */
     SAI_PORT_STAT_IN_CONFIGURED_DROP_REASONS_7_DROPPED_PKTS,
 
+    /** Get in port packet drops configured by debug counter API at index 8 */
+    SAI_PORT_STAT_IN_CONFIGURED_DROP_REASONS_8_DROPPED_PKTS,
+
+    /** Get in port packet drops configured by debug counter API at index 9 */
+    SAI_PORT_STAT_IN_CONFIGURED_DROP_REASONS_9_DROPPED_PKTS,
+
+    /** Get in port packet drops configured by debug counter API at index 10 */
+    SAI_PORT_STAT_IN_CONFIGURED_DROP_REASONS_10_DROPPED_PKTS,
+
+    /** Get in port packet drops configured by debug counter API at index 11 */
+    SAI_PORT_STAT_IN_CONFIGURED_DROP_REASONS_11_DROPPED_PKTS,
+
+    /** Get in port packet drops configured by debug counter API at index 12 */
+    SAI_PORT_STAT_IN_CONFIGURED_DROP_REASONS_12_DROPPED_PKTS,
+
+    /** Get in port packet drops configured by debug counter API at index 13 */
+    SAI_PORT_STAT_IN_CONFIGURED_DROP_REASONS_13_DROPPED_PKTS,
+
+    /** Get in port packet drops configured by debug counter API at index 14 */
+    SAI_PORT_STAT_IN_CONFIGURED_DROP_REASONS_14_DROPPED_PKTS,
+
+    /** Get in port packet drops configured by debug counter API at index 15 */
+    SAI_PORT_STAT_IN_CONFIGURED_DROP_REASONS_15_DROPPED_PKTS,
+
     /** Port stat in drop reasons range end */
     SAI_PORT_STAT_IN_DROP_REASON_RANGE_END = 0x00001fff,
 


### PR DESCRIPTION
This PR adds the following:

SAI_IN_DROP_REASON_SMAC_ZERO
SAI_IN_DROP_REASON_DMAC_ZERO
SAI_IN_DROP_REASON_LPM_MISS
8 additional port stat drop reason counters

Signed-off-by: Prasun Sinha <prasunsinha@google.com>
