### PR TITLE
Add per-port MACsec PFC mode attribute

### DIFF
--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -396,6 +396,22 @@ typedef enum _sai_macsec_port_security_mode_t
 } sai_macsec_port_security_mode_t;
 
 /**
+ * @brief Attribute Data for MACsec PFC mode
+ *
+ * Controls whether PFC frames on a MACsec port are handled as clear
+ * (unencrypted) or secure (encrypted) frames.
+ */
+typedef enum _sai_macsec_port_pfc_mode_t
+{
+    /** Clear PFC: PFC frames bypass MACsec encryption */
+    SAI_MACSEC_PORT_PFC_MODE_UNENCRYPTED,
+
+    /** Secure PFC: PFC frames are MACsec-encrypted */
+    SAI_MACSEC_PORT_PFC_MODE_ENCRYPTED,
+
+} sai_macsec_port_pfc_mode_t;
+
+/**
  * @brief Attribute Id for sai_macsec_port
  */
 typedef enum _sai_macsec_port_attr_t
@@ -493,6 +509,15 @@ typedef enum _sai_macsec_port_attr_t
      * @default SAI_MACSEC_PORT_SECURITY_MODE_MUST_SECURE
      */
     SAI_MACSEC_PORT_ATTR_SECURITY_MODE,
+
+    /**
+     * @brief Configure MACsec PFC mode
+     *
+     * @type sai_macsec_port_pfc_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_MACSEC_PORT_PFC_MODE_UNENCRYPTED
+     */
+    SAI_MACSEC_PORT_ATTR_PFC_MODE,
 
     /**
      * @brief End of MACsec Port attributes

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -408,6 +408,22 @@ typedef enum _sai_port_priority_flow_control_mode_t
 } sai_port_priority_flow_control_mode_t;
 
 /**
+ * @brief MACsec PFC mode
+ *
+ * Controls whether PFC frames on a MACsec-enabled port are handled as
+ * normal clear PFC frames or as encrypted/secure PFC frames.
+ */
+typedef enum _sai_port_macsec_pfc_mode_t
+{
+    /** Default behavior: clear PFC */
+    SAI_PORT_MACSEC_PFC_MODE_UNENCRYPTED,
+
+    /** Secure / encrypted PFC */
+    SAI_PORT_MACSEC_PFC_MODE_ENCRYPTED,
+
+} sai_port_macsec_pfc_mode_t;
+
+/**
  * @brief PTP mode
  * These modes can be used at the port and switch level.
  * All ports use the value set at the switch level unless explicitly configured
@@ -1507,6 +1523,18 @@ typedef enum _sai_port_attr_t
      * @objects SAI_OBJECT_TYPE_MACSEC_PORT
      */
     SAI_PORT_ATTR_MACSEC_PORT_LIST,
+
+    /**
+     * @brief Configure per-port MACsec PFC mode
+     *
+     * When MACsec is not enabled on the port, implementations may ignore this
+     * attribute and behave as SAI_PORT_MACSEC_PFC_MODE_UNENCRYPTED.
+     *
+     * @type sai_port_macsec_pfc_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_PORT_MACSEC_PFC_MODE_UNENCRYPTED
+     */
+    SAI_PORT_ATTR_MACSEC_PFC_MODE,
 
     /**
      * @brief Enable/Disable Mirror session

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -1525,18 +1525,6 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_MACSEC_PORT_LIST,
 
     /**
-     * @brief Configure per-port MACsec PFC mode
-     *
-     * When MACsec is not enabled on the port, implementations may ignore this
-     * attribute and behave as SAI_PORT_MACSEC_PFC_MODE_UNENCRYPTED.
-     *
-     * @type sai_port_macsec_pfc_mode_t
-     * @flags CREATE_AND_SET
-     * @default SAI_PORT_MACSEC_PFC_MODE_UNENCRYPTED
-     */
-    SAI_PORT_ATTR_MACSEC_PFC_MODE,
-
-    /**
      * @brief Enable/Disable Mirror session
      *
      * Enable ingress mirroring by assigning list of mirror session object id
@@ -3354,6 +3342,18 @@ typedef enum _sai_port_attr_t
      * @default SAI_NULL_OBJECT_ID
      */
     SAI_PORT_ATTR_UNKNOWN_MULTICAST_STORM_CONTROL_POLICER_ID,
+
+    /**
+     * @brief Configure per-port MACsec PFC mode
+     *
+     * When MACsec is not enabled on the port, implementations may ignore this
+     * attribute and behave as SAI_PORT_MACSEC_PFC_MODE_UNENCRYPTED.
+     *
+     * @type sai_port_macsec_pfc_mode_t
+     * @flags CREATE_AND_SET
+     * @default SAI_PORT_MACSEC_PFC_MODE_UNENCRYPTED
+     */
+    SAI_PORT_ATTR_MACSEC_PFC_MODE,
 
     /**
      * @brief End of attributes

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -408,22 +408,6 @@ typedef enum _sai_port_priority_flow_control_mode_t
 } sai_port_priority_flow_control_mode_t;
 
 /**
- * @brief MACsec PFC mode
- *
- * Controls whether PFC frames on a MACsec-enabled port are handled as
- * normal clear PFC frames or as encrypted/secure PFC frames.
- */
-typedef enum _sai_port_macsec_pfc_mode_t
-{
-    /** Default behavior: clear PFC */
-    SAI_PORT_MACSEC_PFC_MODE_UNENCRYPTED,
-
-    /** Secure / encrypted PFC */
-    SAI_PORT_MACSEC_PFC_MODE_ENCRYPTED,
-
-} sai_port_macsec_pfc_mode_t;
-
-/**
  * @brief PTP mode
  * These modes can be used at the port and switch level.
  * All ports use the value set at the switch level unless explicitly configured
@@ -3342,18 +3326,6 @@ typedef enum _sai_port_attr_t
      * @default SAI_NULL_OBJECT_ID
      */
     SAI_PORT_ATTR_UNKNOWN_MULTICAST_STORM_CONTROL_POLICER_ID,
-
-    /**
-     * @brief Configure per-port MACsec PFC mode
-     *
-     * When MACsec is not enabled on the port, implementations may ignore this
-     * attribute and behave as SAI_PORT_MACSEC_PFC_MODE_UNENCRYPTED.
-     *
-     * @type sai_port_macsec_pfc_mode_t
-     * @flags CREATE_AND_SET
-     * @default SAI_PORT_MACSEC_PFC_MODE_UNENCRYPTED
-     */
-    SAI_PORT_ATTR_MACSEC_PFC_MODE,
 
     /**
      * @brief End of attributes


### PR DESCRIPTION
Define a new per-port attribute to control whether PFC frames on a MACsec-enabled port are handled as unencrypted (clear) or encrypted (secure) PFC frames.

Per-port control is needed because mixed rollout scenarios are possible on a single device, and a global knob does not scale well for dynamic port management and staged deployment.

The default behavior is set to unencrypted PFC.