### PR TITLE
Add packet trimming counter

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -3368,6 +3368,12 @@ typedef enum _sai_port_stat_t
     /** Packets trimmed due to failed shared buffer admission [uint64_t] */
     SAI_PORT_STAT_TRIM_PACKETS,
 
+    /** Packets trimmed but dropped due to failed shared buffer admission on a trim queue */
+    SAI_PORT_STAT_DROPPED_TRIM_PACKETS,
+
+    /** Packets trimmed and successfully transmitted on port */
+    SAI_PORT_STAT_TX_TRIM_PACKETS,
+
     /** Port stat in drop reasons range start */
     SAI_PORT_STAT_IN_DROP_REASON_RANGE_BASE = 0x00001000,
 

--- a/inc/saiqueue.h
+++ b/inc/saiqueue.h
@@ -433,6 +433,12 @@ typedef enum _sai_queue_stat_t
     /** Get watermark queue shared occupancy in cells [uint64_t] */
     SAI_QUEUE_STAT_SHARED_WATERMARK_CELLS = 0x0000002c,
 
+    /** Packets trimmed but failed to be admitted on a trim queue due to congestion. Counted on the original trimming-eligible queue [uint64_t] */
+    SAI_QUEUE_STAT_DROPPED_TRIM_PACKETS = 0x0000002d,
+
+    /** Packets trimmed and successfully transmitted on a trim queue. Counted on the original trimming-eligible queue [uint64_t] */
+    SAI_QUEUE_STAT_TX_TRIM_PACKETS = 0x0000002e,
+
     /** Custom range base value */
     SAI_QUEUE_STAT_CUSTOM_RANGE_BASE = 0x10000000
 

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -3518,6 +3518,15 @@ typedef enum _sai_switch_asic_sdk_health_category_t
  */
 typedef enum _sai_switch_stat_t
 {
+    /** Switch stat range start */
+    SAI_SWITCH_STAT_START,
+
+    /** Global (switch-wise) counter of packets trimmed but dropped due to failed shared buffer admission on a trim queue */
+    SAI_SWITCH_STAT_DROPPED_TRIM_PACKETS = SAI_SWITCH_STAT_START,
+
+    /** Global (switch-wise) counter of packets trimmed and successfully sent on a trim queue */
+    SAI_SWITCH_STAT_TX_TRIM_PACKETS,
+
     /** Switch stat in drop reasons range start */
     SAI_SWITCH_STAT_IN_DROP_REASON_RANGE_BASE = 0x00001000,
 
@@ -3598,6 +3607,9 @@ typedef enum _sai_switch_stat_t
 
     /** Switch stat fabric drop reasons range end */
     SAI_SWITCH_STAT_FABRIC_DROP_REASON_RANGE_END = 0x00003fff,
+
+    /** Switch stat range end */
+    SAI_SWITCH_STAT_END,
 
 } sai_switch_stat_t;
 


### PR DESCRIPTION
This PR adds the following:

SAI_PORT_STAT_DROPPED_TRIM_PACKETS
SAI_PORT_STAT_TX_TRIM_PACKETS
SAI_QUEUE_STAT_DROPPED_TRIM_PACKETS
SAI_QUEUE_STAT_TX_TRIM_PACKETS
SAI_SWITCH_STAT_DROPPED_TRIM_PACKETS
SAI_SWITCH_STAT_TX_TRIM_PACKETS
