### PR TITLE
Add label attribute for ACL entry

### DIFF
--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -1850,6 +1850,15 @@ typedef enum _sai_acl_entry_attr_t
      */
     SAI_ACL_ENTRY_ATTR_ADMIN_STATE,
 
+    /**
+     * @brief Attribute used to uniquely identify ACL entry.
+     *
+     * @type sai_s8_list_t
+     * @flags CREATE_AND_SET
+     * @default empty
+     */
+    SAI_ACL_ENTRY_ATTR_LABEL,
+
     /*
      * Match fields [sai_acl_field_data_t]
      * - Mandatory to pass at least one field during ACL Rule creation.


### PR DESCRIPTION
Summary:

This is similar to #1158, #1407, #1430.

Those PRs added label attribute for LAG/virtual router, counter, ACL Counter. This PR adds similar label attribute for ACL entries.

Adding a label attribute that can be used to uniquely identify ACL entry object during warmboot. This attribute is considered as user data attached to the object.