### PR TITLE
Fix bug of creating metadata for custom attribute SAI_ACL_ENTRY/TABLE_ATTR_(FIELD/ACTION)

### DIFF
--- a/doc/custom-headers/saiaclcustom.h
+++ b/doc/custom-headers/saiaclcustom.h
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2018 Microsoft Open Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ *    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ *    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ *
+ *    See the Apache Version 2.0 License for specific language governing
+ *    permissions and limitations under the License.
+ *
+ *    Microsoft would like to thank the following companies for their review and
+ *    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+ *    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+ *
+ * @file    saiaclcustom.h
+ *
+ * @brief   This module defines ACL custom of the Switch Abstraction Interface (SAI)
+ */
+
+#ifndef __SAIACLCUSTOM_H_
+#define __SAIACLCUSTOM_H_
+
+#include <saiacl.h>
+
+/**
+ * @brief Custom ACL Action Type
+ *
+ * @flags free
+ */
+typedef enum _sai_acl_action_type_custom_t {
+    /** Start of custom action type. */
+    SAI_ACL_ACTION_TYPE_CUSTOM_RANGE_START = SAI_ACL_ACTION_TYPE_CUSTOM_RANGE_BASE,
+    /**
+     * @brief ACTION TYPE 1
+     */
+    SAI_ACL_ACTION_TYPE_1 = SAI_ACL_ACTION_TYPE_CUSTOM_RANGE_START,
+
+    /** End of custom action type. */
+    SAI_ACL_ACTION_TYPE_CUSTOM_RANGE_END
+} sai_acl_action_type_custom_t;
+
+/**
+ * @brief SAI ACL table attribute custom
+ *
+ * @flags free
+ */
+typedef enum _sai_acl_table_attr_custom_t {
+    /**
+     * @brief Start of ACL table custom attributes
+     */
+    SAI_ACL_TABLE_ATTR_CUSTOM_RANGE_START = SAI_ACL_TABLE_ATTR_CUSTOM_RANGE_BASE,
+    /**
+     * @brief Custom 1
+     *
+     * @type bool
+     * @flags CREATE_ONLY
+     * @default false
+     */
+    SAI_ACL_TABLE_ATTR_1 = SAI_ACL_TABLE_ATTR_CUSTOM_RANGE_START,
+
+    SAI_ACL_TABLE_ATTR_CUSTOM_RANGE_END,
+
+    /**
+     * @brief Start of ACL table custom field attributes
+     */
+    SAI_ACL_TABLE_ATTR_FIELD_CUSTOM_RANGE_START = SAI_ACL_TABLE_ATTR_FIELD_CUSTOM_RANGE_BASE,
+    /**
+     * @brief Custom 1
+     *
+     * @type bool
+     * @flags CREATE_ONLY
+     * @default false
+     */
+    SAI_ACL_TABLE_ATTR_FIELD_1 = SAI_ACL_TABLE_ATTR_FIELD_CUSTOM_RANGE_START,
+    /**
+     * @brief Custom 2
+     *
+     * @type bool
+     * @flags CREATE_ONLY
+     * @default false
+     */
+    SAI_ACL_TABLE_ATTR_FIELD_2,
+
+    /** End of custom range base */
+    SAI_ACL_TABLE_ATTR_FIELD_CUSTOM_RANGE_END
+} sai_acl_table_attr_custom_t;
+
+/**
+ * @brief SAI ACL entry attribute custom,
+ *
+ * @flags free
+ */
+typedef enum _sai_acl_entry_attr_custom_t {
+    /**
+     * @brief Start of ACL entry custom field attributes
+     */
+    SAI_ACL_ENTRY_ATTR_FIELD_CUSTOM_RANGE_START = SAI_ACL_ENTRY_ATTR_FIELD_CUSTOM_RANGE_BASE,
+    /**
+     * @brief Custom 1
+     *
+     * @type bool
+     * @flags CREATE_ONLY
+     * @default false
+     */
+    SAI_ACL_ENTRY_ATTR_FIELD_1 = SAI_ACL_ENTRY_ATTR_FIELD_CUSTOM_RANGE_START,
+    /**
+     * @brief Custom 2
+     *
+     * @type bool
+     * @flags CREATE_ONLY
+     * @default false
+     */
+    SAI_ACL_ENTRY_ATTR_FIELD_2,
+
+    /** End of custom range base */
+    SAI_ACL_ENTRY_ATTR_FIELD_CUSTOM_RANGE_END,
+
+    /**
+     * @brief Start of ACL entry custom action attributes
+     */
+    SAI_ACL_ENTRY_ATTR_ACTION_CUSTOM_RANGE_START = SAI_ACL_ENTRY_ATTR_ACTION_CUSTOM_RANGE_BASE,
+    /**
+     * @brief Custom 1
+     *
+     * @type bool
+     * @flags CREATE_ONLY
+     * @default false
+     */
+    SAI_ACL_ENTRY_ATTR_ACTION_1 = SAI_ACL_ENTRY_ATTR_ACTION_CUSTOM_RANGE_START,
+
+    /** End of ACL entry custom action attributes */
+    SAI_ACL_ENTRY_ATTR_ACTION_CUSTOM_RANGE_END
+} sai_acl_entry_attr_custom_t;
+
+#endif /* __SAIACLCUSTOM_H_ */

--- a/doc/custom-headers/saiportcustom.h
+++ b/doc/custom-headers/saiportcustom.h
@@ -35,6 +35,7 @@
  */
 typedef enum _sai_port_attr_custom_t
 {
+    SAI_PORT_ATTR_CUSTOM_RANGE_START = SAI_PORT_ATTR_CUSTOM_RANGE_BASE,
     /**
      * @brief Custom 1
      *
@@ -42,6 +43,8 @@ typedef enum _sai_port_attr_custom_t
      * @flags READ_ONLY
      */
     SAI_PORT_ATTR_CUSTOM1 = SAI_PORT_ATTR_CUSTOM_RANGE_START,
+
+    SAI_PORT_ATTR_CUSTOM_RANGE_END
 
     /* Add new csutom port attributes above this line */
 

--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -304,6 +304,9 @@ typedef enum _sai_acl_action_type_t
     /** Bind a TAM object */
     SAI_ACL_ACTION_TYPE_TAM_OBJECT = 0x0000003d,
 
+    /** Custom range base of ACL action type */
+    SAI_ACL_ACTION_TYPE_CUSTOM_RANGE_BASE = 0x10000000
+
 } sai_acl_action_type_t;
 
 /**
@@ -408,14 +411,9 @@ typedef enum _sai_acl_table_group_attr_t
     SAI_ACL_TABLE_GROUP_ATTR_END,
 
     /**
-     * @brief Custom range base value start
+     * @brief Custom range base value
      */
-    SAI_ACL_TABLE_GROUP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /**
-     * @brief End of Custom range base
-     */
-    SAI_ACL_TABLE_GROUP_ATTR_CUSTOM_RANGE_END
+    SAI_ACL_TABLE_GROUP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_acl_table_group_attr_t;
 
@@ -467,14 +465,9 @@ typedef enum _sai_acl_table_chain_group_attr_t
     SAI_ACL_TABLE_CHAIN_GROUP_ATTR_END,
 
     /**
-     * @brief Custom range base value start
+     * @brief Custom range base value
      */
-    SAI_ACL_TABLE_CHAIN_GROUP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /**
-     * @brief End of Custom range base
-     */
-    SAI_ACL_TABLE_CHAIN_GROUP_ATTR_CUSTOM_RANGE_END
+    SAI_ACL_TABLE_CHAIN_GROUP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_acl_table_chain_group_attr_t;
 
@@ -553,14 +546,9 @@ typedef enum _sai_acl_table_group_member_attr_t
     SAI_ACL_TABLE_GROUP_MEMBER_ATTR_END,
 
     /**
-     * @brief Custom range base value start
+     * @brief Custom range base value
      */
-    SAI_ACL_TABLE_GROUP_MEMBER_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /**
-     * @brief End of Custom range base
-     */
-    SAI_ACL_TABLE_GROUP_MEMBER_ATTR_CUSTOM_RANGE_END
+    SAI_ACL_TABLE_GROUP_MEMBER_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_acl_table_group_member_attr_t;
 
