### PR TITLE
ACL match route destination

### DIFF
--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -1684,9 +1684,18 @@ typedef enum _sai_acl_table_attr_t
     SAI_ACL_TABLE_ATTR_FIELD_ACL_MIRROR_SESSION_ID = SAI_ACL_TABLE_ATTR_FIELD_START + 0x168,
 
     /**
+     * @brief Match on route destination object
+     *
+     * @type bool
+     * @flags CREATE_ONLY
+     * @default false
+     */
+    SAI_ACL_TABLE_ATTR_FIELD_ROUTE_DST = SAI_ACL_TABLE_ATTR_FIELD_START + 0x169,
+
+    /**
      * @brief End of ACL Table Match Field
      */
-    SAI_ACL_TABLE_ATTR_FIELD_END = SAI_ACL_TABLE_ATTR_FIELD_ACL_MIRROR_SESSION_ID,
+    SAI_ACL_TABLE_ATTR_FIELD_END = SAI_ACL_TABLE_ATTR_FIELD_ROUTE_DST,
 
     /**
      * @brief ACL table entries associated with this table.
@@ -2890,9 +2899,20 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_FIELD_ACL_MIRROR_SESSION_ID = SAI_ACL_ENTRY_ATTR_FIELD_START + 0x168,
 
     /**
+     * @brief Route destination object: next hop or next hop group, or a router
+     * interface for a directly reachable route
+     *
+     * @type sai_acl_field_data_t sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_NEXT_HOP, SAI_OBJECT_TYPE_NEXT_HOP_GROUP, SAI_OBJECT_TYPE_ROUTER_INTERFACE
+     * @default disabled
+     */
+    SAI_ACL_ENTRY_ATTR_FIELD_ROUTE_DST = SAI_ACL_ENTRY_ATTR_FIELD_START + 0x169,
+
+    /**
      * @brief End of Rule Match Fields
      */
-    SAI_ACL_ENTRY_ATTR_FIELD_END = SAI_ACL_ENTRY_ATTR_FIELD_ACL_MIRROR_SESSION_ID,
+    SAI_ACL_ENTRY_ATTR_FIELD_END = SAI_ACL_ENTRY_ATTR_FIELD_ROUTE_DST,
 
     /*
      * Actions [sai_acl_action_data_t]

--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -2899,8 +2899,10 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_FIELD_ACL_MIRROR_SESSION_ID = SAI_ACL_ENTRY_ATTR_FIELD_START + 0x168,
 
     /**
-     * @brief Route destination object: next hop or next hop group, or a router
-     * interface for a directly reachable route
+     * @brief Route destination object: next hop or next hop group, or egress
+     * router interface for a directly reachable route.
+     *
+     * May be updated by redirect action by ACLs in previous stages.
      *
      * @type sai_acl_field_data_t sai_object_id_t
      * @flags CREATE_AND_SET

--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -2902,7 +2902,7 @@ typedef enum _sai_acl_entry_attr_t
      * @brief Route destination object: next hop or next hop group, or egress
      * router interface for a directly reachable route.
      *
-     * May be updated by redirect action by ACLs in previous stages.
+     * Value may be updated by redirect action of ACL entries in previous stages.
      *
      * @type sai_acl_field_data_t sai_object_id_t
      * @flags CREATE_AND_SET


### PR DESCRIPTION
## Summary

Add ACL match field to match on the destination selected by routing lookup. This is the original destination prior to ECMP group & LAG hashing.

## Purpose

Enable features which need to match on original route destination (e.g. ECMP group) and take action like accounting, or redirect to a new destination before ECMP member selection happens.

## Changes

- Add `SAI_ACL_TABLE_ATTR_FIELD_ROUTE_DST`
- Add `SAI_ACL_ENTRY_ATTR_FIELD_ROUTE_DST`

## Compatibility

Support for the new field can be queried via sai_query_attribute_enum_values_capability()
