### PR TITLE
Adding custom range base type for SAI_TAM_TEL_MATH_FUNC_TYPE

### DIFF
--- a/inc/saitam.h
+++ b/inc/saitam.h
@@ -180,6 +180,9 @@ typedef enum _sai_tam_tel_math_func_type_t
     /** Packet Rate computation */
     SAI_TAM_TEL_MATH_FUNC_TYPE_RATE,
 
+    /** Custom range base value */
+    SAI_TAM_TEL_MATH_FUNC_TYPE_CUSTOM_RANGE_BASE = 0x10000000
+
 } sai_tam_tel_math_func_type_t;
 
 /**


### PR DESCRIPTION
**Title:**
Add missing CUSTOM_RANGE_BASE values to SAI_TAM_TEL_MATH_FUNC_TYPE

**Description:**
This PR fixes an issue where the CUSTOM_RANGE_BASE value was missing from _sai_tam_tel_math_func_type_t , the following additions were made:

- Added  SAI_TAM_TEL_MATH_FUNC_TYPE_CUSTOM_RANGE_BASE = 0x10000000 to sai_switch_stat_t

**Why:**
These enum types lacked defined custom range base values, making it impossible to use extended or custom values reliably.