### PR TITLE
EVPN VXLAN multihoming: split-horizon for P2MP tunnels

### DIFF
--- a/doc/tunnel/SAI-Proposal-EVPN-Multihoming.md
+++ b/doc/tunnel/SAI-Proposal-EVPN-Multihoming.md
@@ -32,6 +32,7 @@
 | ---- | ---------  | ------------------------------------------------ | ------------------ |
 | 0.1  | Sep 23' 2024   | Jai Kumar, Rajesh Sankaran                   | Initial draft  |
 | 0.2  | Oct 23' 2024   | Rajesh Sankaran                              | Changed DF, single active attributes |
+| 0.3  | May 18' 2026   | James Andrew                                 | Added split-horizon support for P2MP tunnels |
 
 
 # 1.0  Introduction
@@ -199,11 +200,59 @@ typedef enum _sai_vlan_member_attr_t
 
 ### 3.2.3 Split Horizon support
 
-  - Tunnels of peer mode SAI_TUNNEL_PEER_MODE_P2P are only considered here. 
   - The isolation group object of type SAI_ISOLATION_GROUP_TYPE_BRIDGE_PORT is used to achieve the split horizon functionality.
   - There is no change to the Isolation group and group member definition.
-  - Bridgeport of type SAI_BRIDGE_PORT_TYPE_TUNNEL will have the isolation group attribute set.
+  - For SAI_TUNNEL_PEER_MODE_P2P tunnels:
+    - each tunnel is associated with a particular remote VTEP and has an
+    associated bridge port of type SAI_BRIDGE_PORT_TYPE_TUNNEL.
+    - This per-remote-VTEP bridge port of type SAI_BRIDGE_PORT_TYPE_TUNNEL will
+    have the isolation group attribute set.
+  - For SAI_TUNNEL_PEER_MODE_P2MP tunnels:
+    - We introduce a new bridge port type SAI_BRIDGE_PORT_TYPE_TUNNEL_TERM_PEER
+    with an associated attribute SAI_BRIDGE_PORT_ATTR_TUNNEL_TERM_PEER_IP. This
+    bridge port represents decapsulated tunnel-terminated traffic from a
+    specific remote VTEP. It is explicitly rx-only and cannot be used for
+    encap/tx.
+    - THis per-remote_VTEP bridge port of type
+      SAI_BRIDGE_PORT_TYPE_TUNNEL_TERM_PEER will have the isolation group
+      attribute set.
   - The isolation group members will be the client side bridge ports of type SAI_BRIDGE_PORT_TYPE_PORT which share the ESI with the peering VTEPs.
+
+
+```
+typedef enum _sai_bridge_port_type_t
+...
+
+    /**
+     * @brief Bridge tunnel peer termination port
+     *
+     * Bridge port for traffic terminated from a specific tunnel peer.
+     * Tunnel should use peer mode P2MP.
+     */
+    SAI_BRIDGE_PORT_TYPE_TUNNEL_TERM_PEER,
+} sai_bridge_port_type_t;
+```
+
+The Bridge-port of type SAI_BRIDGE_PORT_TYPE_TUNNEL_TERM_PEER should have SAI_BRIDGE_PORT_ATTR_TUNNEL_ID and SAI_BRIDGE_PORT_ATTR_TUNNEL_TERM_PEER_IP attributes set.
+
+```
+typedef enum _sai_bridge_port_attr_t
+{
+...
+    /**
+     * @brief Tunnel peer IP address
+     *
+     * Identifies the peer (remote tunnel endpoint) from which tunnel-terminated
+     * traffic is received on this bridge port.
+     *
+     * @type sai_ip_address_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_BRIDGE_PORT_ATTR_TYPE == SAI_BRIDGE_PORT_TYPE_TUNNEL_TERM_PEER
+     */
+    SAI_BRIDGE_PORT_ATTR_TUNNEL_TERM_PEER_IP,
+...
+}
+```
 
 ### 3.2.4 Fast Failover support
 
@@ -486,12 +535,14 @@ At VTEP5 the following objects are created.
 
 ## 4.2 Split Horizon workflow
 
+![EVPN Multihoming](figures/sai_evpnmh_splithorizon.png "Figure 1: Split Horizon")
+__Figure 2: Split Horizon Flow__
+
+## 4.2.1 Tunnel peer mode type P2P
+
   When Tunnel objects of peer mode type P2P are created, the isolation group objects can be re-used 
   to achieve the split horizon functionality and do not need the attributes being introduced as part of this
   PR. It is being elaborated here for completeness.
-
-![EVPN Multihoming](figures/sai_evpnmh_splithorizon.png "Figure 1: Split Horizon")
-__Figure 2: Split Horizon Flow__
 
   At VTEP1 the following SAI objects with sub types are created.
 
@@ -537,9 +588,25 @@ __Figure 2: Split Horizon Flow__
         /* Repeat for all combinations */
         .............
         .............
