### PR TITLE
saiport: Add counters for 1519_TO_MAX_OCTETS packet size range

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -4042,13 +4042,13 @@ typedef enum _sai_port_stat_t
     /** SAI port stat credits freed update messages rx */
     SAI_PORT_STAT_CBFC_NUM_CF_UPDATE_MESSAGES_RX,
 
-    /** SAI port stat ether stats packets with frame size 1519 octets to max MTU supported by the port */
+    /** Number of packets with frame size 1519 octets to max MTU supported by the port */
     SAI_PORT_STAT_ETHER_STATS_PKTS_1519_TO_MAX_OCTETS,
 
-    /** SAI port stat ether RX packets with frame size 1519 octets to max MTU supported by the port */
+    /** Number of received packets with frame size 1519 octets to max MTU supported by the port */
     SAI_PORT_STAT_ETHER_IN_PKTS_1519_TO_MAX_OCTETS,
 
-    /** SAI port stat ether TX packets with frame size 1519 octets to max MTU supported by the port */
+    /** Number of transmitted packets with frame size 1519 octets to max MTU supported by the port */
     SAI_PORT_STAT_ETHER_OUT_PKTS_1519_TO_MAX_OCTETS,
 
     /** Port stat in drop reasons range start */

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -4042,6 +4042,15 @@ typedef enum _sai_port_stat_t
     /** SAI port stat credits freed update messages rx */
     SAI_PORT_STAT_CBFC_NUM_CF_UPDATE_MESSAGES_RX,
 
+    /** SAI port stat ether stats packets with frame size 1519 octets to max MTU supported by the port */
+    SAI_PORT_STAT_ETHER_STATS_PKTS_1519_TO_MAX_OCTETS,
+
+    /** SAI port stat ether RX packets with frame size 1519 octets to max MTU supported by the port */
+    SAI_PORT_STAT_ETHER_IN_PKTS_1519_TO_MAX_OCTETS,
+
+    /** SAI port stat ether TX packets with frame size 1519 octets to max MTU supported by the port */
+    SAI_PORT_STAT_ETHER_OUT_PKTS_1519_TO_MAX_OCTETS,
+
     /** Port stat in drop reasons range start */
     SAI_PORT_STAT_IN_DROP_REASON_RANGE_BASE = 0x00001000,
 


### PR DESCRIPTION
Add a new port statistic for ASICs that expose a single aggregate jumbo packet counter instead of the detailed SAI jumbo histogram buckets (1519–2047, 2048–4095, 4096–9216, 9217–16383).

The following counters are introduced:
- SAI_PORT_STAT_ETHER_STATS_PKTS_1519_TO_MAX_OCTETS
- SAI_PORT_STAT_ETHER_IN_PKTS_1519_TO_MAX_OCTETS
- SAI_PORT_STAT_ETHER_OUT_PKTS_1519_TO_MAX_OCTETS

The new counter reports packets with frame length greater than 1518 octets up to the maximum frame size supported by the port hardware (MAX_OCTETS). This enables platforms that provide only a cumulative jumbo packet counter to expose the statistic through SAI.

If the underlying ASIC provides packet length histogram counters, vendors may derive and expose this cumulative counter by aggregating the corresponding histogram buckets.

From a user perspective, a cumulative jumbo packet counter provides a simple view of jumbo traffic without requiring consumers to interpret or sum multiple histogram counters.