### PR TITLE
Link Down Debounce Feature

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -3268,6 +3268,18 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_CBFC_CREDIT_POOL_LIST,
 
     /**
+     * @brief Link down debounce time in microseconds
+     *
+     * 0 means no delay time so link down events are immediately delivered as usual
+     * This attribute overrides the switch level debounce configuration
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_PORT_ATTR_LINK_DOWN_DEBOUNCE_TIMEOUT,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_ATTR_END,

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -3482,6 +3482,18 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_APSU_ISL_READY,
 
     /**
+     * @brief Link down debounce time in microseconds
+     *
+     * 0 means no delay time so link down events are immediately delivered as usual
+     * This attribute overrides the switch level debounce configuration
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_PORT_ATTR_LINK_DOWN_DEBOUNCE_TIMEOUT,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_ATTR_END,

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -3599,6 +3599,17 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_PTP_SYNTONIZE_ADJUST,
 
     /**
+     * @brief Link down debounce time in microseconds
+     *
+     * 0 means no delay time so link down events are immediately delivered as usual
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_SWITCH_ATTR_LINK_DOWN_DEBOUNCE_TIMEOUT,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -3610,6 +3610,22 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_LINK_DOWN_DEBOUNCE_TIMEOUT,
 
     /**
+     * @brief Link down debounce timeout values supported in microseconds
+     *
+     * @type sai_u32_list_t
+     * @flags READ_ONLY
+     */
+    SAI_SWITCH_ATTR_LINK_DOWN_DEBOUNCE_TIMEOUT_INTEVALS,
+
+    /**
+     * @brief Link up debounce timeout values supported in microseconds
+     *
+     * @type sai_u32_list_t
+     * @flags READ_ONLY
+     */
+    SAI_SWITCH_ATTR_LINK_UP_DEBOUNCE_TIMEOUT_INTEVALS,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -3653,6 +3653,33 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_TAM_EVENT_LEARN_NOTIFY,
 
     /**
+     * @brief Link down debounce time in microseconds
+     *
+     * 0 means no delay time so link down events are immediately delivered as usual
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_SWITCH_ATTR_LINK_DOWN_DEBOUNCE_TIMEOUT,
+
+    /**
+     * @brief Link down debounce timeout values supported in microseconds
+     *
+     * @type sai_u32_list_t
+     * @flags READ_ONLY
+     */
+    SAI_SWITCH_ATTR_LINK_DOWN_DEBOUNCE_TIMEOUT_INTEVALS,
+
+    /**
+     * @brief Link up debounce timeout values supported in microseconds
+     *
+     * @type sai_u32_list_t
+     * @flags READ_ONLY
+     */
+    SAI_SWITCH_ATTR_LINK_UP_DEBOUNCE_TIMEOUT_INTEVALS,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,


### PR DESCRIPTION
Link down delay works by establishing a link down debounce/delay timer. In a link state transition from up -> down, the timer starts but the link down notification is suppressed until the timer expires. 
Link down events are typically immediately notified for the short reach interconnects as protocols need to converge faster but for long distance cables, there is a ripple effect of link down and debounce feature is very useful without creating a churn in protocol states.