### PR TITLE
Introduce buffer pool type SAI_BUFFER_POOL_TYPE_EGRESS_HBM

### DIFF
--- a/inc/saibuffer.h
+++ b/inc/saibuffer.h
@@ -285,8 +285,16 @@ typedef enum _sai_buffer_pool_type_t
     SAI_BUFFER_POOL_TYPE_EGRESS,
 
     /** Buffer pool used by both ingress and egress */
-    SAI_BUFFER_POOL_TYPE_BOTH
+    SAI_BUFFER_POOL_TYPE_BOTH,
 
+    /** Egress HBM buffer pool */
+    SAI_BUFFER_POOL_TYPE_EGRESS_HBM,
+
+    /** Custom range base value */
+    SAI_BUFFER_POOL_TYPE_CUSTOM_RANGE_START = 0x10000000,
+
+    /** End of custom range base */
+    SAI_BUFFER_POOL_TYPE_CUSTOM_RANGE_END
 } sai_buffer_pool_type_t;
 
 /**


### PR DESCRIPTION
This PR adds support for a new buffer pool type: `SAI_BUFFER_POOL_TYPE_EGRESS_HBM`.

`SAI_BUFFER_POOL_TYPE_EGRESS_HBM` represents egress buffer pools located in off-chip High Bandwidth Memory (HBM). This new type enables hardware drivers to differentiate HBM-based pools from traditional egress pools, allowing for more accurate configuration and optimization.

Certain attributes of the buffer pool will apply specifically to HBM pools, providing clearer semantics and improving hardware abstraction.
