### PR TITLE
TRIM to Sender and TC-DSCP Map

### DIFF
--- a/doc/SAI-Proposal-Packet-Trimming.md
+++ b/doc/SAI-Proposal-Packet-Trimming.md
@@ -224,3 +224,47 @@ typedef enum _sai_packet_trim_dscp_resolution_mode_t
 |saiqueue.h |SAI_QUEUE_STAT_TRIM_PACKETS|Per-queue counter of packets trimmed on trimming-eligible queue due to failed shared buffer admission|
 |           |SAI_QUEUE_STAT_DROPPED_TRIM_PACKETS|Per-queue counter of packets trimmed on trimming-eligible queue but dropped due to failed shared buffer admission on a trim queue|
 |           |SAI_QUEUE_STAT_TX_TRIM_PACKETS|Per-queue counter of packets trimmed on trimming-eligible queue and successfully sent via a trim queue|
+
+## TRIM or Data Packet DSCP Marking
+The current SAI specification defines a single port attribute, SAI_PORT_ATTR_QOS_TC_AND_COLOR_TO_DSCP_MAP, for specifying TRIM and/or Data Packet TC to DSCP marking.
+
+This creates an issue when data packet remarking is not needed and there is no corresponding entry in the TC map. According to the SAI specification, the default value of TC 0 becomes effective and maps to the default DSCP value, which inadvertently changes the DSCP value of the data packet.
+
+To address this unintended behavior, we are introducing a new port-based attribute: SAI_PORT_ATTR_QOS_TRIM_TC_AND_COLOR_TO_DSCP_MAP. This attribute handles TC to DSCP mapping exclusively for TRIM packets.
+
+### Capability Query
+NOS can do a cpability query for SAI_PORT_ATTR_QOS_TRIM_TC_AND_COLOR_TO_DSCP_MAP attribure to check an implementation's support.
+
+If both SAI_PORT_ATTR_QOS_TRIM_TC_AND_COLOR_TO_DSCP_MAP and SAI_PORT_ATTR_QOS_TC_AND_COLOR_TO_DSCP_MAP are configured then TRIM packets will use SAI_PORT_ATTR_QOS_TRIM_TC_AND_COLOR_TO_DSCP_MAP and data packets will use SAI_PORT_ATTR_QOS_TC_AND_COLOR_TO_DSCP_MAP.
+
+If only SAI_PORT_ATTR_QOS_TC_AND_COLOR_TO_DSCP_MAP is confiured then NOS can configure both data packet TC and TRIM TC as long as the desired behavior of DSCP value of data packets is maintained.
+
+If only SAI_PORT_ATTR_QOS_TRIM_TC_AND_COLOR_TO_DSCP_MAP is configured then data packets do not undergo any DSCP remarking and only TRIM packets will use the configured map for DSCP marking.
+
+### TRIM to Sender TC and DSCP Value
+Trim to Sender may use a different TC value if in DSCP resolution mode or may use a different DSCP value from TRIM to receiver.
+
+Two new switch attributes are introduced specific to TRIM to sender. Note that the SAI_SWITCH_ATTR_PACKET_TRIM_DSCP_RESOLUTION_MODE is same for TRIM to sender and TRIM to reciever. 
+Also note that a queue can only be eligible for TRIM or TRIM_TO_SENDER but not for both.
+
+```
+    /**
+     * @brief New packet trim to sender DSCP value
+     *
+     * @type sai_uint8_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     * @validonly SAI_SWITCH_ATTR_PACKET_TRIM_DSCP_RESOLUTION_MODE == SAI_PACKET_TRIM_DSCP_RESOLUTION_MODE_DSCP_VALUE
+     */
+    SAI_SWITCH_ATTR_PACKET_TRIM_TO_SENDER_DSCP_VALUE,
+
+    /**
+     * @brief New packet trim to sender TC value
+     *
+     * @type sai_uint8_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     * @validonly SAI_SWITCH_ATTR_PACKET_TRIM_DSCP_RESOLUTION_MODE == SAI_PACKET_TRIM_DSCP_RESOLUTION_MODE_FROM_TC
+     */
+    SAI_SWITCH_ATTR_PACKET_TRIM_TO_SENDER_TC_VALUE,
+```

