### PR TITLE
[debugcounter] Add support for SAI_IN_DROP_REASON_EGRESS_LINK_DOWN

### DIFF
--- a/inc/saidebugcounter.h
+++ b/inc/saidebugcounter.h
@@ -287,6 +287,7 @@ typedef enum _sai_in_drop_reason_t
      * @brief Packet is destined for neighboring device but neighbor device link is down
      *
      * Counted on ingress link
+     * Specific to L3 routing next hop resolution when the egress link is down.
      */
     SAI_IN_DROP_REASON_L3_EGRESS_LINK_DOWN,
 
@@ -355,6 +356,13 @@ typedef enum _sai_in_drop_reason_t
 
     /** IPv4 or IPv6 Routing table (LPM) unicast miss */
     SAI_IN_DROP_REASON_LPM_MISS = 0x00000039,
+
+    /**
+     * @brief Packet is destined for neighboring device but neighbor device link is down.
+     * Generic counter across all forwarding pipelines when the resolved egress link is down.
+     * e.g.: L2 bridging, L3 routing, tunnels
+     */
+    SAI_IN_DROP_REASON_EGRESS_LINK_DOWN,
 
     /** End of in drop reasons */
     SAI_IN_DROP_REASON_END,


### PR DESCRIPTION
### Summary
Extend the `sai_in_drop_reason_t` enum with `SAI_IN_DROP_REASON_EGRESS_LINK_DOWN` to support tracking packets dropped at ingress when the target egress port/interface is down.

### Motivation
While `SAI_IN_DROP_REASON_L3_EGRESS_LINK_DOWN` specifically targets routed (L3) packets, certain ASIC architectures and pipelines drop traffic at ingress whenever the destination egress link is down regardless of packet type, or do not distinguish between L2 and L3 drops for this condition.

Adding `SAI_IN_DROP_REASON_EGRESS_LINK_DOWN` enables debug counters to generically capture egress link down drops across both L2 (bridged) and L3 (routed) traffic.

### Changes
- Modified `inc/saidebugcounter.h` to add `SAI_IN_DROP_REASON_EGRESS_LINK_DOWN` to `sai_in_drop_reason_t`.

Signed-off-by: Tommy Smail <tommysmail@google.com>