### PR TITLE
[meta] Force enums with strict flags to have zero enum defined

### DIFF
--- a/experimental/saitypesextensions.h
+++ b/experimental/saitypesextensions.h
@@ -141,6 +141,8 @@ typedef enum _sai_dash_tunnel_dscp_mode_t
  */
 typedef enum _sai_dash_routing_actions_t
 {
+    SAI_DASH_ROUTING_ACTIONS_NONE = 0,
+
     SAI_DASH_ROUTING_ACTIONS_STATIC_ENCAP = 1,
 
     SAI_DASH_ROUTING_ACTIONS_NAT = 2,
@@ -174,6 +176,8 @@ typedef enum _sai_dash_ha_role_t
  */
 typedef enum _sai_dash_flow_enabled_key_t
 {
+    SAI_DASH_FLOW_ENABLED_KEY_NONE = 0,
+
     SAI_DASH_FLOW_ENABLED_KEY_ENI_MAC = 1,
 
     SAI_DASH_FLOW_ENABLED_KEY_VNI = 2,

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -1926,6 +1926,11 @@ typedef sai_status_t (*sai_bulk_object_get_attribute_fn)(
 typedef enum _sai_stats_mode_t
 {
     /**
+     * @brief No mode defined
+     */
+    SAI_STATS_MODE_NONE = 0 << 0,
+
+    /**
      * @brief Read statistics
      */
     SAI_STATS_MODE_READ = 1 << 0,
@@ -2102,6 +2107,11 @@ typedef enum _sai_ser_correction_type_t
  */
 typedef enum _sai_ser_log_type_t
 {
+    /**
+     * @brief No errors
+     */
+    SAI_SER_LOG_TYPE_NONE = 0 << 0,
+
     /**
      * @brief Error happens on memory
      */

--- a/meta/saimetadatatypes.h
+++ b/meta/saimetadatatypes.h
@@ -550,6 +550,13 @@ typedef enum _sai_attr_value_type_t
 typedef enum _sai_attr_flags_t
 {
     /**
+     * @brief No flags defined.
+     *
+     * This member should not be used.
+     */
+    SAI_ATTR_FLAGS_NONE = (0 << 0),
+
+    /**
      * @brief Mandatory on create flag.
      *
      * Attribute with this flag is mandatory when calling CREATE API, unless

--- a/meta/saisanitycheck.c
+++ b/meta/saisanitycheck.c
@@ -6110,6 +6110,36 @@ void check_enum_flags_type(
     META_ASSERT_FAIL("enum %s flags type %d not supported yet, FIXME", emd->name, emd->flagstype);
 }
 
+void check_enum_flag_zero(
+        _In_ const sai_enum_metadata_t* emd)
+{
+    META_LOG_ENTER();
+
+    /*
+     * this check tests whether each strict flag has value at index 0 which
+     * enum value is zero (no flags defined) this will be handy during
+     * serialization of empty flags
+     */
+
+    if (emd->flagstype != SAI_ENUM_FLAGS_TYPE_STRICT)
+        return;
+
+    /* enum contains strict flags */
+
+    if (emd->valuescount == 0)
+    {
+        META_ASSERT_FAIL("enum %s (flags strict) don't contain any values!", emd->name);
+    }
+
+    if (emd->values[0] != 0)
+    {
+        META_ASSERT_FAIL("enum %s (flags strict) value %s = %d at index 0 is not zero (no flags):",
+                emd->name,
+                emd->valuesnames[0],
+                emd->values[0]);
+    }
+}
+
 void check_single_enum(
         _In_ const sai_enum_metadata_t* emd)
 {
@@ -6121,6 +6151,7 @@ void check_single_enum(
     check_enum_flags_type_ranges(emd);
     check_enum_flags_type_free(emd);
     check_enum_object_type(emd);
+    check_enum_flag_zero(emd);
 }
 
 void check_all_enums()


### PR DESCRIPTION
This could be handy for serialization purposes if no flags are defined in serialized enum. But actual purpose of having zero value could have no meaning (for exaple stats mode)