### PR TITLE
[SAI] Copy BCM sairouterinterface extensions to SAI repository.

### DIFF
--- a/inc/sainexthopgroup.h
+++ b/inc/sainexthopgroup.h
@@ -360,6 +360,17 @@ typedef enum _sai_next_hop_group_attr_t
     SAI_NEXT_HOP_GROUP_ATTR_ADMIN_ROLE,
 
     /**
+     * @brief Weighted multi path configuration mode.
+     * false: Nexthop group is programmed with repeated member entries proportional to their weight
+     * true: Nexthop group is programmed with switch native configuration
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_NEXT_HOP_GROUP_ATTR_NATIVE_WCMP,
+
+    /**
      * @brief End of attributes
      */
     SAI_NEXT_HOP_GROUP_ATTR_END,


### PR DESCRIPTION
Description::
Added experimental SAI attributes for Router Interface MAC customization and a new NATIVE_WCMP flag for Next Hop Groups.

What i did:
Defined new RIF attributes for Anycast/Source MAC control and introduced a toggle in Next Hop Groups to enable hardware-native weighted load balancing.

Why i did:
To support advanced L3 topologies (like SAG) and optimize hardware resource usage by replacing entry-repetition with native switch WCMP logic.