### PR TITLE
meta/Makefile: use &: for grouped targets

### DIFF
--- a/meta/Makefile
+++ b/meta/Makefile
@@ -126,12 +126,12 @@ saiattrversion.h: $(DEPS) attrversion.sh
 saimetadatasize.h: $(DEPS)
 	./size.sh
 
-saimetadatatest.c saimetadata.c saimetadata.h: xml $(XMLDEPS) parse.pl $(CONSTHEADERS) $(EXTRA) saiattrversion.h
+saimetadatatest.c saimetadata.c saimetadata.h &: xml $(XMLDEPS) parse.pl $(CONSTHEADERS) $(EXTRA) saiattrversion.h
 	perl -I. parse.pl
 
 RPC_MODULES=$(shell find rpc -type f -name "*.pm")
 
-sai.thrift sai_rpc_server.cpp sai_adapter.py: xml $(XMLDEPS) gensairpc.pl templates/*.tt $(RPC_MODULES)
+sai.thrift sai_rpc_server.cpp sai_adapter.py &: xml $(XMLDEPS) gensairpc.pl templates/*.tt $(RPC_MODULES)
 	perl -Irpc gensairpc.pl $(GEN_SAIRPC_OPTS)
 
 rpc: sai.thrift sai_rpc_server.cpp sai_adapter.py


### PR DESCRIPTION
The meta/Makefile contains several rules which are not correct for parallel make. These rules contain several targets to the left of the colon, and express the intent that the targets are built together as a group. Unfortunately, that's not what the syntax means:  Rather:

   t1 t2 t3 : prereq
           recipe # recipe generates all three!

is essentially a syntactic sugar condensing multiple rules with the same recipe and prerequisites:

   t1 : prereq
           recipe # recipe generates all three!

   t2 : prereq
           recipe

   t3 : prereq
           recipe

Under parallel make these rules fire in parallel which can wreak havoc, since they stomp on each other's files.

The issue can be addressed using the grouped targets feature:

   t1 t2 t3 &: prereq
           recipe # recipe generates all three!

The ampersand-colon separator &: means that there is only one rule here which Make understands to be updating all three targets.

This feature has been available since GNU Make 4.2.90. Ubuntu-latest is on 4.3.

(The grouped targets feature was the subject of a bugfix before 4.4. The bug potentially causes a grouped target not to be remade if it is deleted.  This is minor problem because it's not expected that someone will be deleting, say, the generated file saimetadata.c individually rather than doing a "make clean" which deletes all the generated files.)