@@ -1699,14 +1687,14 @@ typedef enum _sai_acl_table_attr_t
     SAI_ACL_TABLE_ATTR_END,
 
     /**
-     * @brief Custom range base value start
+     * @brief Custom range base value
      */
-    SAI_ACL_TABLE_ATTR_CUSTOM_RANGE_START = 0x10000000,
+    SAI_ACL_TABLE_ATTR_CUSTOM_RANGE_BASE = 0x10000000,
 
     /**
-     * @brief End of Custom range base
+     * @brief Custom field attribute range base value
      */
-    SAI_ACL_TABLE_ATTR_CUSTOM_RANGE_END
+    SAI_ACL_TABLE_ATTR_FIELD_CUSTOM_RANGE_BASE = SAI_ACL_TABLE_ATTR_CUSTOM_RANGE_BASE + 0x00001000
 
 } sai_acl_table_attr_t;
 
@@ -3387,11 +3375,20 @@ typedef enum _sai_acl_entry_attr_t
      */
     SAI_ACL_ENTRY_ATTR_END,
 
-    /** Custom range base value */
-    SAI_ACL_ENTRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
+    /**
+     * @brief Custom range base value
+     */
+    SAI_ACL_ENTRY_ATTR_CUSTOM_RANGE_BASE = 0x10000000,
 
-    /** End of custom range base */
-    SAI_ACL_ENTRY_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Base value of custom ACL_ENTRY_ATTR_FIELD
+     */
+    SAI_ACL_ENTRY_ATTR_FIELD_CUSTOM_RANGE_BASE = SAI_ACL_ENTRY_ATTR_CUSTOM_RANGE_BASE + 0x00001000,
+
+    /**
+     * @brief Base value of custom ACL_ENTRY_ATTR_ACTION
+     */
+    SAI_ACL_ENTRY_ATTR_ACTION_CUSTOM_RANGE_BASE = SAI_ACL_ENTRY_ATTR_CUSTOM_RANGE_BASE + 0x00002000
 
 } sai_acl_entry_attr_t;
 
@@ -3473,10 +3470,7 @@ typedef enum _sai_acl_counter_attr_t
     SAI_ACL_COUNTER_ATTR_END,
 
     /** Custom range base value */
-    SAI_ACL_COUNTER_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_ACL_COUNTER_ATTR_CUSTOM_RANGE_END
+    SAI_ACL_COUNTER_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_acl_counter_attr_t;
 
@@ -3541,10 +3535,7 @@ typedef enum _sai_acl_range_attr_t
     SAI_ACL_RANGE_ATTR_END,
 
     /** Custom range base value */
-    SAI_ACL_RANGE_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_ACL_RANGE_ATTR_CUSTOM_RANGE_END
+    SAI_ACL_RANGE_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_acl_range_attr_t;
 

--- a/inc/saiars.h
+++ b/inc/saiars.h
@@ -166,10 +166,7 @@ typedef enum _sai_ars_attr_t
     SAI_ARS_ATTR_END,
 
     /** Custom range base value */
-    SAI_ARS_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_ARS_ATTR_CUSTOM_RANGE_END
+    SAI_ARS_ATTR_CUSTOM_RANGE_BASE = 0x10000000,
 
 } sai_ars_attr_t;
 

--- a/inc/saiarsprofile.h
+++ b/inc/saiarsprofile.h
@@ -467,10 +467,7 @@ typedef enum _sai_ars_profile_attr_t
     SAI_ARS_PROFILE_ATTR_END,
 
     /** Custom range base value */
-    SAI_ARS_PROFILE_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_ARS_PROFILE_ATTR_CUSTOM_RANGE_END
+    SAI_ARS_PROFILE_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_ars_profile_attr_t;
 

--- a/inc/saibfd.h
+++ b/inc/saibfd.h
@@ -549,10 +549,7 @@ typedef enum _sai_bfd_session_attr_t
     SAI_BFD_SESSION_ATTR_END,
 
     /** Custom range base value */
-    SAI_BFD_SESSION_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_BFD_SESSION_ATTR_CUSTOM_RANGE_END
+    SAI_BFD_SESSION_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_bfd_session_attr_t;
 

--- a/inc/saibridge.h
+++ b/inc/saibridge.h
@@ -359,11 +359,10 @@ typedef enum _sai_bridge_port_attr_t
      */
     SAI_BRIDGE_PORT_ATTR_END,
 
-    /** Custom range base value */
-    SAI_BRIDGE_PORT_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_BRIDGE_PORT_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Custom range base value
+     */
+    SAI_BRIDGE_PORT_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_bridge_port_attr_t;
 
@@ -685,11 +684,10 @@ typedef enum _sai_bridge_attr_t
      */
     SAI_BRIDGE_ATTR_END,
 
-    /** Custom range base value */
-    SAI_BRIDGE_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_BRIDGE_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Custom range base value
+     */
+    SAI_BRIDGE_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_bridge_attr_t;
 

--- a/inc/saibuffer.h
+++ b/inc/saibuffer.h
@@ -110,11 +110,10 @@ typedef enum _sai_ingress_priority_group_attr_t
      */
     SAI_INGRESS_PRIORITY_GROUP_ATTR_END,
 
-    /** Custom range base value */
-    SAI_INGRESS_PRIORITY_GROUP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_INGRESS_PRIORITY_GROUP_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Custom range base value
+     */
+    SAI_INGRESS_PRIORITY_GROUP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_ingress_priority_group_attr_t;
 
@@ -168,7 +167,9 @@ typedef enum _sai_ingress_priority_group_stat_t
     /** Get watermark pg XOFF room occupancy in cells [uint64_t] */
     SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_CELLS = 0x0000000e,
 
-    /** Custom range base value */
+    /**
+     * @brief Custom range base value
+     */
     SAI_INGRESS_PRIORITY_GROUP_STAT_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_ingress_priority_group_stat_t;
@@ -414,11 +415,10 @@ typedef enum _sai_buffer_pool_attr_t
      */
     SAI_BUFFER_POOL_ATTR_END,
 
-    /** Custom range base value */
-    SAI_BUFFER_POOL_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_BUFFER_POOL_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Custom range base value
+     */
+    SAI_BUFFER_POOL_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_buffer_pool_attr_t;
 
@@ -786,11 +786,10 @@ typedef enum _sai_buffer_profile_attr_t
      */
     SAI_BUFFER_PROFILE_ATTR_END,
 
-    /** Custom range base value */
-    SAI_BUFFER_PROFILE_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_BUFFER_PROFILE_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Custom range base value
+     */
+    SAI_BUFFER_PROFILE_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_buffer_profile_attr_t;
 

--- a/inc/saicounter.h
+++ b/inc/saicounter.h
@@ -125,11 +125,10 @@ typedef enum _sai_counter_attr_t
      */
     SAI_COUNTER_ATTR_END,
 
-    /** Custom range base value */
-    SAI_COUNTER_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_COUNTER_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Custom range base value
+     */
+    SAI_COUNTER_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_counter_attr_t;
 

--- a/inc/saidebugcounter.h
+++ b/inc/saidebugcounter.h
@@ -455,11 +455,10 @@ typedef enum _sai_debug_counter_attr_t
      */
     SAI_DEBUG_COUNTER_ATTR_END,
 
-    /** Custom range base value */
-    SAI_DEBUG_COUNTER_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_DEBUG_COUNTER_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Custom range base value
+     */
+    SAI_DEBUG_COUNTER_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_debug_counter_attr_t;
 

--- a/inc/saidtel.h
+++ b/inc/saidtel.h
@@ -167,14 +167,9 @@ typedef enum _sai_dtel_attr_t
     SAI_DTEL_ATTR_END,
 
     /**
-     * @brief Custom range base value start
+     * @brief Custom range base value
      */
-    SAI_DTEL_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /**
-     * @brief End of Custom range base
-     */
-    SAI_DTEL_ATTR_CUSTOM_RANGE_END
+    SAI_DTEL_ATTR_CUSTOM_RANGE_BASE = 0x10000000,
 
 } sai_dtel_attr_t;
 
