### PR TITLE
Add SAI_MIRROR_SESSION_ATTR_LABEL to mirror session attributes

### DIFF
--- a/inc/saimirror.h
+++ b/inc/saimirror.h
@@ -395,6 +395,15 @@ typedef enum _sai_mirror_session_attr_t
     SAI_MIRROR_SESSION_ATTR_GRE_HEADER_FIRST_16BIT,
 
     /**
+     * @brief Label attribute used to uniquely identify mirror session.
+     *
+     * @type char
+     * @flags CREATE_AND_SET
+     * @default ""
+     */
+    SAI_MIRROR_SESSION_ATTR_LABEL,
+
+    /**
      * @brief End of attributes
      */
     SAI_MIRROR_SESSION_ATTR_END,


### PR DESCRIPTION
Similar to the label used in SAI policer object, mirror session label attribute can be used to identify the same user mirror session configuration, e.g., in warmboot use case.