### PR TITLE
Add SAI_ATTR_PORT_FW_REVISION to saiport

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -2722,6 +2722,16 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_FAST_LINKUP_ENABLED,
 
     /**
+     * @brief Get port SerDes firmware revision
+     *
+     * Standard attribute to collect port SerDes firmware rev.
+     *
+     * @type sai_s8_list_t
+     * @flags READ_ONLY
+     */
+    SAI_PORT_ATTR_SERDES_FW_REVISION,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_ATTR_END,


### PR DESCRIPTION
This proposal outlines the addition of a new port attribute designed to provide a standardized method for querying the active SerDes firmware revision of a port.

**Proposal -**

Add label SAI_ATTR_PORT_FW_REVISION under sai_port_attr_h in saiport.h to store firmware related information. This attribute will store a string denoting the current SerDes firmware version running on the port. 