@@ -251,14 +246,9 @@ typedef enum _sai_dtel_queue_report_attr_t
     SAI_DTEL_QUEUE_REPORT_ATTR_END,
 
     /**
-     * @brief Custom range base value start
+     * @brief Custom range base value
      */
-    SAI_DTEL_QUEUE_REPORT_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /**
-     * @brief End of Custom range base
-     */
-    SAI_DTEL_QUEUE_REPORT_ATTR_CUSTOM_RANGE_END
+    SAI_DTEL_QUEUE_REPORT_ATTR_CUSTOM_RANGE_BASE = 0x10000000,
 
 } sai_dtel_queue_report_attr_t;
 
@@ -349,14 +339,9 @@ typedef enum _sai_dtel_int_session_attr_t
     SAI_DTEL_INT_SESSION_ATTR_END,
 
     /**
-     * @brief Custom range base value start
+     * @brief Custom range base value
      */
-    SAI_DTEL_INT_SESSION_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /**
-     * @brief End of Custom range base
-     */
-    SAI_DTEL_INT_SESSION_ATTR_CUSTOM_RANGE_END
+    SAI_DTEL_INT_SESSION_ATTR_CUSTOM_RANGE_BASE = 0x10000000,
 
 } sai_dtel_int_session_attr_t;
 
@@ -439,12 +424,7 @@ typedef enum _sai_dtel_report_session_attr_t
     /**
      * @brief Custom range base value start
      */
-    SAI_DTEL_REPORT_SESSION_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /**
-     * @brief End of Custom range base
-     */
-    SAI_DTEL_REPORT_SESSION_ATTR_CUSTOM_RANGE_END
+    SAI_DTEL_REPORT_SESSION_ATTR_CUSTOM_RANGE_BASE = 0x10000000,
 
 } sai_dtel_report_session_attr_t;
 
@@ -529,14 +509,9 @@ typedef enum _sai_dtel_event_attr_t
     SAI_DTEL_EVENT_ATTR_END,
 
     /**
-     * @brief Custom range base value start
+     * @brief Custom range base value
      */
-    SAI_DTEL_EVENT_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /**
-     * @brief End of Custom range base
-     */
-    SAI_DTEL_EVENT_ATTR_CUSTOM_RANGE_END
+    SAI_DTEL_EVENT_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_dtel_event_attr_t;
 

--- a/inc/saifdb.h
+++ b/inc/saifdb.h
@@ -195,11 +195,10 @@ typedef enum _sai_fdb_entry_attr_t
      */
     SAI_FDB_ENTRY_ATTR_END,
 
-    /** Start of custom range base value */
-    SAI_FDB_ENTRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range */
-    SAI_FDB_ENTRY_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Start of custom range base value
+     */
+    SAI_FDB_ENTRY_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_fdb_entry_attr_t;
 
@@ -281,11 +280,10 @@ typedef enum _sai_fdb_flush_attr_t
      */
     SAI_FDB_FLUSH_ATTR_END,
 
-    /** Custom range base value */
-    SAI_FDB_FLUSH_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_FDB_FLUSH_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Custom range base value
+     */
+    SAI_FDB_FLUSH_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_fdb_flush_attr_t;
 

--- a/inc/saigenericprogrammable.h
+++ b/inc/saigenericprogrammable.h
@@ -79,10 +79,7 @@ typedef enum _sai_generic_programmable_attr_t
     SAI_GENERIC_PROGRAMMABLE_ATTR_END,
 
     /** Custom range base value */
-    SAI_GENERIC_PROGRAMMABLE_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_GENERIC_PROGRAMMABLE_ATTR_CUSTOM_RANGE_END
+    SAI_GENERIC_PROGRAMMABLE_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_generic_programmable_attr_t;
 

--- a/inc/saihash.h
+++ b/inc/saihash.h
@@ -236,10 +236,7 @@ typedef enum _sai_fine_grained_hash_field_attr_t
     SAI_FINE_GRAINED_HASH_FIELD_ATTR_END,
 
     /** Custom range base value */
-    SAI_FINE_GRAINED_HASH_FIELD_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_FINE_GRAINED_HASH_FIELD_ATTR_CUSTOM_RANGE_END
+    SAI_FINE_GRAINED_HASH_FIELD_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_fine_grained_hash_field_attr_t;
 
@@ -288,10 +285,7 @@ typedef enum _sai_hash_attr_t
     SAI_HASH_ATTR_END,
 
     /** Custom range base value */
-    SAI_HASH_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_HASH_ATTR_CUSTOM_RANGE_END
+    SAI_HASH_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_hash_attr_t;
 

--- a/inc/saihostif.h
+++ b/inc/saihostif.h
@@ -103,11 +103,10 @@ typedef enum _sai_hostif_trap_group_attr_t
      */
     SAI_HOSTIF_TRAP_GROUP_ATTR_END,
 
-    /** Start of custom range base */
-    SAI_HOSTIF_TRAP_GROUP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range */
-    SAI_HOSTIF_TRAP_GROUP_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Custom range base value
+     */
+    SAI_HOSTIF_TRAP_GROUP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_hostif_trap_group_attr_t;
 
@@ -621,11 +620,10 @@ typedef enum _sai_hostif_trap_attr_t
      */
     SAI_HOSTIF_TRAP_ATTR_END,
 
-    /** Custom range start */
-    SAI_HOSTIF_TRAP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** Custom range end */
-    SAI_HOSTIF_TRAP_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Custom range base value
+     */
+    SAI_HOSTIF_TRAP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_hostif_trap_attr_t;
 
@@ -774,11 +772,10 @@ typedef enum _sai_hostif_user_defined_trap_attr_t
      */
     SAI_HOSTIF_USER_DEFINED_TRAP_ATTR_END,
 
-    /** Custom range start */
-    SAI_HOSTIF_USER_DEFINED_TRAP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** Custom range end */
-    SAI_HOSTIF_USER_DEFINED_TRAP_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Custom range base value
+     */
+    SAI_HOSTIF_USER_DEFINED_TRAP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_hostif_user_defined_trap_attr_t;
 
@@ -974,11 +971,10 @@ typedef enum _sai_hostif_attr_t
      */
     SAI_HOSTIF_ATTR_END,
 
-    /** Custom range base value */
-    SAI_HOSTIF_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_HOSTIF_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Custom range base value
+     */
+    SAI_HOSTIF_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_hostif_attr_t;
 
@@ -1146,11 +1142,10 @@ typedef enum _sai_hostif_table_entry_attr_t
      */
     SAI_HOSTIF_TABLE_ENTRY_ATTR_END,
 
-    /** Custom range base value */
-    SAI_HOSTIF_TABLE_ENTRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_HOSTIF_TABLE_ENTRY_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Custom range base value
+     */
+    SAI_HOSTIF_TABLE_ENTRY_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_hostif_table_entry_attr_t;
 
@@ -1332,11 +1327,10 @@ typedef enum _sai_hostif_packet_attr_t
      */
     SAI_HOSTIF_PACKET_ATTR_END,
 
-    /** Custom range base value */
-    SAI_HOSTIF_PACKET_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_HOSTIF_PACKET_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Custom range base value
+     */
+    SAI_HOSTIF_PACKET_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_hostif_packet_attr_t;
 

--- a/inc/saiicmpecho.h
+++ b/inc/saiicmpecho.h
@@ -251,10 +251,7 @@ typedef enum _sai_icmp_echo_session_attr_t
     SAI_ICMP_ECHO_SESSION_ATTR_END,
 
     /** Custom range base value */
-    SAI_ICMP_ECHO_SESSION_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_ICMP_ECHO_SESSION_ATTR_CUSTOM_RANGE_END
+    SAI_ICMP_ECHO_SESSION_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_icmp_echo_session_attr_t;
 

--- a/inc/saiipmc.h
+++ b/inc/saiipmc.h
@@ -138,10 +138,7 @@ typedef enum _sai_ipmc_entry_attr_t
     SAI_IPMC_ENTRY_ATTR_END,
 
     /** Custom range base value */
