### PR TITLE
Update saidebugcounter.h

### DIFF
--- a/inc/saidebugcounter.h
+++ b/inc/saidebugcounter.h
@@ -323,7 +323,7 @@ typedef enum _sai_in_drop_reason_t
      * Packet is dropped due to local SID configuration or incorrect value in SRV6 packet header
      * e.g.: Local SID packet action is set to SAI_PACKET_ACTION_DROP
      * Next Header is SRH and Segments Left value is 0 for End, End.X, End.T, End.B* endpoint types
-     * Next Header is not SRH while local SID is configured for packet DA
+     * Next Header is not SRH while local SID is configured for packet DA,if SRH header is present
      * Segments Left value is not 0 when received packet is destined to S and S is a local SID of type End.D*
      */
     SAI_IN_DROP_REASON_SRV6_LOCAL_SID_DROP,


### PR DESCRIPTION
We believe the comment in 3rd line needs update. {Next Header is not SRH while local SID is configured for packet DA} In SRV6 packet, SRH header need not be always present. For example a) MicroSID cases
b) In reduced mode with only one SID