### PR TITLE
Add queue DLR deleted packets and bytes stats

### DIFF
--- a/inc/saiqueue.h
+++ b/inc/saiqueue.h
@@ -465,6 +465,12 @@ typedef enum _sai_queue_stat_t
     /** Packets trimmed and successfully transmitted on a trim queue. Counted on the original trimming-eligible queue [uint64_t] */
     SAI_QUEUE_STAT_TX_TRIM_PACKETS = 0x0000002e,
 
+    /** Get packets deleted from a queue when PFC Deadlock Recovery is triggered with SAI_PACKET_ACTION_DROP [uint64_t] */
+    SAI_QUEUE_STAT_PFC_DLR_DELETED_PACKETS = 0x0000002f,
+
+    /** Get bytes deleted from a queue when PFC Deadlock Recovery is triggered with SAI_PACKET_ACTION_DROP [uint64_t] */
+    SAI_QUEUE_STAT_PFC_DLR_DELETED_BYTES = 0x00000030,
+
     /** Custom range base value */
     SAI_QUEUE_STAT_CUSTOM_RANGE_BASE = 0x10000000
 


### PR DESCRIPTION
# Add PFC DLR deleted packets and bytes statistics to SAI queue attributes

## Description:

This PR introduces two new SAI queue statistics attributes to support Priority Flow Control (PFC) Deadlock Recovery (DLR) diagnostics:

```
SAI_QUEUE_STAT_PFC_DLR_DELETED_PACKETS
SAI_QUEUE_STAT_PFC_DLR_DELETED_BYTES
```

## Purpose

When PFC DLR is enabled with SAI_PACKET_ACTION_DROP, these statistics track packets and bytes that are deleted during deadlock recovery operations. This provides essential visibility into traffic management behavior during PFC deadlock scenarios.

## Rationale

These attributes follow the existing pattern established by SAI_QUEUE_STAT_CREDIT_WD_DELETED_PACKETS and complement the credit watchdog statistics by providing comprehensive deleted traffic metrics for PFC DLR operations.

## Benefits

- Enhanced Diagnostics: Enables network operators to monitor and analyze PFC deadlock recovery effectiveness
- Traffic Management: Provides granular visibility into deleted traffic during congestion management
- Consistency: Maintains alignment with existing queue statistics patterns