### PR TITLE
HW FRR switchover notification support for protection groups 

### DIFF
--- a/doc/SAI-Proposal-HW-FRR.md
+++ b/doc/SAI-Proposal-HW-FRR.md
@@ -158,3 +158,50 @@ if (saistatus != SAI_STATUS_SUCCESS) {
     return saistatus;
 }
 ```
+
+## 5.0 Per-Monitored-Object Switchover Notification
+
+To provide NOS visibility for HW-triggered FRR, add a switch-level notification callback.
+Notification is generated per monitored object, and one monitored object may point to multiple protection groups.
+
+### Notification
+
+```c
+typedef struct _sai_next_hop_group_hw_protection_switchover_notification_data_t
+{
+    sai_object_id_t monitored_oid;     // monitored object id
+    sai_next_hop_group_member_observed_role_t new_role // Current role after the switchover
+    uint32_t        switchover_success_count;  // number of protection groups switched successfully
+    sai_object_list_t failed_next_hop_groups; // failed protection-group object ids
+} sai_next_hop_group_hw_protection_switchover_notification_data_t;
+
+typedef void (*sai_next_hop_group_hw_protection_switchover_notification_fn)(
+        _In_ uint32_t count,
+        _In_ const sai_next_hop_group_hw_protection_switchover_notification_data_t *data);
+```
+
+### Switch attribute for callback registration
+
+```c
+SAI_SWITCH_ATTR_NEXT_HOP_GROUP_HW_PROTECTION_SWITCHOVER_NOTIFY
+```
+
+### Usage example
+
+```c
+switch_attr.id = SAI_SWITCH_ATTR_NEXT_HOP_GROUP_HW_PROTECTION_SWITCHOVER_NOTIFY;
+switch_attr.value.ptr = (void*)nhg_hw_protection_switchover_cb;
+sai_switch_api->set_switch_attribute(switch_id, &switch_attr);
+```
+
+Example callback report:
+```c
+  monitored_oid = <monitored_object_oid>
+  new_role = SAI_NEXT_HOP_GROUP_MEMBER_CONFIGURED_ROLE_STANDBY
+  switchover_success_count = 5
+  failed_next_hop_groups.count = 2
+  failed_next_hop_groups.list[0] = failed_nhg_oid1
+  failed_next_hop_groups.list[1] = failed_nhg_oid2
+```
+In this example, `switchover_success_count = 5` means five protection groups switched over successfully
+for the monitored object, while `failed_next_hop_groups.count = 2` means two protection groups failed.

--- a/inc/sainexthopgroup.h
+++ b/inc/sainexthopgroup.h
@@ -112,6 +112,36 @@ typedef enum _sai_next_hop_group_admin_role_t
 } sai_next_hop_group_admin_role_t;
 
 /**
+ * @brief Defines the HW protection switchover status
+ */
+typedef struct _sai_next_hop_group_hw_protection_switchover_notification_data_t
+{
+    /**
+     * @brief Monitored object id
+     *
+     * @objects SAI_OBJECT_TYPE_PORT, SAI_OBJECT_TYPE_LAG, SAI_OBJECT_TYPE_ROUTER_INTERFACE, SAI_OBJECT_TYPE_VLAN_MEMBER, SAI_OBJECT_TYPE_TUNNEL, SAI_OBJECT_TYPE_BRIDGE_PORT, SAI_OBJECT_TYPE_ICMP_ECHO_SESSION, SAI_OBJECT_TYPE_BFD_SESSION
+     */
+    sai_object_id_t monitored_oid;
+
+    /**
+     * @brief Current role after the switchover
+     */
+    sai_next_hop_group_member_observed_role_t new_role;
+
+    /**
+     * @brief Number of protection groups that switched over successfully
+     */
+    uint32_t switchover_success_count;
+
+    /**
+     * @brief List of protection groups that failed switchover.
+     *
+     * @objects SAI_OBJECT_TYPE_NEXT_HOP_GROUP
+     */
+    sai_object_list_t failed_next_hop_groups;
+} sai_next_hop_group_hw_protection_switchover_notification_data_t;
+
+/**
  * @brief Attribute id for next hop
  */
 typedef enum _sai_next_hop_group_attr_t
@@ -682,6 +712,20 @@ typedef sai_status_t (*sai_get_next_hop_group_map_attribute_fn)(
         _In_ sai_object_id_t next_hop_group_map_id,
         _In_ uint32_t attr_count,
         _Inout_ sai_attribute_t *attr_list);
+
+/**
+ * @brief Next Hop Group HW protection switchover notification callback
+ *
+ * Passed as a parameter into sai_initialize_switch().
+ *
+ * @count data[count]
+ *
+ * @param[in] count Number of notifications
+ * @param[in] data Array of notification data
+ */
+typedef void (*sai_next_hop_group_hw_protection_switchover_notification_fn)(
+        _In_ uint32_t count,
+        _In_ const sai_next_hop_group_hw_protection_switchover_notification_data_t *data);
 
 /**
  * @brief Next Hop methods table retrieved with sai_api_query()

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -3599,6 +3599,15 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_PTP_SYNTONIZE_ADJUST,
 
     /**
+     * @brief HW protection switchover notification callback function passed to the adapter.
+     *
+     * @type sai_pointer_t sai_next_hop_group_hw_protection_switchover_notification_fn
+     * @flags CREATE_AND_SET
+     * @default NULL
+     */
+    SAI_SWITCH_ATTR_NEXT_HOP_GROUP_HW_PROTECTION_SWITCHOVER_NOTIFY,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,

--- a/meta/parse.pl
+++ b/meta/parse.pl
@@ -2695,6 +2695,7 @@ sub ProcessStructValueType
     my $type = shift;
 
     return "SAI_ATTR_VALUE_TYPE_OBJECT_ID"        if $type eq "sai_object_id_t";
+    return "SAI_ATTR_VALUE_TYPE_OBJECT_LIST"      if $type eq "sai_object_list_t";
     return "SAI_ATTR_VALUE_TYPE_MAC"              if $type eq "sai_mac_t";
     return "SAI_ATTR_VALUE_TYPE_IP_ADDRESS"       if $type eq "sai_ip_address_t";
     return "SAI_ATTR_VALUE_TYPE_IP_PREFIX"        if $type eq "sai_ip_prefix_t";
@@ -2743,7 +2744,7 @@ sub ProcessStructObjects
 
     my $type = $struct->{type};
 
-    return "NULL" if not $type eq "sai_object_id_t" and not $type eq "sai_attribute_t*";
+    return "NULL" if not $type eq "sai_object_id_t" and not $type eq "sai_object_list_t" and not $type eq "sai_attribute_t*";
 
     WriteSource "const sai_object_type_t sai_metadata_struct_member_sai_${rawname}_t_${key}_allowed_objects[] = {";
 
@@ -2767,7 +2768,7 @@ sub ProcessStructObjectLen
 
     my $type = $struct->{type};
 
-    return 0 if not $type eq "sai_object_id_t" and not $type eq "sai_attribute_t*";
+    return 0 if not $type eq "sai_object_id_t" and not $type eq "sai_object_list_t" and not $type eq "sai_attribute_t*";
 
     my @objects = @{ $struct->{objects} };
 
@@ -4172,13 +4173,13 @@ sub ProcessSingleNonObjectId
 
         # allowed entries on object structs
 
-        if (not $type =~ /^sai_(nat_entry_data|mac|object_id|vlan_id|ip_address|ip_prefix|acl_chain|label_id|ip6|uint8|uint16|uint32|u32_range|\w+_type)_t$/)
+        if (not $type =~ /^sai_(nat_entry_data|mac|object_id|object_list|vlan_id|ip_address|ip_prefix|acl_chain|label_id|ip6|uint8|uint16|uint32|u32_range|\w+_type)_t$/)
         {
             LogError "struct member $member type '$type' is not allowed on struct $structname";
             next;
         }
 
-        next if not $type eq "sai_object_id_t";
+        next if not $type eq "sai_object_id_t" and not $type eq "sai_object_list_t";
 
         my $objects = ExtractObjectsFromDesc($structname, $member, $desc);
 
@@ -5536,7 +5537,7 @@ sub ProcessNotificationStruct
         next if $type =~ /^(uint32_t|bool)$/;
         next if $type =~ /^(sai_twamp_session_stats_data_t)$/;
 
-        if ($type =~ /^(sai_object_id_t|sai_attribute_t\*)$/)
+        if ($type =~ /^(sai_object_id_t|sai_object_list_t|sai_attribute_t\*)$/)
         {
             my $objects = ExtractObjectsFromDesc($structname, $member, $desc);
 

--- a/meta/templates/sai_rpc_server_helper_functions.tt
+++ b/meta/templates/sai_rpc_server_helper_functions.tt
@@ -122,7 +122,7 @@ void sai_thrift_parse_[% struct.short_name %](const [% struct.thrift_name %] &th
 #ifdef UNSUPPORTED /* complex struct members are not supported yet */
 
         [%- END -%]
-  [% struct.short_name %]->[% member.name %] = thrift_[% struct.short_name %].[% member.name %];
+  [% struct.short_name %]->[% member.name %] = static_cast<[% member.type.name %]>(thrift_[% struct.short_name %].[% member.name %]);
 
         [%- IF member.type.thrift_name.match(unsupported_fields) -%]
 #endif


### PR DESCRIPTION
Added HW FRR switchover notification support for protection groups with a switch-level callback. The new callback reports switchover results per monitored object, including: monitored_oid,
switchover_success_count, and list protection groups that failed switchover. The callback is registered
through SAI_SWITCH_ATTR_NEXT_HOP_GROUP_HW_PROTECTION_SWITCHOVER_NOTIFY.