### PR TITLE
[SAI] Add SAI_IPMC_GROUP_ATTR_LABEL and SAI_NEXT_HOP_GROUP_ATTR_LABEL.

### DIFF
--- a/inc/saiipmcgroup.h
+++ b/inc/saiipmcgroup.h
@@ -81,6 +81,15 @@ typedef enum _sai_ipmc_group_attr_t
     SAI_IPMC_GROUP_ATTR_IPMC_OUTPUT_LIST,
 
     /**
+     * @brief Label attribute used to uniquely identify IPMC-group.
+     *
+     * @type char
+     * @flags CREATE_AND_SET
+     * @default ""
+     */
+    SAI_IPMC_GROUP_ATTR_LABEL,
+
+    /**
      * @brief End of attributes
      */
     SAI_IPMC_GROUP_ATTR_END,

--- a/inc/sail2mcgroup.h
+++ b/inc/sail2mcgroup.h
@@ -61,6 +61,15 @@ typedef enum _sai_l2mc_group_attr_t
     SAI_L2MC_GROUP_ATTR_L2MC_MEMBER_LIST,
 
     /**
+     * @brief Label attribute used to uniquely identify L2MC-group.
+     *
+     * @type char
+     * @flags CREATE_AND_SET
+     * @default ""
+     */
+    SAI_L2MC_GROUP_ATTR_LABEL,
+
+    /**
      * @brief End of attributes
      */
     SAI_L2MC_GROUP_ATTR_END,

--- a/inc/sainexthop.h
+++ b/inc/sainexthop.h
@@ -270,6 +270,15 @@ typedef enum _sai_next_hop_attr_t
     SAI_NEXT_HOP_ATTR_META_DATA,
 
     /**
+     * @brief Label attribute used to uniquely identify next-hop.
+     *
+     * @type char
+     * @flags CREATE_AND_SET
+     * @default ""
+     */
+    SAI_NEXT_HOP_ATTR_LABEL,
+
+    /**
      * @brief End of attributes
      */
     SAI_NEXT_HOP_ATTR_END,

--- a/inc/sainexthopgroup.h
+++ b/inc/sainexthopgroup.h
@@ -399,6 +399,17 @@ typedef enum _sai_next_hop_group_attr_t
     SAI_NEXT_HOP_GROUP_ATTR_MEMBERS_WEIGHT,
 
     /**
+     * @brief Weighted multi path configuration mode.
+     * false: Nexthop group is programmed with repeated member entries proportional to their weight
+     * true: Nexthop group is programmed with switch native configuration
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_NEXT_HOP_GROUP_ATTR_NATIVE_WCMP,
+
+    /**
      * @brief End of attributes
      */
     SAI_NEXT_HOP_GROUP_ATTR_END,


### PR DESCRIPTION
Description:
Introduce unique label attributes to IPMC groups, L2MC groups, and Next Hop objects:

This PR adds SAI_IPMC_GROUP_ATTR_LABEL, SAI_L2MC_GROUP_ATTR_LABEL, and SAI_NEXT_HOP_ATTR_LABEL as string-type attributes across their respective headers. These new attributes are defined with CREATE_AND_SET flags and a default empty string to enable unique identification and improved management of these resources.

what i did:
Added a LABEL attribute to IPMC groups, L2MC groups, and Next Hop objects.

why i did:
To allow unique string-based identification and easier tracking of these resources.