### PR TITLE
[meta] Add opt-in saithrift RPCs for draining SAI notifications

### DIFF
--- a/meta/sai_rpc_frontend.cpp
+++ b/meta/sai_rpc_frontend.cpp
@@ -897,15 +897,17 @@ static void sai_thrift_nat_type_t_parse(
 
 namespace
 {
-    constexpr std::int32_t kPortStateChangeNotification = 0;
-    constexpr std::int32_t kBfdSessionStateChangeNotification = 1;
+    constexpr sai_thrift_notification_type_t::type kPortStateChangeNotification =
+            sai_thrift_notification_type_t::SAI_THRIFT_NOTIFICATION_TYPE_PORT_STATE_CHANGE;
+    constexpr sai_thrift_notification_type_t::type kBfdSessionStateChangeNotification =
+            sai_thrift_notification_type_t::SAI_THRIFT_NOTIFICATION_TYPE_BFD_SESSION_STATE_CHANGE;
     constexpr std::size_t kNotificationQueueCapacity = 256;
 
     std::mutex notification_queue_mutex;
     std::deque<sai_thrift_notification_event_t> notification_queue;
 
     void enqueue_notification(
-            std::int32_t notification_type,
+            sai_thrift_notification_type_t::type notification_type,
             sai_object_id_t object_id,
             std::int32_t state)
     {

--- a/meta/sai_rpc_frontend.cpp
+++ b/meta/sai_rpc_frontend.cpp
@@ -27,11 +27,17 @@
 #include "sai_rpc.h"
 
 extern "C" {
+#include "sai.h"
 #include "saimetadata.h"
 }
 
+#include <cstdint>
+#include <cstddef>
+#include <deque>
 #include <iostream>
 #include <cstring>
+#include <mutex>
+#include <vector>
 
 using namespace ::sai;
 
@@ -889,12 +895,138 @@ static void sai_thrift_nat_type_t_parse(
     *nat_type = (sai_nat_type_t)thrift_nat_type;
 }
 
+namespace
+{
+    constexpr std::int32_t kPortStateChangeNotification = 0;
+    constexpr std::int32_t kBfdSessionStateChangeNotification = 1;
+    constexpr std::size_t kNotificationQueueCapacity = 256;
+
+    std::mutex notification_queue_mutex;
+    std::deque<sai_thrift_notification_event_t> notification_queue;
+
+    void enqueue_notification(
+            std::int32_t notification_type,
+            sai_object_id_t object_id,
+            std::int32_t state)
+    {
+        std::lock_guard<std::mutex> lock(notification_queue_mutex);
+
+        if (notification_queue.size() >= kNotificationQueueCapacity)
+        {
+            notification_queue.pop_front();
+        }
+
+        sai_thrift_notification_event_t event;
+        event.notification_type = notification_type;
+        event.object_id = static_cast<sai_thrift_object_id_t>(object_id);
+        event.state = state;
+        notification_queue.push_back(event);
+    }
+
+    void on_port_state_change(
+            std::uint32_t count,
+            const sai_port_oper_status_notification_t *data)
+    {
+        if (data == nullptr)
+        {
+            return;
+        }
+
+        for (std::uint32_t index = 0; index < count; ++index)
+        {
+            enqueue_notification(
+                    kPortStateChangeNotification,
+                    data[index].port_id,
+                    static_cast<std::int32_t>(data[index].port_state));
+        }
+    }
+
+    void on_bfd_session_state_change(
+            std::uint32_t count,
+            const sai_bfd_session_state_notification_t *data)
+    {
+        if (data == nullptr)
+        {
+            return;
+        }
+
+        for (std::uint32_t index = 0; index < count; ++index)
+        {
+            enqueue_notification(
+                    kBfdSessionStateChangeNotification,
+                    data[index].bfd_session_id,
+                    static_cast<std::int32_t>(data[index].session_state));
+        }
+    }
+}
+
 // including it here we never have to modify the generated file
 #include "sai_rpc_server.cpp"
+
+static sai_status_t set_switch_notification_callback(
+        sai_attr_id_t attribute_id,
+        sai_pointer_t callback)
+{
+    if (switch_id == SAI_NULL_OBJECT_ID)
+    {
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    sai_switch_api_t *switch_api = nullptr;
+    sai_status_t status = sai_api_query(
+            SAI_API_SWITCH,
+            reinterpret_cast<void **>(&switch_api));
+    if (status != SAI_STATUS_SUCCESS || switch_api == nullptr)
+    {
+        return status != SAI_STATUS_SUCCESS ? status : SAI_STATUS_FAILURE;
+    }
+
+    sai_attribute_t attribute = {};
+    attribute.id = attribute_id;
+    attribute.value.ptr = callback;
+    return switch_api->set_switch_attribute(switch_id, &attribute);
+}
 
 class sai_rpcHandlerFrontend:
     virtual public sai_rpcHandler
 {
+    /**
+     * @brief Enable the server-owned port and BFD notification callbacks.
+     */
+    sai_thrift_status_t sai_thrift_enable_notifications() override
+    {
+        sai_status_t status = set_switch_notification_callback(
+                SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY,
+                reinterpret_cast<sai_pointer_t>(&on_port_state_change));
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            return static_cast<sai_thrift_status_t>(status);
+        }
+
+        status = set_switch_notification_callback(
+                SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY,
+                reinterpret_cast<sai_pointer_t>(&on_bfd_session_state_change));
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            set_switch_notification_callback(
+                    SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY,
+                    nullptr);
+        }
+
+        return static_cast<sai_thrift_status_t>(status);
+    }
+
+    /**
+     * @brief Drain all queued asynchronous notification records.
+     */
+    void sai_thrift_drain_notifications(
+            std::vector<sai_thrift_notification_event_t> &notifications) override
+    {
+        std::lock_guard<std::mutex> lock(notification_queue_mutex);
+        notifications.assign(notification_queue.begin(), notification_queue.end());
+        notification_queue.clear();
+    }
+
     /**
      * @brief Thrift wrapper for sai_object_type_get_availability() SAI function
      */

--- a/meta/templates/sai.thrift.tt
+++ b/meta/templates/sai.thrift.tt
@@ -70,6 +70,12 @@ struct sai_thrift_attr_capability_t {
     2: bool boolset_implemented;
     3: bool get_implemented;
 }
+
+struct sai_thrift_notification_event_t {
+    1: i32 notification_type;
+    2: sai_thrift_object_id_t object_id;
+    3: i32 state;
+}
 [% END -%]
 
 [%- ######################################################################## -%]

--- a/meta/templates/sai.thrift.tt
+++ b/meta/templates/sai.thrift.tt
@@ -71,8 +71,13 @@ struct sai_thrift_attr_capability_t {
     3: bool get_implemented;
 }
 
+enum sai_thrift_notification_type_t {
+    SAI_THRIFT_NOTIFICATION_TYPE_PORT_STATE_CHANGE = 0;
+    SAI_THRIFT_NOTIFICATION_TYPE_BFD_SESSION_STATE_CHANGE = 1;
+}
+
 struct sai_thrift_notification_event_t {
-    1: i32 notification_type;
+    1: sai_thrift_notification_type_t notification_type;
     2: sai_thrift_object_id_t object_id;
     3: i32 state;
 }

--- a/meta/templates/sai_rpc_server_functions.tt
+++ b/meta/templates/sai_rpc_server_functions.tt
@@ -5,7 +5,7 @@
 [%- create_switch_function = 'create_switch' %]
 [%- remove_switch_function = 'remove_switch' %]
 
-[%- sai_utils_functions = '(query_attribute_enum_values_capability|sai_object_type_get_availability|sai_object_type_query|sai_switch_id_query|sai_api_uninitialize)' -%]
+[%- sai_utils_functions = '(query_attribute_enum_values_capability|sai_object_type_get_availability|sai_object_type_query|sai_switch_id_query|sai_api_uninitialize|enable_notifications|drain_notifications)' -%]
 
 [%- ######################################################################## -%]
 

--- a/meta/templates/sai_thrift_utils.tt
+++ b/meta/templates/sai_thrift_utils.tt
@@ -2,6 +2,9 @@
 
 [%- BLOCK define_objects_api -%]
     // sai objects API
+    sai_thrift_status_t sai_thrift_enable_notifications();
+    list<sai_thrift_notification_event_t> sai_thrift_drain_notifications();
+
     list<i32> sai_thrift_query_attribute_enum_values_capability(1: sai_thrift_object_type_t object_type, 2: sai_thrift_attr_id_t attr_id, 3: i32 caps_count);
     i64 sai_thrift_object_type_get_availability(1 : sai_thrift_object_type_t object_type, 2: sai_thrift_attr_id_t attr_id, 3: i32 attr_type);
     sai_thrift_object_id_t sai_thrift_switch_id_query(1 : sai_thrift_object_id_t object_id);


### PR DESCRIPTION
**Context / motivation**
Part of the SAIVPP unit-test framework. SAI delivers port state and BFD session state asynchronously through function pointers written into `SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY` and `SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY`. A Thrift client cannot supply a function pointer, so there is currently no way for any saithrift-based test suite to observe that a notification was delivered. This blocks testing the notification path on any target, not just VPP.

**What this change does**
* **`meta/templates/sai_thrift_utils.tt`, `meta/templates/sai.thrift.tt`.** Declare `sai_thrift_enable_notifications()` and `sai_thrift_drain_notifications()`, plus a `sai_thrift_notification_event_t` record carrying notification type, object id and state.
* **`meta/templates/sai_rpc_server_functions.tt`.** Add the two method names to the `sai_utils_functions` regex so the generator emits stub bodies instead of trying to bind them to SAI metadata.
* **`meta/sai_rpc_frontend.cpp`.** Implement both methods in `sai_rpcHandlerFrontend`, following the existing `sai_thrift_object_type_get_availability` pattern. The enable RPC installs server-owned callbacks and is idempotent; the drain RPC is non-blocking and atomically empties a mutex-protected bounded queue.
* **Post-create registration.** The callbacks are installed on the already-created switch via `set_switch_attribute`, not at create time. `SwitchStateBase::set_switch_default_attributes()` writes NULL into both attributes during `initialize_default_objects`, so a pointer supplied at create time is silently discarded. Both attributes are `CREATE_AND_SET` and the senders re-read them when an event fires, so a post-create set is correct, simpler, and additionally suppresses the forced port-UP notifications raised during host-interface creation.

**Scope / risk**
* **Default-preserving:** behaviour is unchanged unless a test explicitly calls the enable RPC. No existing RPC is modified.
* **No function pointer crosses Thrift.** The callbacks live entirely inside `saiserver`; only notification type, object id and state are serialized.
* **Bounded:** the queue holds 256 events and drops the oldest on overflow, so a client that never drains cannot grow memory without limit.
* **RAII containers and standard synchronization only.** No new dependencies, no unsafe C memory or string calls, no credentials or certificates.
* No SAI headers, metadata definitions, or backend behaviour change.
* **Validated behavior:** `gensairpc.pl` completes and the generated service contains both methods; `saithriftv2` and `saiserver` build and link; enable followed by drain from a throwaway client returns an empty list without crashing. End-to-end validation is in the notification test PR.

**Dependencies**
None. This is a prerequisite for the notification test cases, #2336.