### PR TITLE
Count BFD session state changes from UP to DOWN

### DIFF
--- a/inc/saibfd.h
+++ b/inc/saibfd.h
@@ -589,7 +589,10 @@ typedef enum _sai_bfd_session_stat_t
     SAI_BFD_SESSION_STAT_OUT_PACKETS,
 
     /** Packet Drop stat count */
-    SAI_BFD_SESSION_STAT_DROP_PACKETS
+    SAI_BFD_SESSION_STAT_DROP_PACKETS,
+
+    /** Count transitions where the session state changes from UP to DOWN */
+    SAI_BFD_SESSION_STAT_SESSION_UP2DOWN_TRANSITIONS
 
 } sai_bfd_session_stat_t;
 


### PR DESCRIPTION
It is number of BFD session UP-DOWN transitions. Counts transitions where the session state changes from UP to DOWN.
It helps Identify unstable links/neighbors by tracking how often a BFD session drops (flaps) from UP to DOWN.