### PR TITLE
Add port MRU attribute

### DIFF
--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -3494,6 +3494,32 @@ typedef enum _sai_port_attr_t
     SAI_PORT_ATTR_LINK_DOWN_DEBOUNCE_TIMEOUT,
 
     /**
+     * @brief Enable independent Maximum Receive Unit (MRU) enforcement
+     *
+     * When true, SAI_PORT_ATTR_MRU governs the ingress frame-size
+     * admission threshold independently of SAI_PORT_ATTR_MTU.
+     * When false, ingress admission behavior is unchanged and follows
+     * the implementation's existing use of SAI_PORT_ATTR_MTU.
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_PORT_ATTR_MRU_ENABLED,
+
+    /**
+     * @brief Maximum Receive Unit (MRU) in bytes
+     *
+     * Frames arriving on this port that exceed this value are dropped.
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 1514
+     * @validonly SAI_PORT_ATTR_MRU_ENABLED == true
+     */
+    SAI_PORT_ATTR_MRU,
+
+    /**
      * @brief End of attributes
      */
     SAI_PORT_ATTR_END,

--- a/meta/acronyms.txt
+++ b/meta/acronyms.txt
@@ -108,6 +108,7 @@ MDIX - Medium Dependent Interface Crossover
 MILLI - milli (1/1000)
 MMU - Memory Management Unit
 MPLS - Multi Protocol Label Switching
+MRU - Maximum Receive Unit
 MTU - Maximum Transmission Unit
 NACK - Negative Acknowledgement
 NAPT - Network Address Port Translation


### PR DESCRIPTION
**Summary**
Adds two port attributes that allow the maximum receive frame size (MRU) to be configured independently of `SAI_PORT_ATTR_MTU`. Today `SAI_PORT_ATTR_MTU` governs the egress frame-size limit, and on many implementations the same value is applied as the ingress admission threshold. This change lets an implementation that supports separate RX/TX enforcement expose an independent receive limit, while leaving single-threshold implementations unaffected.

**Backward compatibility**
`SAI_PORT_ATTR_MRU` takes effect only when `SAI_PORT_ATTR_MRU_ENABLED` is `true`. The default is `false`, under which receive-side behavior is unchanged: implementations that apply `SAI_PORT_ATTR_MTU` to both directions continue to do so. Existing applications require no change.

**New Attributes**
- `SAI_PORT_ATTR_MRU_ENABLED` 
- `SAI_PORT_ATTR_MRU` 