### PR TITLE
Support for Next Hop Meta Data

### DIFF
--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -1580,9 +1580,18 @@ typedef enum _sai_acl_table_attr_t
     SAI_ACL_TABLE_ATTR_FIELD_DST_PREFIX_META = SAI_ACL_TABLE_ATTR_FIELD_START + 0x161,
 
     /**
+     * @brief Nexthop DST User metadata
+     *
+     * @type bool
+     * @flags CREATE_ONLY
+     * @default false
+     */
+    SAI_ACL_TABLE_ATTR_FIELD_NEXT_HOP_USER_META = SAI_ACL_TABLE_ATTR_FIELD_START + 0x162,
+
+    /**
      * @brief End of ACL Table Match Field
      */
-    SAI_ACL_TABLE_ATTR_FIELD_END = SAI_ACL_TABLE_ATTR_FIELD_DST_PREFIX_META,
+    SAI_ACL_TABLE_ATTR_FIELD_END = SAI_ACL_TABLE_ATTR_FIELD_NEXT_HOP_USER_META,
 
     /**
      * @brief ACL table entries associated with this table.
@@ -2708,9 +2717,21 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_FIELD_DST_PREFIX_META = SAI_ACL_ENTRY_ATTR_FIELD_START + 0x161,
 
     /**
+     * @brief Match user meta data in Next Hop Table
+     *
+     * Value must be in the range defined in
+     * #SAI_SWITCH_ATTR_NEXT_HOP_USER_META_DATA_RANGE
+     *
+     * @type sai_acl_field_data_t sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default disabled
+     */
+    SAI_ACL_ENTRY_ATTR_FIELD_NEXT_HOP_USER_META = SAI_ACL_ENTRY_ATTR_FIELD_START + 0x162,
+
+    /**
      * @brief End of Rule Match Fields
      */
-    SAI_ACL_ENTRY_ATTR_FIELD_END = SAI_ACL_ENTRY_ATTR_FIELD_DST_PREFIX_META,
+    SAI_ACL_ENTRY_ATTR_FIELD_END = SAI_ACL_ENTRY_ATTR_FIELD_NEXT_HOP_USER_META,
 
     /*
      * Actions [sai_acl_action_data_t]

--- a/inc/sainexthop.h
+++ b/inc/sainexthop.h
@@ -259,6 +259,17 @@ typedef enum _sai_next_hop_attr_t
     SAI_NEXT_HOP_ATTR_DISABLE_VLAN_REWRITE,
 
     /**
+     * @brief User based Meta Data
+     *
+     * Value Range #SAI_SWITCH_ATTR_NEXT_HOP_USER_META_DATA_RANGE
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_NEXT_HOP_ATTR_META_DATA,
+
+    /**
      * @brief End of attributes
      */
     SAI_NEXT_HOP_ATTR_END,

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -3461,6 +3461,14 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_DEFAULT_CPU_EGRESS_BUFFER_POOL,
 
     /**
+     * @brief Nexthop DST Table user-based meta data range
+     *
+     * @type sai_u32_range_t
+     * @flags READ_ONLY
+     */
+    SAI_SWITCH_ATTR_NEXT_HOP_USER_META_DATA_RANGE,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,


### PR DESCRIPTION
Metadata can be assigned in the Next Hop Table and subsequently matched in ACL entries, providing increased flexibility for policy management.