-    SAI_IPMC_ENTRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** Custom range base end value */
-    SAI_IPMC_ENTRY_ATTR_CUSTOM_RANGE_END
+    SAI_IPMC_ENTRY_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_ipmc_entry_attr_t;
 

--- a/inc/saiipmcgroup.h
+++ b/inc/saiipmcgroup.h
@@ -86,10 +86,7 @@ typedef enum _sai_ipmc_group_attr_t
     SAI_IPMC_GROUP_ATTR_END,
 
     /** Custom range base value */
-    SAI_IPMC_GROUP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_IPMC_GROUP_ATTR_CUSTOM_RANGE_END
+    SAI_IPMC_GROUP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_ipmc_group_attr_t;
 
@@ -124,10 +121,7 @@ typedef enum _sai_ipmc_group_member_attr_t
     SAI_IPMC_GROUP_MEMBER_ATTR_END,
 
     /** Custom range base value */
-    SAI_IPMC_GROUP_MEMBER_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_IPMC_GROUP_MEMBER_ATTR_CUSTOM_RANGE_END
+    SAI_IPMC_GROUP_MEMBER_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_ipmc_group_member_attr_t;
 

--- a/inc/saiipsec.h
+++ b/inc/saiipsec.h
@@ -339,12 +339,7 @@ typedef enum _sai_ipsec_attr_t
     /**
      * @brief Custom range base value
      */
-    SAI_IPSEC_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /**
-     * @brief End of custom range base
-     */
-    SAI_IPSEC_ATTR_CUSTOM_RANGE_END
+    SAI_IPSEC_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 } sai_ipsec_attr_t;
 
 /**
@@ -469,12 +464,7 @@ typedef enum _sai_ipsec_port_attr_t
     /**
      * @brief Custom range base value
      */
-    SAI_IPSEC_PORT_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /**
-     * @brief End of custom range base
-     */
-    SAI_IPSEC_PORT_ATTR_CUSTOM_RANGE_END
+    SAI_IPSEC_PORT_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 } sai_ipsec_port_attr_t;
 
 /**
@@ -750,12 +740,7 @@ typedef enum _sai_ipsec_sa_attr_t
     /**
      * @brief Custom range base value
      */
-    SAI_IPSEC_SA_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /**
-     * @brief End of custom range base
-     */
-    SAI_IPSEC_SA_ATTR_CUSTOM_RANGE_END
+    SAI_IPSEC_SA_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 } sai_ipsec_sa_attr_t;
 
 /**

--- a/inc/saiisolationgroup.h
+++ b/inc/saiisolationgroup.h
@@ -79,10 +79,7 @@ typedef enum _sai_isolation_group_attr_t
     SAI_ISOLATION_GROUP_ATTR_END,
 
     /** Custom range base value */
-    SAI_ISOLATION_GROUP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_ISOLATION_GROUP_ATTR_CUSTOM_RANGE_END
+    SAI_ISOLATION_GROUP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_isolation_group_attr_t;
 
@@ -122,10 +119,7 @@ typedef enum _sai_isolation_group_member_attr_t
     SAI_ISOLATION_GROUP_MEMBER_ATTR_END,
 
     /** Custom range base value */
-    SAI_ISOLATION_GROUP_MEMBER_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_ISOLATION_GROUP_MEMBER_ATTR_CUSTOM_RANGE_END
+    SAI_ISOLATION_GROUP_MEMBER_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_isolation_group_member_attr_t;
 

--- a/inc/sail2mc.h
+++ b/inc/sail2mc.h
@@ -114,10 +114,7 @@ typedef enum _sai_l2mc_entry_attr_t
     SAI_L2MC_ENTRY_ATTR_END,
 
     /** Custom range base value */
-    SAI_L2MC_ENTRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_L2MC_ENTRY_ATTR_CUSTOM_RANGE_END
+    SAI_L2MC_ENTRY_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_l2mc_entry_attr_t;
 

--- a/inc/sail2mcgroup.h
+++ b/inc/sail2mcgroup.h
@@ -66,10 +66,7 @@ typedef enum _sai_l2mc_group_attr_t
     SAI_L2MC_GROUP_ATTR_END,
 
     /** Custom range base value */
-    SAI_L2MC_GROUP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_L2MC_GROUP_ATTR_CUSTOM_RANGE_END
+    SAI_L2MC_GROUP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_l2mc_group_attr_t;
 
@@ -114,10 +111,7 @@ typedef enum _sai_l2mc_group_member_attr_t
     SAI_L2MC_GROUP_MEMBER_ATTR_END,
 
     /** Custom range base value */
-    SAI_L2MC_GROUP_MEMBER_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_L2MC_GROUP_MEMBER_ATTR_CUSTOM_RANGE_END
+    SAI_L2MC_GROUP_MEMBER_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_l2mc_group_member_attr_t;
 

--- a/inc/sailag.h
+++ b/inc/sailag.h
@@ -219,10 +219,7 @@ typedef enum _sai_lag_attr_t
     SAI_LAG_ATTR_END,
 
     /** Custom range base value */
-    SAI_LAG_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_LAG_ATTR_CUSTOM_RANGE_END
+    SAI_LAG_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_lag_attr_t;
 
@@ -339,10 +336,7 @@ typedef enum _sai_lag_member_attr_t
     SAI_LAG_MEMBER_ATTR_END,
 
     /** Custom range base value */
-    SAI_LAG_MEMBER_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_LAG_MEMBER_ATTR_CUSTOM_RANGE_END
+    SAI_LAG_MEMBER_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_lag_member_attr_t;
 

--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -353,12 +353,8 @@ typedef enum _sai_macsec_attr_t
     /**
      * @brief Custom range base value
      */
-    SAI_MACSEC_ATTR_CUSTOM_RANGE_START = 0x10000000,
+    SAI_MACSEC_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
-    /**
-     * @brief End of custom range base
-     */
-    SAI_MACSEC_ATTR_CUSTOM_RANGE_END
 } sai_macsec_attr_t;
 
 /**
@@ -470,12 +466,7 @@ typedef enum _sai_macsec_port_attr_t
     /**
      * @brief Custom range base value
      */
-    SAI_MACSEC_PORT_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /**
-     * @brief End of custom range base
-     */
-    SAI_MACSEC_PORT_ATTR_CUSTOM_RANGE_END
+    SAI_MACSEC_PORT_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 } sai_macsec_port_attr_t;
 
 /**
@@ -565,12 +556,7 @@ typedef enum _sai_macsec_flow_attr_t
     /**
      * @brief Custom range base value
      */
-    SAI_MACSEC_FLOW_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /**
-     * @brief End of custom range base
-     */
-    SAI_MACSEC_FLOW_ATTR_CUSTOM_RANGE_END
+    SAI_MACSEC_FLOW_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 } sai_macsec_flow_attr_t;
 
 /**
@@ -813,12 +799,7 @@ typedef enum _sai_macsec_sc_attr_t
     /**
      * @brief Custom range base value
      */
-    SAI_MACSEC_SC_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /**
-     * @brief End of custom range base
-     */
-    SAI_MACSEC_SC_ATTR_CUSTOM_RANGE_END
+    SAI_MACSEC_SC_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 } sai_macsec_sc_attr_t;
 
 /**
@@ -954,12 +935,7 @@ typedef enum _sai_macsec_sa_attr_t
     /**
      * @brief Custom range base value
      */
-    SAI_MACSEC_SA_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /**
-     * @brief End of custom range base
-     */
-    SAI_MACSEC_SA_ATTR_CUSTOM_RANGE_END
+    SAI_MACSEC_SA_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 } sai_macsec_sa_attr_t;
 
 /**

--- a/inc/saimcastfdb.h
+++ b/inc/saimcastfdb.h
@@ -104,10 +104,7 @@ typedef enum _sai_mcast_fdb_entry_attr_t
     SAI_MCAST_FDB_ENTRY_ATTR_END,
 
     /** Start of custom range base value */
-    SAI_MCAST_FDB_ENTRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range */
-    SAI_MCAST_FDB_ENTRY_ATTR_CUSTOM_RANGE_END
+    SAI_MCAST_FDB_ENTRY_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_mcast_fdb_entry_attr_t;
 

