### PR TITLE
[SAI] Update SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_VR_ID flags and default value.

### DIFF
--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -992,8 +992,9 @@ typedef enum _sai_tunnel_term_table_entry_attr_t
      * the termination entry key
      *
      * @type sai_object_id_t
-     * @flags MANDATORY_ON_CREATE | CREATE_AND_SET
+     * @flags CREATE_ONLY
      * @objects SAI_OBJECT_TYPE_VIRTUAL_ROUTER
+     * @default SAI_NULL_OBJECT_ID
      * @deprecated true
      */
     SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_VR_ID = SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_START,


### PR DESCRIPTION
Description:
Update SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_VR_ID flags and default value:

This PR modifies the attribute flags for SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_VR_ID in saitunnel.h. It changes the attribute from being mandatory during creation to having a default value of SAI_NULL_OBJECT_ID, and updates its operational flags to CREATE_ONLY.