--- a/inc/saibuffer.h
+++ b/inc/saibuffer.h
@@ -645,6 +645,19 @@ typedef enum _sai_buffer_profile_packet_admission_fail_action_t
      * Interface statistics may show sent trimmed packets.
      */
     SAI_BUFFER_PROFILE_PACKET_ADMISSION_FAIL_ACTION_DROP_AND_TRIM,
+
+    /**
+     * @brief Trim the packet and forward it to the sender
+     *
+     * Try sending a shortened packet over a different
+     * queue. Original packet will be dropped and trimmed copy of the packet will be send to the sender.
+     * The IP length and checksum fields will be updated in a trimmed copy.
+     * SAI_QUEUE_STAT_DROPPED_PACKETS as well as SAI_QUEUE_STAT_DROPPED_BYTES
+     * will count the original discarded frames even if they will be trimmed afterwards.
+     * Interface statistics must show dropped packets.
+     * Interface statistics may show sent trimmed packets.
+     */
+    SAI_BUFFER_PROFILE_PACKET_ADMISSION_FAIL_ACTION_DROP_AND_TRIM_TO_SENDER,
 } sai_buffer_profile_packet_admission_fail_action_t;
 
 /**

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -3494,6 +3494,20 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_LINK_DOWN_DEBOUNCE_TIMEOUT,
 
     /**
+     * @brief Enable TRIM TC AND COLOR -> DSCP MAP
+     *
+     * Map id = #SAI_NULL_OBJECT_ID to disable trim map on port.
+     * Default no trim map.
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_QOS_MAP
+     * @allownull true
+     * @default SAI_NULL_OBJECT_ID
+     */
+    SAI_PORT_ATTR_QOS_TRIM_TC_AND_COLOR_TO_DSCP_MAP,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_ATTR_END,

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -3680,6 +3680,26 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_LINK_UP_DEBOUNCE_TIMEOUT_INTEVALS,
 
     /**
+     * @brief New packet trim to sender DSCP value
+     *
+     * @type sai_uint8_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     * @validonly SAI_SWITCH_ATTR_PACKET_TRIM_DSCP_RESOLUTION_MODE == SAI_PACKET_TRIM_DSCP_RESOLUTION_MODE_DSCP_VALUE
+     */
+    SAI_SWITCH_ATTR_PACKET_TRIM_TO_SENDER_DSCP_VALUE,
+
+    /**
+     * @brief New packet trim to sender TC value
+     *
+     * @type sai_uint8_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     * @validonly SAI_SWITCH_ATTR_PACKET_TRIM_DSCP_RESOLUTION_MODE == SAI_PACKET_TRIM_DSCP_RESOLUTION_MODE_FROM_TC
+     */
+    SAI_SWITCH_ATTR_PACKET_TRIM_TO_SENDER_TC_VALUE,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,


### PR DESCRIPTION
This PR address the usecase of setting different DSCP for TRIM packets going out on different port as mentioned in
https://github.com/JaiOCP/SAI/blob/master/doc/SAI-Proposal-Packet-Trimming.md

Current usage of SAI_PORT_ATTR_QOS_TC_AND_COLOR_TO_DSCP_MAP creates an issue where when TRIM TC is enabled for DSCP marking any other traffic flowing out on the port need to be correctly marked for TC to DSCP even if there is no change in outgoing DSCP. This is because once a map is enabled for a port, SAI spec mandates a default behavior of mapping to TC 0. This is not acceptable if there is requirement to map TC to DSCP only for TRIM packets.

New attribute SAI_PORT_ATTR_QOS_TRIM_TC_AND_COLOR_TO_DSCP_MAP is introduced to control only TRIM related TC to DSCP map and not touch the other data traffic maps.

New attribute SAI_BUFFER_PROFILE_PACKET_ADMISSION_FAIL_ACTION_DROP_AND_TRIM_TO_SENDER is introduced where TRIM packets can be forwarded in the reverse direction to the sender. All the other attributes for TRIM as applicable including stats remains same.