-                                                                        
+
 ```
 
+## 4.2.2 Tunnel peer mode type P2MP
+
+When Tunnel objects of peer mode type P2MP are used, we use bridge ports of
+type SAI_BRIDGE_PORT_TYPE_TUNNEL_TERM_PEER with the
+SAI_BRIDGE_PORT_ATTR_TUNNEL_TERM_PEER_IP attribute to associate the isolation
+group object with tunnel-terminated packets from a particular remote VTEP.
+
+At VTEP1 the following SAI objects with sub types are created.
+
+- SAI_OBJECT_TYPE_TUNNEL with peer mode as SAI_TUNNEL_PEER_MODE_P2MP, tnl_oid.
+- SAI_OBJECT_TYPE_BRIDGE_PORT of type SAI_BRIDGE_PORT_TYPE_TUNNEL_TERM_PEER, bp_tnl_oid_2-4 corresponding to each remote VTEP, with SAI_BRIDGE_PORT_ATTR_REMOTE_TUNNEL_TERM_PEER_IP set to the IP of VTEPs2-4 respectively. All bridge ports bp_tnl_oid_2-4 set the SAI_BRIDGE_PORT_ATTR_TUNNEL_ID to the same P2MP tunnel tnl_oid.
+- SAI_OBJECT_TYPE_BRIDGE_PORT of type SAI_BRIDGE_PORT_TYPE_PORT, bp_lag_oid_1-2 corresponding to client side LAGs 1,2.
+- SAI_OBJECT_TYPE_ISOLATION_GROUP of type SAI_ISOLATION_GROUP_TYPE_BRIDGE_PORT, isogrp_oid_2-4 corresponding to bp_tnl_oid_2-4 as above.
+- bp_tnl_oid_2-4 have SAI_BRIDGE_PORT_ATTR_ISOLATION_GROUP set as isogrp_oid_2-4 respectively.
+
+The remainder of the flow is identical to [4.2.1 Tunnel peer mode type P2P](421-tunnel-peer-mode-type-p2p).
 
 ## 4.3 DF workflow
 

--- a/inc/saibridge.h
+++ b/inc/saibridge.h
@@ -89,6 +89,14 @@ typedef enum _sai_bridge_port_type_t
 
     /** Nexthop group should be of type bridge port */
     SAI_BRIDGE_PORT_TYPE_BRIDGE_PORT_NEXT_HOP_GROUP,
+
+    /**
+     * @brief Bridge tunnel termination peer port
+     *
+     * Bridge port for traffic terminated from a specific tunnel peer.
+     * Tunnel object should use peer mode P2MP.
+     */
+    SAI_BRIDGE_PORT_TYPE_TUNNEL_TERM_PEER,
 } sai_bridge_port_type_t;
 
 /**
@@ -175,7 +183,7 @@ typedef enum _sai_bridge_port_attr_t
      * @type sai_object_id_t
      * @flags MANDATORY_ON_CREATE | CREATE_ONLY
      * @objects SAI_OBJECT_TYPE_TUNNEL
-     * @condition SAI_BRIDGE_PORT_ATTR_TYPE == SAI_BRIDGE_PORT_TYPE_TUNNEL
+     * @condition SAI_BRIDGE_PORT_ATTR_TYPE == SAI_BRIDGE_PORT_TYPE_TUNNEL or SAI_BRIDGE_PORT_ATTR_TYPE == SAI_BRIDGE_PORT_TYPE_TUNNEL_TERM_PEER
      */
     SAI_BRIDGE_PORT_ATTR_TUNNEL_ID,
 
@@ -185,7 +193,7 @@ typedef enum _sai_bridge_port_attr_t
      * @type sai_object_id_t
      * @flags MANDATORY_ON_CREATE | CREATE_AND_SET
      * @objects SAI_OBJECT_TYPE_BRIDGE
-     * @condition SAI_BRIDGE_PORT_ATTR_TYPE == SAI_BRIDGE_PORT_TYPE_SUB_PORT or SAI_BRIDGE_PORT_ATTR_TYPE == SAI_BRIDGE_PORT_TYPE_1D_ROUTER or SAI_BRIDGE_PORT_ATTR_TYPE == SAI_BRIDGE_PORT_TYPE_TUNNEL or SAI_BRIDGE_PORT_ATTR_TYPE == SAI_BRIDGE_PORT_TYPE_BRIDGE_PORT_NEXT_HOP_GROUP
+     * @condition SAI_BRIDGE_PORT_ATTR_TYPE == SAI_BRIDGE_PORT_TYPE_SUB_PORT or SAI_BRIDGE_PORT_ATTR_TYPE == SAI_BRIDGE_PORT_TYPE_1D_ROUTER or SAI_BRIDGE_PORT_ATTR_TYPE == SAI_BRIDGE_PORT_TYPE_TUNNEL or SAI_BRIDGE_PORT_ATTR_TYPE == SAI_BRIDGE_PORT_TYPE_BRIDGE_PORT_NEXT_HOP_GROUP or SAI_BRIDGE_PORT_ATTR_TYPE == SAI_BRIDGE_PORT_TYPE_TUNNEL_TERM_PEER
      */
     SAI_BRIDGE_PORT_ATTR_BRIDGE_ID,
 
@@ -353,6 +361,18 @@ typedef enum _sai_bridge_port_attr_t
      * @validonly SAI_BRIDGE_PORT_ATTR_TYPE == SAI_BRIDGE_PORT_TYPE_PORT
      */
     SAI_BRIDGE_PORT_ATTR_BRIDGE_PORT_SET_SWITCHOVER,
+
+    /**
+     * @brief Tunnel peer IP address
+     *
+     * Identifies the peer (remote tunnel endpoint) from which tunnel-terminated
+     * traffic is received on this bridge port.
+     *
+     * @type sai_ip_address_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     * @condition SAI_BRIDGE_PORT_ATTR_TYPE == SAI_BRIDGE_PORT_TYPE_TUNNEL_TERM_PEER
+     */
+    SAI_BRIDGE_PORT_ATTR_TUNNEL_TERM_PEER_IP,
 
     /**
      * @brief End of attributes


### PR DESCRIPTION
This change adds a new bridge port type to enable split-horizon filtering for P2MP VXLAN tunnels. This provides parity with the existing P2P tunnel model without requiring vendor-specific ACL logic in the NOS.

The existing spec for EVPN VXLAN multihoming ([SAI-Proposal-EVPN-Multihoming.md](https://github.com/opencomputeproject/SAI/blob/master/doc/tunnel/SAI-Proposal-EVPN-Multihoming.md) provides an example for configuring split-horizon which targets only P2P tunnels. Vendors using only P2MP tunnels have no equivalent path within the current API.

Split-horizon requires the ability to attach isolation groups at per-remote-VTEP granularity. With P2P tunnels this falls out naturally since each remote VTEP already has its own tunnel object and bridge port. With P2MP tunnels there's a single shared tunnel object, so we need something else to hang the isolation group on.

This change introduces a new bridge port type, `SAI_BRIDGE_PORT_TYPE_TUNNEL_TERM_PEER`, with an associated attribute `SAI_BRIDGE_PORT_ATTR_TUNNEL_TERM_PEER_IP`. This bridge port represents decapsulated tunnel-terminated traffic from a specific remote VTEP. It is explicitly rx-only and cannot be used for encap/tx.

A dedicated bridge port type makes it clear that these objects exist solely to deumultiplex inbound decapsulated traffic by source VTEP, giving the NOS a per-peer object to attach isolation groups to. This avoids any ambiguity with the existing `SAI_BRIDGE_PORT_TYPE_TUNNEL`, which is used for encap (via FDB entries, L2MC groups, next hops), and may still be used for decap in scenarios which do not require per-remote VTEP demux.

The flow for configuring split-horizon with P2MP tunnels then mirrors the P2P case:

1. Create a P2MP tunnel object.
2. Create a `TUNNEL_TERM_PEER` bridge port per remote VTEP, specifying the peer IP.
3. Attach an isolation group to any peer bridge port whose remote VTEP shares an Ethernet Segment with the local device.
4. Add the relevant local access ports as members of that isolation group.

## Alternative approach - User-managed ACLs

The alternative is to push this into NOS-managed ACLs. This approach was proposed in [EVPN Multi Home Support #2084](https://github.com/opencomputeproject/SAI/pull/2084#discussion_r1836429887), and uses ACLs to match on `SAI_ACL_ENTRY_FIELD_TUNNEL_TERMINATED` and `SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP` to identify traffic from an ES peer, then use `SAI_ACL_ENTRY_ATTR_ACTION_SET_ISOLATION_GROUP` to block forwarding to access ports representing any ES shared with that ES peer.

ACL support is very varied between vendors, with differing stage support for fields, field/action combinations, and resource constraints. Requiring the NOS to manage ACLs pushes this vendor-specific complexity into the NOS. For example: the match fields here (source IP, tunnel terminated) are properties of the ingress/decap path, while the action (set isolation group) is an egress filtering operation. A vendor whose hardware doesn't support both at the same pipeline stage would require the NOS to use two ACL tables: one ingress ACL to identify ES-peer traffic and stamp metadata (`SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA`), and one egress ACL to match the metadata and apply the isolation group. The NOS becomes responsible for metadata value allocation as well as ACL table/entry and isolation group management. Other vendors may have different restrictions resulting in vendor-specific code in the NOS.

This approach is also inconsistent with the level of abstraction of other multi-homing scenarios. Specifically for non-designated forwarder, the existing API has attributes like `SAI_BRIDGE_PORT_ATTR_TUNNEL_TERM_BUM_TX_DROP` which assume the SAI implementation internally understands whether traffic arriving at an egress bridge port was tunnel-terminated. Requiring the NOS to separately manage ACLs that detect and mark tunnel-terminated traffic is a different level of abstraction to this.

The proposed bridge port type allows the vendor to encapsulate any pipeline-specific logic within their SAI implementation and gives the NOS a uniform model that closely mirrors the P2P split-horizon flow.