### PR TITLE
MACSEC: Add additional IEEE 802.1ae stats for SA

### DIFF
--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -1108,6 +1108,22 @@ typedef enum _sai_macsec_sa_stat_t
      * Valid for ingress, always returns 0 for egress.
      */
     SAI_MACSEC_SA_STAT_IN_PKTS_OK,
+
+    /**
+     * @brief IEEE 802.1ae defined inOctetsDecrypted.
+     * Valid for ingress, always returns 0 for egress.
+     * The number of octets of User Data recovered from received
+     * frames that were both integrity protected and encrypted.
+     */
+    SAI_MACSEC_SA_STAT_IN_OCTETS_DECRYPTED,
+
+    /**
+     * @brief IEEE 802.1ae defined inOctetsValidated.
+     * Valid for ingress, always returns 0 for egress.
+     * The number of octets of User Data recovered from received
+     * frames that were integrity protected but not encrypted.
+     */
+    SAI_MACSEC_SA_STAT_IN_OCTETS_VALIDATED,
 } sai_macsec_sa_stat_t;
 
 /**


### PR DESCRIPTION
# Add IEEE 802.1AE Ingress Octet Statistics for MACsec SA

## Summary

This PR adds two missing IEEE 802.1AE-2018 mandatory statistics counters to the SAI MACsec SA ingress statistics:
- `SAI_MACSEC_SA_STAT_IN_OCTETS_DECRYPTED`
- `SAI_MACSEC_SA_STAT_IN_OCTETS_VALIDATED`

These counters provide visibility into the volume of plaintext data recovered from MACsec-protected frames, differentiating between encrypted and integrity-only traffic.

## Motivation

### Standards Compliance Enhancement

The SAI MACsec implementation already provides comprehensive packet-level statistics (IN_PKTS_OK, IN_PKTS_DELAYED, etc.). This PR extends this by adding the complementary octet-level counters specified in IEEE 802.1AE-2018 Clause 10.7.9, completing the full statistics suite for IEEE 802.1AE compliance.