### PR TITLE
Adding custom range base values

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -3599,6 +3599,9 @@ typedef enum _sai_switch_stat_t
     /** Switch stat fabric drop reasons range end */
     SAI_SWITCH_STAT_FABRIC_DROP_REASON_RANGE_END = 0x00003fff,
 
+    /** Custom range base value */
+    SAI_SWITCH_STAT_CUSTOM_RANGE_BASE = 0x10000000
+
 } sai_switch_stat_t;
 
 /**

--- a/inc/saitam.h
+++ b/inc/saitam.h
@@ -1292,6 +1292,9 @@ typedef enum _sai_tam_report_mode_t
     /** Report in a sampling mode, one report is sent for every n reports */
     SAI_TAM_REPORT_MODE_SAMPLING,
 
+    /** Custom range base value */
+    SAI_TAM_REPORT_MODE_CUSTOM_RANGE_BASE = 0x10000000
+
 } sai_tam_report_mode_t;
 
 /**

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -813,6 +813,9 @@ typedef enum _sai_acl_table_supported_match_type_t
     /** Exact */
     SAI_ACL_TABLE_SUPPORTED_MATCH_TYPE_EXACT,
 
+    /** Custom range base value */
+    SAI_ACL_TABLE_SUPPORTED_MATCH_TYPE_CUSTOM_RANGE_BASE = 0x10000000
+
 } sai_acl_table_supported_match_type_t;
 
 /**


### PR DESCRIPTION
**Title:**
Add missing CUSTOM_RANGE_BASE values to enum definitions

**Description:**
This PR fixes an issue where the CUSTOM_RANGE_BASE value was missing from some enum types/stats.Specifically, the following additions were made:

- Added SAI_SWITCH_STAT_CUSTOM_RANGE_BASE = 0x10000000 to sai_switch_stat_t
- Added SAI_ACL_TABLE_SUPPORTED_MATCH_TYPE_CUSTOM_RANGE_BASE = 0x10000000 to sai_acl_table_supported_match_type_t
- Added SAI_TAM_REPORT_MODE_CUSTOM_RANGE_BASE = 0x10000000 to sai_tam_report_mode_t

**Why:**
These enum types lacked defined custom range base values, making it impossible to use extended or custom values reliably.