### PR TITLE
Support for ADMIN state for BFD session

### DIFF
--- a/inc/saibfd.h
+++ b/inc/saibfd.h
@@ -553,6 +553,18 @@ typedef enum _sai_bfd_session_attr_t
     SAI_BFD_SESSION_ATTR_NEXT_HOP_ID,
 
     /**
+     * @brief Admin state
+     *
+     * Allows user to administratively disable a BFD session without deleting it. Setting this
+     * attribute to false disables the session.
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default true
+     */
+    SAI_BFD_SESSION_ATTR_ADMIN_STATE,
+
+    /**
      * @brief End of attributes
      */
     SAI_BFD_SESSION_ATTR_END,


### PR DESCRIPTION
SAI_BFD_SESSION_ATTR_ADMIN_STATE adds explicit administrative control of a BFD session (true by default, CREATE_AND_SET).
When set to false, the session is placed in administratively disabled state without deleting the BFD object, which aligns with BFD administrative control behavior. Adds standards-aligned admin down/up control semantics for BFD sessions.

Use cases:
This can be used to cleanly suppress protocol activity during maintenance, staged bring-up, or troubleshooting, while preserving session configuration and object lifecycle. Avoiding delete/recreate churn for temporary disablement.