--- a/inc/saimirror.h
+++ b/inc/saimirror.h
@@ -409,10 +409,7 @@ typedef enum _sai_mirror_session_attr_t
     SAI_MIRROR_SESSION_ATTR_END,
 
     /** Custom range base value */
-    SAI_MIRROR_SESSION_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_MIRROR_SESSION_ATTR_CUSTOM_RANGE_END
+    SAI_MIRROR_SESSION_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_mirror_session_attr_t;
 

--- a/inc/saimpls.h
+++ b/inc/saimpls.h
@@ -218,10 +218,7 @@ typedef enum _sai_inseg_entry_attr_t
     SAI_INSEG_ENTRY_ATTR_END,
 
     /** Custom range base value */
-    SAI_INSEG_ENTRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_INSEG_ENTRY_ATTR_CUSTOM_RANGE_END
+    SAI_INSEG_ENTRY_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_inseg_entry_attr_t;
 

--- a/inc/saimymac.h
+++ b/inc/saimymac.h
@@ -98,10 +98,7 @@ typedef enum _sai_my_mac_attr_t
     SAI_MY_MAC_ATTR_END,
 
     /** Custom range base value */
-    SAI_MY_MAC_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_MY_MAC_ATTR_CUSTOM_RANGE_END
+    SAI_MY_MAC_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_my_mac_attr_t;
 

--- a/inc/sainat.h
+++ b/inc/sainat.h
@@ -226,10 +226,7 @@ typedef enum _sai_nat_entry_attr_t
     SAI_NAT_ENTRY_ATTR_END,
 
     /** Custom range base value */
-    SAI_NAT_ENTRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_NAT_ENTRY_ATTR_CUSTOM_RANGE_END
+    SAI_NAT_ENTRY_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_nat_entry_attr_t;
 
@@ -615,10 +612,7 @@ typedef enum _sai_nat_zone_counter_attr_t
     SAI_NAT_ZONE_COUNTER_ATTR_END,
 
     /** Custom range base value */
-    SAI_NAT_ZONE_COUNTER_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_NAT_ZONE_COUNTER_ATTR_CUSTOM_RANGE_END
+    SAI_NAT_ZONE_COUNTER_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_nat_zone_counter_attr_t;
 

--- a/inc/saineighbor.h
+++ b/inc/saineighbor.h
@@ -172,10 +172,7 @@ typedef enum _sai_neighbor_entry_attr_t
     SAI_NEIGHBOR_ENTRY_ATTR_END,
 
     /** Custom range base value */
-    SAI_NEIGHBOR_ENTRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_NEIGHBOR_ENTRY_ATTR_CUSTOM_RANGE_END
+    SAI_NEIGHBOR_ENTRY_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_neighbor_entry_attr_t;
 

--- a/inc/sainexthop.h
+++ b/inc/sainexthop.h
@@ -275,10 +275,7 @@ typedef enum _sai_next_hop_attr_t
     SAI_NEXT_HOP_ATTR_END,
 
     /** Custom range base value */
-    SAI_NEXT_HOP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_NEXT_HOP_ATTR_CUSTOM_RANGE_END
+    SAI_NEXT_HOP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_next_hop_attr_t;
 

--- a/inc/sainexthopgroup.h
+++ b/inc/sainexthopgroup.h
@@ -305,10 +305,7 @@ typedef enum _sai_next_hop_group_attr_t
     SAI_NEXT_HOP_GROUP_ATTR_END,
 
     /** Custom range base value */
-    SAI_NEXT_HOP_GROUP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_NEXT_HOP_GROUP_ATTR_CUSTOM_RANGE_END
+    SAI_NEXT_HOP_GROUP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_next_hop_group_attr_t;
 
@@ -446,10 +443,7 @@ typedef enum _sai_next_hop_group_member_attr_t
     SAI_NEXT_HOP_GROUP_MEMBER_ATTR_END,
 
     /** Custom range base value */
-    SAI_NEXT_HOP_GROUP_MEMBER_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_NEXT_HOP_GROUP_MEMBER_ATTR_CUSTOM_RANGE_END
+    SAI_NEXT_HOP_GROUP_MEMBER_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_next_hop_group_member_attr_t;
 
@@ -490,10 +484,7 @@ typedef enum _sai_next_hop_group_map_attr_t
     SAI_NEXT_HOP_GROUP_MAP_ATTR_END,
 
     /** Custom range base value */
-    SAI_NEXT_HOP_GROUP_MAP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_NEXT_HOP_GROUP_MAP_ATTR_CUSTOM_RANGE_END
+    SAI_NEXT_HOP_GROUP_MAP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_next_hop_group_map_attr_t;
 

--- a/inc/saipoe.h
+++ b/inc/saipoe.h
@@ -162,10 +162,7 @@ typedef enum _sai_poe_device_attr_t
     SAI_POE_DEVICE_ATTR_END,
 
     /** Custom range base value */
-    SAI_POE_DEVICE_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_POE_DEVICE_ATTR_CUSTOM_RANGE_END
+    SAI_POE_DEVICE_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_poe_device_attr_t;
 
@@ -234,10 +231,7 @@ typedef enum _sai_poe_pse_attr_t
     SAI_POE_PSE_ATTR_END,
 
     /** Custom range base value */
-    SAI_POE_PSE_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_POE_PSE_ATTR_CUSTOM_RANGE_END
+    SAI_POE_PSE_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_poe_pse_attr_t;
 
@@ -325,10 +319,7 @@ typedef enum _sai_poe_port_attr_t
     SAI_POE_PORT_ATTR_END,
 
     /** Custom range base value */
-    SAI_POE_PORT_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_POE_PORT_ATTR_CUSTOM_RANGE_END
+    SAI_POE_PORT_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_poe_port_attr_t;
 

--- a/inc/saipolicer.h
+++ b/inc/saipolicer.h
@@ -246,10 +246,7 @@ typedef enum _sai_policer_attr_t
     SAI_POLICER_ATTR_END,
 
     /** Custom range base value */
-    SAI_POLICER_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_POLICER_ATTR_CUSTOM_RANGE_END
+    SAI_POLICER_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_policer_attr_t;
 

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -2737,10 +2737,7 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_END,
 
     /** Custom range base value */
-    SAI_PORT_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_PORT_ATTR_CUSTOM_RANGE_END,
+    SAI_PORT_ATTR_CUSTOM_RANGE_BASE = 0x10000000,
 
     /** Extensions range base */
     SAI_PORT_ATTR_EXTENSIONS_RANGE_BASE = 0x20000000
@@ -3743,10 +3740,7 @@ typedef enum _sai_port_pool_attr_t
     SAI_PORT_POOL_ATTR_END,
 
     /** Custom range base value */
-    SAI_PORT_POOL_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_PORT_POOL_ATTR_CUSTOM_RANGE_END
+    SAI_PORT_POOL_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_port_pool_attr_t;
 
@@ -4372,10 +4366,7 @@ typedef enum _sai_port_serdes_attr_t
     SAI_PORT_SERDES_ATTR_END,
 
     /** Custom range base value */
-    SAI_PORT_SERDES_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_PORT_SERDES_ATTR_CUSTOM_RANGE_END
+    SAI_PORT_SERDES_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_port_serdes_attr_t;
 
@@ -4496,10 +4487,7 @@ typedef enum _sai_port_connector_attr_t
     SAI_PORT_CONNECTOR_ATTR_END,
 
     /** Custom range base value */
-    SAI_PORT_CONNECTOR_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_PORT_CONNECTOR_ATTR_CUSTOM_RANGE_END
+    SAI_PORT_CONNECTOR_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_port_connector_attr_t;
 

--- a/inc/saiprefixcompression.h
+++ b/inc/saiprefixcompression.h
@@ -75,10 +75,7 @@ typedef enum _sai_prefix_compression_table_attr_t
     SAI_PREFIX_COMPRESSION_TABLE_ATTR_END,
 
     /** Custom range base value */
-    SAI_PREFIX_COMPRESSION_TABLE_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_PREFIX_COMPRESSION_TABLE_ATTR_CUSTOM_RANGE_END
+    SAI_PREFIX_COMPRESSION_TABLE_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_prefix_compression_table_attr_t;
 
