### PR TITLE
Added missing enable=True to acl_action_data_t in IPv6NextHdrTest (sa…

### DIFF
--- a/ptf/saiacl.py
+++ b/ptf/saiacl.py
@@ -4798,7 +4798,7 @@ class IPv6NextHdrTest(SaiHelperSimplified):
 
         packet_action = sai_thrift_acl_action_data_t(
             parameter=sai_thrift_acl_action_parameter_t(
-                s32=SAI_PACKET_ACTION_DROP))
+                s32=SAI_PACKET_ACTION_DROP), enable=True)
 
         field_ipv6_next_header = sai_thrift_acl_field_data_t(
             data=sai_thrift_acl_field_data_data_t(u8=ipv6_next_header),


### PR DESCRIPTION
Enable=True was needed in acl_action_data_t of the IPv6NextHdrTest test case (saiacl module)

Problem statement:
=============
IPv6NextHdrTest(saiacl module) needs modification as per SAI Standard.

in IPv6NextHdrTest(saiacl) while configuring acl_action_data_t enable flag is missing. But as per SAI Header/standard sai_action paramer valid only when enable flag set to TRUE.

SAI Testcase link: https://github.com/opencomputeproject/SAI/blob/master/ptf/saiacl.py#L4799C36-L4799C51

673 typedef struct _sai_acl_action_data_t
674 {
675 /**
676 * @brief Action enable/disable
677 /
678 bool enable;
679
680 /*
681 * @brief Action parameter
682 *
683 * @passparam meta
684 *** @validonly enable == true**
685 */
686 sai_acl_action_parameter_t parameter;
687
688 } sai_acl_action_data_t;

SAI Header link: https://github.com/opencomputeproject/SAI/blob/master/inc/saitypes.h#L691

Fix:
==
Included the enable=True flag in the sai_thrift_acl_action_parameter_t setup used in the IPv6NextHdrTest test case in saiacl.py