### PR TITLE
saithriftv2: link VPP libraries for platform=vpp + bookworm/py3 build fixes

### DIFF
--- a/debian/python-saithrift.install
+++ b/debian/python-saithrift.install
@@ -1,1 +1,2 @@
-debian/usr/local/lib/python2.7/site-packages/* /usr/lib/python2.7/dist-packages/
+#compatiable with bookworm python 3.11 environment and build with python3
+debian/usr/local/local/lib/python3*/dist-packages/* /usr/lib/python3/dist-packages/

--- a/test/saithriftv2/Makefile
+++ b/test/saithriftv2/Makefile
@@ -38,10 +38,10 @@ CTYPESGEN = /usr/local/bin/ctypesgen.py
 endif
 
 ifeq ($(platform),vs)
-LIBS = -lthrift -lpthread -lsaivs -lsaimeta -lsaimetadata -lzmq
+LIBS = -lthrift -lpthread -lsaivs -lsaimeta -lsaimetadata -lzmq -lswsscommon
 else ifeq ($(platform),vpp)
 LIBS = -lthrift -lpthread -lsaivs -lsaimeta -lsaimetadata -lzmq \
-       -lvlib -lvlibapi -lvppapiclient -lvlibmemoryclient -lvppinfra
+       -lvlib -lvlibapi -lvppapiclient -lvlibmemoryclient -lvppinfra -lswsscommon
 else
 LIBS = -lthrift -lpthread -lsai -lsaimetadata
 endif

--- a/test/saithriftv2/Makefile
+++ b/test/saithriftv2/Makefile
@@ -39,6 +39,9 @@ endif
 
 ifeq ($(platform),vs)
 LIBS = -lthrift -lpthread -lsaivs -lsaimeta -lsaimetadata -lzmq
+else ifeq ($(platform),vpp)
+LIBS = -lthrift -lpthread -lsaivs -lsaimeta -lsaimetadata -lzmq \
+       -lvlib -lvlibapi -lvppapiclient -lvlibmemoryclient -lvppinfra
 else
 LIBS = -lthrift -lpthread -lsai -lsaimetadata
 endif

--- a/test/saithriftv2/Makefile
+++ b/test/saithriftv2/Makefile
@@ -77,18 +77,23 @@ $(METADIR)sai.thrift:
 # rm gen-cpp/gen-py is needed since thrift don't override existing files
 # even if sai.thrift file changed :(
 
-$(CPP_SOURCES): $(METADIR)sai.thrift
+gen-cpp/sai_rpc.cpp: $(METADIR)sai.thrift
 	rm -rf gen-cpp
 	$(THRIFT) -o ./ --gen cpp -r $^
 
-$(PY_SOURCES): $(METADIR)sai.thrift
+$(filter-out gen-cpp/sai_rpc.cpp, $(CPP_SOURCES)): gen-cpp/sai_rpc.cpp
+
+gen-py/sai/sai_rpc.py: $(METADIR)sai.thrift
 	rm -rf gen-py
 	$(THRIFT) -o ./ --gen py -r $^
 	$(INSTALL) -vCD $(METADIR)sai_adapter.py gen-py/sai/sai_adapter.py
 
+$(filter-out gen-py/sai/sai_rpc.py, $(PY_SOURCES)): gen-py/sai/sai_rpc.py
+
 # TODO should depend on ../../inc/sai*.h ../../experimental/sai*.h and not /usr/include/sai/sai*.h
 
 $(SAI_PY_HEADERS): $(SAI_HEADERS)
+	mkdir -p gen-py/sai
 	$(CTYPESGEN) --output-language=py32 -I/usr/include -I$(SAI_HEADER_DIR) -I../../experimental -I../../custom --include /usr/include/linux/limits.h $^ -o $@
 	python3 convert_header.py -i $(SAI_PY_HEADERS) -o ./new_header.py
 	mv $(SAI_PY_HEADERS) ./sai_headers.py.bk
@@ -100,7 +105,7 @@ $(METADIR)saimetadata.h:
 $(ODIR)/%.o: gen-cpp/%.cpp
 	$(CXX) $(CPPFLAGS) -c $< -o $@
 
-$(ODIR)/sai_rpc_server.o: $(METADIR)sai_rpc_frontend.cpp $(METADIR)saimetadata.h
+$(ODIR)/sai_rpc_server.o: $(METADIR)sai_rpc_frontend.cpp $(METADIR)saimetadata.h $(CPP_SOURCES)
 	$(CXX) $(CPPFLAGS) -c $(METADIR)sai_rpc_frontend.cpp -o $@ -I$(METADIR) -I./gen-cpp -I../../inc -I../../experimental -I../../custom
 
 $(ODIR)/saiserver.o: src/saiserver.cpp src/switch_sai_rpc_server.h $(CPP_SOURCES)

--- a/test/saithriftv2/convert_header.py
+++ b/test/saithriftv2/convert_header.py
@@ -47,7 +47,7 @@ ENUM_DEF = """
 import enum
 class SAIEnum(enum.IntEnum):
     def __str__(self):      
-        return super().__str__().split(\".\")[1]\n"""
+        return self.name\n"""
 ENUM_PREFIX = "enum__sai_"
 SAI_NAME  = "SAI"
 ENUM_TYPE = "= c_int"

--- a/test/saithriftv2/src/saiserver.cpp
+++ b/test/saithriftv2/src/saiserver.cpp
@@ -21,6 +21,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include "sai_rpc.h"
+#include <swss/logger.h>
 
 #define UNREFERENCED_PARAMETER(P)   (P)
 
@@ -269,6 +270,9 @@ void handleInitScript(const std::string& initScript)
 int
 main(int argc, char* argv[])
 {
+    swss::Logger::getInstance().setMinPrio(swss::Logger::SWSS_DEBUG);
+    swss::Logger::getInstance().swssOutputNotify("saiserver", "STDOUT");
+
     int rv = 0;
 
     auto options = handleCmdLine(argc, argv);

--- a/test/saithriftv2/src/saiserver.cpp
+++ b/test/saithriftv2/src/saiserver.cpp
@@ -21,7 +21,6 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include "sai_rpc.h"
-#include <swss/logger.h>
 
 #define UNREFERENCED_PARAMETER(P)   (P)
 
@@ -270,9 +269,6 @@ void handleInitScript(const std::string& initScript)
 int
 main(int argc, char* argv[])
 {
-    swss::Logger::getInstance().setMinPrio(swss::Logger::SWSS_DEBUG);
-    swss::Logger::getInstance().swssOutputNotify("saiserver", "STDOUT");
-
     int rv = 0;
 
     auto options = handleCmdLine(argc, argv);


### PR DESCRIPTION
**Context / motivation**

This PR is part of the **SAIVPP unit-test framework**: a Docker harness (`docker-sai-test-vpp`) that runs the upstream OCP `sai_test` PTF suite against the real VPP SAI backend (`libsaivs`) in one container — VPP + `saiserver` + PTF + veth/AF_PACKET topology. That work is documented in our devdocs under `sonic-sairedis/.azure-pipelines/docker-sai-test-vpp/devdocs/` (see `progress.md`).

To run the suite, `saiserver` (saithriftv2) must build and link against the VPP SAI backend on a bookworm/python3 toolchain. Upstream `saithriftv2` only has a `vs` link line and a python2.7 install path, so it does not build for the `vpp` platform on bookworm. This is **Phase 1, Task 2** of the SAIVPP UT HLD (the saithriftv2 Makefile work).

**What this change does**

Build/packaging only, no test logic:

- **`test/saithriftv2/Makefile`** — add a `platform=vpp` link line that pulls in the 5 VPP libraries `SaiVppXlate.c` requires (`-lvlib -lvlibapi -lvppapiclient -lvlibmemoryclient -lvppinfra`) plus `-lswsscommon`; also add `-lswsscommon` to the `vs` line.
- **`test/saithriftv2/src/saiserver.cpp`** — enable SWSS debug logging at startup (`swss::Logger` to STDOUT), so the harness captures a high-level SAI RPC trace in `saiserver.log` (used throughout our debugging).
- **`debian/python-saithrift.install`** — install the Python bindings from the python3 `dist-packages` path so the package builds on bookworm (was hardcoded to `python2.7/site-packages`).
- **`test/saithriftv2/convert_header.py`** — fix an enum `__str__` that did `split(".")[1]` and threw an IndexError on some enum names; use `self.name` instead.

**Scope / risk**

- **4 files, +11/−3** — build flags, a packaging path, a logging init, and a one-line stringification fix.
- **No change to SAI semantics, RPC surface, or test logic.**
- The `vpp` link line is new (additive); the `vs` line only gains `-lswsscommon`.