@@ -106,10 +103,7 @@ typedef enum _sai_prefix_compression_entry_attr_t
     SAI_PREFIX_COMPRESSION_ENTRY_ATTR_END,
 
     /** Custom range base value */
-    SAI_PREFIX_COMPRESSION_ENTRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_PREFIX_COMPRESSION_ENTRY_ATTR_CUSTOM_RANGE_END
+    SAI_PREFIX_COMPRESSION_ENTRY_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_prefix_compression_entry_attr_t;
 

--- a/inc/saiqosmap.h
+++ b/inc/saiqosmap.h
@@ -125,10 +125,7 @@ typedef enum _sai_qos_map_attr_t
     SAI_QOS_MAP_ATTR_END,
 
     /** Custom range base value */
-    SAI_QOS_MAP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_QOS_MAP_ATTR_CUSTOM_RANGE_END
+    SAI_QOS_MAP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_qos_map_attr_t;
 

--- a/inc/saiqueue.h
+++ b/inc/saiqueue.h
@@ -286,10 +286,7 @@ typedef enum _sai_queue_attr_t
     SAI_QUEUE_ATTR_END,
 
     /** Custom range base value */
-    SAI_QUEUE_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_QUEUE_ATTR_CUSTOM_RANGE_END
+    SAI_QUEUE_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_queue_attr_t;
 

--- a/inc/sairoute.h
+++ b/inc/sairoute.h
@@ -148,10 +148,7 @@ typedef enum _sai_route_entry_attr_t
     SAI_ROUTE_ENTRY_ATTR_END,
 
     /** Custom range base value */
-    SAI_ROUTE_ENTRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_ROUTE_ENTRY_ATTR_CUSTOM_RANGE_END
+    SAI_ROUTE_ENTRY_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_route_entry_attr_t;
 

--- a/inc/sairouterinterface.h
+++ b/inc/sairouterinterface.h
@@ -348,10 +348,7 @@ typedef enum _sai_router_interface_attr_t
     SAI_ROUTER_INTERFACE_ATTR_END,
 
     /** Custom range base value */
-    SAI_ROUTER_INTERFACE_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_ROUTER_INTERFACE_ATTR_CUSTOM_RANGE_END
+    SAI_ROUTER_INTERFACE_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_router_interface_attr_t;
 

--- a/inc/sairpfgroup.h
+++ b/inc/sairpfgroup.h
@@ -66,10 +66,7 @@ typedef enum _sai_rpf_group_attr_t
     SAI_RPF_GROUP_ATTR_END,
 
     /** Custom range base value */
-    SAI_RPF_GROUP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_RPF_GROUP_ATTR_CUSTOM_RANGE_END
+    SAI_RPF_GROUP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_rpf_group_attr_t;
 
@@ -104,10 +101,7 @@ typedef enum _sai_rpf_group_member_attr_t
     SAI_RPF_GROUP_MEMBER_ATTR_END,
 
     /** Custom range base value */
-    SAI_RPF_GROUP_MEMBER_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_RPF_GROUP_MEMBER_ATTR_CUSTOM_RANGE_END
+    SAI_RPF_GROUP_MEMBER_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_rpf_group_member_attr_t;
 

--- a/inc/saisamplepacket.h
+++ b/inc/saisamplepacket.h
@@ -141,10 +141,7 @@ typedef enum _sai_samplepacket_attr_t
     SAI_SAMPLEPACKET_ATTR_END,
 
     /** Custom range base value */
-    SAI_SAMPLEPACKET_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_SAMPLEPACKET_ATTR_CUSTOM_RANGE_END
+    SAI_SAMPLEPACKET_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_samplepacket_attr_t;
 

--- a/inc/saischeduler.h
+++ b/inc/saischeduler.h
@@ -144,10 +144,7 @@ typedef enum _sai_scheduler_attr_t
     SAI_SCHEDULER_ATTR_END,
 
     /** Custom range base value */
-    SAI_SCHEDULER_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_SCHEDULER_ATTR_CUSTOM_RANGE_END
+    SAI_SCHEDULER_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_scheduler_attr_t;
 

--- a/inc/saischedulergroup.h
+++ b/inc/saischedulergroup.h
@@ -113,10 +113,7 @@ typedef enum _sai_scheduler_group_attr_t
     SAI_SCHEDULER_GROUP_ATTR_END,
 
     /** Custom range base value */
-    SAI_SCHEDULER_GROUP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_SCHEDULER_GROUP_ATTR_CUSTOM_RANGE_END
+    SAI_SCHEDULER_GROUP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_scheduler_group_attr_t;
 

--- a/inc/saisrv6.h
+++ b/inc/saisrv6.h
@@ -118,10 +118,7 @@ typedef enum _sai_my_sid_entry_endpoint_behavior_t
     SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDT46,
 
     /** Custom range base value */
-    SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of Custom range base */
-    SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_CUSTOM_RANGE_END
+    SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_my_sid_entry_endpoint_behavior_t;
 
@@ -231,10 +228,7 @@ typedef enum _sai_srv6_sidlist_attr_t
     SAI_SRV6_SIDLIST_ATTR_END,
 
     /** Custom range base value */
-    SAI_SRV6_SIDLIST_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_SRV6_SIDLIST_ATTR_CUSTOM_RANGE_END
+    SAI_SRV6_SIDLIST_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 } sai_srv6_sidlist_attr_t;
 
 /**
@@ -450,10 +444,7 @@ typedef enum _sai_my_sid_entry_attr_t
     SAI_MY_SID_ENTRY_ATTR_END,
 
     /** Custom range base value */
-    SAI_MY_SID_ENTRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_MY_SID_ENTRY_ATTR_CUSTOM_RANGE_END
+    SAI_MY_SID_ENTRY_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_my_sid_entry_attr_t;
 

--- a/inc/saistp.h
+++ b/inc/saistp.h
@@ -93,10 +93,7 @@ typedef enum _sai_stp_attr_t
     SAI_STP_ATTR_END,
 
     /** Custom range base value */
-    SAI_STP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_STP_ATTR_CUSTOM_RANGE_END
+    SAI_STP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_stp_attr_t;
 
@@ -142,10 +139,7 @@ typedef enum _sai_stp_port_attr_t
     SAI_STP_PORT_ATTR_END,
 
     /** Custom range base value */
-    SAI_STP_PORT_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_STP_PORT_ATTR_CUSTOM_RANGE_END
+    SAI_STP_PORT_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_stp_port_attr_t;
 

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -582,10 +582,7 @@ typedef enum _sai_switch_tunnel_attr_t
     SAI_SWITCH_TUNNEL_ATTR_END,
 
     /** Custom range base value */
-    SAI_SWITCH_TUNNEL_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_SWITCH_TUNNEL_ATTR_CUSTOM_RANGE_END
+    SAI_SWITCH_TUNNEL_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_switch_tunnel_attr_t;
 
@@ -3527,10 +3524,7 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_END,
 
     /** Custom range base value */
-    SAI_SWITCH_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_SWITCH_ATTR_CUSTOM_RANGE_END,
+    SAI_SWITCH_ATTR_CUSTOM_RANGE_BASE = 0x10000000,
 
     /** Extensions range base */
     SAI_SWITCH_ATTR_EXTENSIONS_RANGE_BASE = 0x20000000

--- a/inc/saisynce.h
+++ b/inc/saisynce.h
@@ -110,10 +110,7 @@ typedef enum _sai_synce_clock_attr_t
     SAI_SYNCE_CLOCK_ATTR_END,
 
     /** Custom range base value */
-    SAI_SYNCE_CLOCK_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_SYNCE_CLOCK_ATTR_CUSTOM_RANGE_END
+    SAI_SYNCE_CLOCK_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_synce_clock_attr_t;
 

--- a/inc/saisystemport.h
+++ b/inc/saisystemport.h
@@ -134,10 +134,7 @@ typedef enum _sai_system_port_attr_t
     SAI_SYSTEM_PORT_ATTR_END,
 
     /** Custom range base value */
