### PR TITLE
[DASH] Add ENI HA operational flow owner attribute

### DIFF
--- a/experimental/saiexperimentaldasheni.h
+++ b/experimental/saiexperimentaldasheni.h
@@ -566,6 +566,14 @@ typedef enum _sai_eni_attr_t
     SAI_ENI_ATTR_DASH_ENI_MODE,
 
     /**
+     * @brief HA flow ownership operational status
+     *
+     * @type bool
+     * @flags READ_ONLY
+     */
+    SAI_ENI_ATTR_IS_OPERATIONAL_HA_FLOW_OWNER,
+
+    /**
      * @brief End of attributes
      */
     SAI_ENI_ATTR_END,


### PR DESCRIPTION
This ENI attribute is supported in the DPU driven HA mode of operation. 
It indicates which of the HA paired DPUs is the operational owner for flows belonging to the ENI. 
The operational owner can be different from the configured HA owner in case of HA failover.