-    SAI_SYSTEM_PORT_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_SYSTEM_PORT_ATTR_CUSTOM_RANGE_END
+    SAI_SYSTEM_PORT_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_system_port_attr_t;
 

--- a/inc/saitam.h
+++ b/inc/saitam.h
@@ -92,10 +92,7 @@ typedef enum _sai_tam_attr_t
     SAI_TAM_ATTR_END,
 
     /** Custom range base value */
-    SAI_TAM_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_TAM_ATTR_CUSTOM_RANGE_END
+    SAI_TAM_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_tam_attr_t;
 
@@ -210,10 +207,7 @@ typedef enum _sai_tam_math_func_attr_t
     SAI_TAM_MATH_FUNC_ATTR_END,
 
     /** Custom range base value */
-    SAI_TAM_MATH_FUNC_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_TAM_MATH_FUNC_ATTR_CUSTOM_RANGE_END
+    SAI_TAM_MATH_FUNC_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_tam_math_func_attr_t;
 
@@ -380,10 +374,7 @@ typedef enum _sai_tam_event_threshold_attr_t
     SAI_TAM_EVENT_THRESHOLD_ATTR_END,
 
     /** Custom range base value */
-    SAI_TAM_EVENT_THRESHOLD_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_TAM_EVENT_THRESHOLD_ATTR_CUSTOM_RANGE_END
+    SAI_TAM_EVENT_THRESHOLD_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_tam_event_threshold_attr_t;
 
@@ -807,10 +798,7 @@ typedef enum _sai_tam_int_attr_t
     SAI_TAM_INT_ATTR_END,
 
     /** Custom range base value */
-    SAI_TAM_INT_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_TAM_INT_ATTR_CUSTOM_RANGE_END
+    SAI_TAM_INT_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_tam_int_attr_t;
 
@@ -1159,10 +1147,7 @@ typedef enum _sai_tam_tel_type_attr_t
     SAI_TAM_TEL_TYPE_ATTR_END,
 
     /** Custom range base value */
-    SAI_TAM_TEL_TYPE_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_TAM_TEL_TYPE_ATTR_CUSTOM_RANGE_END
+    SAI_TAM_TEL_TYPE_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 } sai_tam_tel_type_attr_t;
 
 /**
@@ -1462,10 +1447,7 @@ typedef enum _sai_tam_report_attr_t
     SAI_TAM_REPORT_ATTR_END,
 
     /** Custom range base value */
-    SAI_TAM_REPORT_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_TAM_REPORT_ATTR_CUSTOM_RANGE_END
+    SAI_TAM_REPORT_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_tam_report_attr_t;
 
@@ -1603,10 +1585,7 @@ typedef enum _sai_tam_telemetry_attr_t
     SAI_TAM_TELEMETRY_ATTR_END,
 
     /** Custom range base value */
-    SAI_TAM_TELEMETRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_TAM_TELEMETRY_ATTR_CUSTOM_RANGE_END
+    SAI_TAM_TELEMETRY_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_tam_telemetry_attr_t;
 
@@ -1794,10 +1773,7 @@ typedef enum _sai_tam_transport_attr_t
     SAI_TAM_TRANSPORT_ATTR_END,
 
     /** Custom range base value */
-    SAI_TAM_TRANSPORT_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_TAM_TRANSPORT_ATTR_CUSTOM_RANGE_END
+    SAI_TAM_TRANSPORT_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_tam_transport_attr_t;
 
@@ -1987,10 +1963,7 @@ typedef enum _sai_tam_collector_attr_t
     SAI_TAM_COLLECTOR_ATTR_END,
 
     /** Custom range base value */
-    SAI_TAM_COLLECTOR_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_TAM_COLLECTOR_ATTR_CUSTOM_RANGE_END
+    SAI_TAM_COLLECTOR_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_tam_collector_attr_t;
 
@@ -2146,10 +2119,7 @@ typedef enum _sai_tam_event_action_attr_t
     SAI_TAM_EVENT_ACTION_ATTR_END,
 
     /** Custom range base value */
-    SAI_TAM_EVENT_ACTION_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_TAM_EVENT_ACTION_ATTR_CUSTOM_RANGE_END
+    SAI_TAM_EVENT_ACTION_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_tam_event_action_attr_t;
 
@@ -2267,10 +2237,7 @@ typedef enum _sai_tam_event_attr_t
     SAI_TAM_EVENT_ATTR_END,
 
     /** Custom range base value */
-    SAI_TAM_EVENT_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_TAM_EVENT_ATTR_CUSTOM_RANGE_END
+    SAI_TAM_EVENT_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_tam_event_attr_t;
 
@@ -2389,10 +2356,7 @@ typedef enum _sai_tam_counter_subscription_attr_t
     SAI_TAM_COUNTER_SUBSCRIPTION_ATTR_END,
 
     /** Custom range base value */
-    SAI_TAM_COUNTER_SUBSCRIPTION_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_TAM_COUNTER_SUBSCRIPTION_ATTR_CUSTOM_RANGE_END
+    SAI_TAM_COUNTER_SUBSCRIPTION_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_tam_counter_subscription_attr_t;
 

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -265,10 +265,7 @@ typedef enum _sai_tunnel_map_entry_attr_t
     SAI_TUNNEL_MAP_ENTRY_ATTR_END,
 
     /** Custom range base value */
-    SAI_TUNNEL_MAP_ENTRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_TUNNEL_MAP_ENTRY_ATTR_CUSTOM_RANGE_END
+    SAI_TUNNEL_MAP_ENTRY_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_tunnel_map_entry_attr_t;
 
@@ -305,10 +302,7 @@ typedef enum _sai_tunnel_map_attr_t
     SAI_TUNNEL_MAP_ATTR_END,
 
     /** Custom range base value */
-    SAI_TUNNEL_MAP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_TUNNEL_MAP_ATTR_CUSTOM_RANGE_END
+    SAI_TUNNEL_MAP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_tunnel_map_attr_t;
 
@@ -802,10 +796,7 @@ typedef enum _sai_tunnel_attr_t
     SAI_TUNNEL_ATTR_END,
 
     /** Custom range base value */
-    SAI_TUNNEL_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_TUNNEL_ATTR_CUSTOM_RANGE_END
+    SAI_TUNNEL_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_tunnel_attr_t;
 
@@ -1077,10 +1068,7 @@ typedef enum _sai_tunnel_term_table_entry_attr_t
     SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_END,
 
     /** Custom range base value */
-    SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** Enc of custom range base */
-    SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_CUSTOM_RANGE_END
+    SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_tunnel_term_table_entry_attr_t;
 

--- a/inc/saitwamp.h
+++ b/inc/saitwamp.h
@@ -582,10 +582,7 @@ typedef enum _sai_twamp_session_attr_t
     SAI_TWAMP_SESSION_ATTR_END,
 
     /** Custom range base value */
-    SAI_TWAMP_SESSION_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_TWAMP_SESSION_ATTR_CUSTOM_RANGE_END
+    SAI_TWAMP_SESSION_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_twamp_session_attr_t;
 

--- a/inc/saiudf.h
+++ b/inc/saiudf.h
@@ -116,10 +116,7 @@ typedef enum _sai_udf_attr_t
     SAI_UDF_ATTR_END,
 
     /** Custom range base value */
-    SAI_UDF_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_UDF_ATTR_CUSTOM_RANGE_END
+    SAI_UDF_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_udf_attr_t;
 
@@ -195,10 +192,7 @@ typedef enum _sai_udf_match_attr_t
     SAI_UDF_MATCH_ATTR_END,
 
     /** Custom range base value */
-    SAI_UDF_MATCH_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_UDF_MATCH_ATTR_CUSTOM_RANGE_END
+    SAI_UDF_MATCH_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_udf_match_attr_t;
 
@@ -273,10 +267,7 @@ typedef enum _sai_udf_group_attr_t
     SAI_UDF_GROUP_ATTR_END,
 
     /** Custom range base value */
-    SAI_UDF_GROUP_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_UDF_GROUP_ATTR_CUSTOM_RANGE_END
+    SAI_UDF_GROUP_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_udf_group_attr_t;
 

--- a/inc/saivirtualrouter.h
+++ b/inc/saivirtualrouter.h
@@ -121,10 +121,7 @@ typedef enum _sai_virtual_router_attr_t
     SAI_VIRTUAL_ROUTER_ATTR_END,
 
     /** Custom range base value */
-    SAI_VIRTUAL_ROUTER_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_VIRTUAL_ROUTER_ATTR_CUSTOM_RANGE_END
+    SAI_VIRTUAL_ROUTER_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_virtual_router_attr_t;
 

--- a/inc/saivlan.h
+++ b/inc/saivlan.h
@@ -427,11 +427,10 @@ typedef enum _sai_vlan_attr_t
      */
     SAI_VLAN_ATTR_END,
 
-    /** Custom range base value */
-    SAI_VLAN_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_VLAN_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Custom range base value
+     */
+    SAI_VLAN_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_vlan_attr_t;
 
@@ -520,11 +519,10 @@ typedef enum _sai_vlan_member_attr_t
      */
     SAI_VLAN_MEMBER_ATTR_END,
 
-    /** Custom range base value */
-    SAI_VLAN_MEMBER_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_VLAN_MEMBER_ATTR_CUSTOM_RANGE_END
+    /**
+     * @brief Custom range base value
+     */
+    SAI_VLAN_MEMBER_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_vlan_member_attr_t;
 

--- a/inc/saiwred.h
+++ b/inc/saiwred.h
@@ -618,10 +618,7 @@ typedef enum _sai_wred_attr_t
     SAI_WRED_ATTR_END,
 
     /** Custom range base value */
-    SAI_WRED_ATTR_CUSTOM_RANGE_START = 0x10000000,
-
-    /** End of custom range base */
-    SAI_WRED_ATTR_CUSTOM_RANGE_END
+    SAI_WRED_ATTR_CUSTOM_RANGE_BASE = 0x10000000
 
 } sai_wred_attr_t;
 

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -92,8 +92,8 @@ defined_attr_t* defined_attributes = NULL;
 
 /* custom ranges start are the same for all objects */
 
-#define CUSTOM_ATTR_RANGE_START SAI_PORT_ATTR_CUSTOM_RANGE_START
 #define CUSTOM_RANGE_START (0x10000000)
+#define CUSTOM_ATTR_RANGE_START CUSTOM_RANGE_START
 #define EXTENSION_RANGE_START (0x20000000)
 #define EXTENSION_OBJECT_TYPE_COUNT (SAI_OBJECT_TYPE_EXTENSIONS_RANGE_END - SAI_OBJECT_TYPE_EXTENSIONS_RANGE_START)
 /* #define CUSTOM_OBJECT_TYPE_COUNT (SAI_OBJECT_TYPE_CUSTOM_RANGE_END - SAI_OBJECT_TYPE_CUSTOM_RANGE_START) */
@@ -107,6 +107,8 @@ defined_attr_t* defined_attributes = NULL;
 #ifndef SAI_OBJECT_TYPE_CUSTOM_RANGE_END
 #define SAI_OBJECT_TYPE_CUSTOM_RANGE_END (CUSTOM_RANGE_START + SAI_METADATA_CUSTOM_OBJECT_COUNT)
 #endif
+
+#define SUB_CUSTOM_RANGE_SIZE 0x1000
 
 bool is_extensions_enum(
         _In_ const sai_enum_metadata_t* emd)
@@ -557,6 +559,18 @@ bool sai_metadata_is_acl_field_or_action(
 
         if (metadata->attrid >= SAI_ACL_ENTRY_ATTR_ACTION_START &&
                 metadata->attrid <= SAI_ACL_ENTRY_ATTR_ACTION_END)
+        {
+            return true;
+        }
+
+        if (metadata->attrid >= SAI_ACL_ENTRY_ATTR_ACTION_CUSTOM_RANGE_BASE &&
+            metadata->attrid < SAI_ACL_ENTRY_ATTR_ACTION_CUSTOM_RANGE_BASE + SUB_CUSTOM_RANGE_SIZE)
+        {
+            return true;
+        }
+
+        if (metadata->attrid >= SAI_ACL_ENTRY_ATTR_FIELD_CUSTOM_RANGE_BASE &&
+            metadata->attrid < SAI_ACL_ENTRY_ATTR_FIELD_CUSTOM_RANGE_BASE + SUB_CUSTOM_RANGE_SIZE)
         {
             return true;
         }
@@ -2207,8 +2221,10 @@ void check_attr_acl_fields(
         case SAI_ATTR_VALUE_TYPE_ACL_FIELD_DATA_UINT8_LIST:
 
             if (md->objecttype == SAI_OBJECT_TYPE_ACL_ENTRY &&
-                    md->attrid >= SAI_ACL_ENTRY_ATTR_FIELD_START &&
-                    md->attrid  <= SAI_ACL_ENTRY_ATTR_FIELD_END)
+                    ((md->attrid >= SAI_ACL_ENTRY_ATTR_FIELD_START &&
+                    md->attrid  <= SAI_ACL_ENTRY_ATTR_FIELD_END) ||
+                    (md->attrid >= SAI_ACL_ENTRY_ATTR_FIELD_CUSTOM_RANGE_BASE &&
+                    md->attrid <= SAI_ACL_ENTRY_ATTR_FIELD_CUSTOM_RANGE_BASE + SUB_CUSTOM_RANGE_SIZE)))
             {
                 break;
 
@@ -5065,6 +5081,54 @@ void check_acl_entry_actions()
                     meta->attridname, enum_name);
         }
 
+        index++;
+        enum_index++;
+    }
+
+    /*
+     * Find the index of first entry action custom attribute, if there is no such nothing will happened.
+     */
+    for (; meta_acl_entry[index] != NULL; index++)
+    {
+        if (meta_acl_entry[index]->attrid == SAI_ACL_ENTRY_ATTR_ACTION_CUSTOM_RANGE_BASE)
+        {
+            break;
+        }
+    }
+
+    while (meta_acl_entry[index] != NULL &&
+           meta_acl_entry[index]->attrid >= SAI_ACL_ENTRY_ATTR_ACTION_CUSTOM_RANGE_BASE &&
+           meta_acl_entry[index]->attrid < SAI_ACL_ENTRY_ATTR_ACTION_CUSTOM_RANGE_BASE + SUB_CUSTOM_RANGE_SIZE)
+    {
+        const sai_attr_metadata_t *meta = meta_acl_entry[index];
+
+        if (meta->flags != SAI_ATTR_FLAGS_CREATE_AND_SET)
+        {
+            META_MD_ASSERT_FAIL(meta, "acl entry action flags should be CREATE_AND_SET");
+        }
+
+        const char* enum_name = sai_metadata_enum_sai_acl_action_type_t.valuesnames[enum_index];
+
+        META_ASSERT_NOT_NULL(enum_name);
+
+        META_LOG_DEBUG("processing acl action: %s %s", meta->attridname, enum_name);
+
+        /*
+         * check acl fields attribute if endings are the same
+         */
+        const char * enum_name_pos = strstr(enum_name, "_ACTION_TYPE_");
+
+        META_ASSERT_NOT_NULL(enum_name_pos);
+
+        const char * attr_entry_pos = strstr(meta->attridname, "_ATTR_ACTION_");
+
+        META_ASSERT_NOT_NULL(attr_entry_pos);
+
+        if (strcmp(enum_name_pos + strlen("_ACTION_TYPE_"), attr_entry_pos + strlen("_ATTR_ACTION_")) != 0)
+        {
+            META_ASSERT_FAIL("attr entry action name %s is not ending at the same enum name %s",
+                    meta->attridname, enum_name);
+        }
         index++;
         enum_index++;
     }


### PR DESCRIPTION
    1. Fix bug in saisanitycheck that there is no check for range
       SAI_ACL_ENTRY_ATTR(/_FIELD/_ACTION)_CUSTOM_RANGE_START to
       SAI_ACL_ENTRY_ATTR(/_FIELD/_ACTION)_CUSTOM_RANGE_END
    2. Remove all SAI_*_CUSTOM_RANGE_START/END, using SAI_*_CUSTOM_RANGE_BASE instead.
    3. Adjust metadata generator to compitable with above changes.